### PR TITLE
[BIT] 引擎能力补齐：fix normal str parse

### DIFF
--- a/tester/api_config/config_analyzer.py
+++ b/tester/api_config/config_analyzer.py
@@ -816,9 +816,9 @@ class APIConfig:
             value, offset = self.get_numpy_type(config, offset)
         elif tocken == "nan":
             value = float('nan')
-        elif tocken is not None and config[offset - len(tocken) - 1] == '\"':
+        elif tocken is not None and config[offset - len(tocken) - 1] == "\"":
             # fix tocken is not correct in str with spaces
-            next_quote_idx  = config.index("\"", offset + 1)
+            next_quote_idx  = config.index("\"", offset)
             value = config[offset - len(tocken):next_quote_idx]
             offset = next_quote_idx
         elif tocken is None:


### PR DESCRIPTION
修复 merged PR #14 中引入的常规字符串解析失败的情况，具体是寻找下一个引号从 `offset` 开始，而不是 `offset + 1`，在带有空格的字符串中这两项没有区别，但是对于没有空格的字符串 `config[offset] = '"'`，`offset + 1` 后就没有引号了