### PR TITLE
【BIT】引擎能力补齐：增加 index 和 key 参数、优化代码结构、增强测试鲁棒性

### DIFF
--- a/tester/api_config/config_analyzer.py
+++ b/tester/api_config/config_analyzer.py
@@ -484,7 +484,7 @@ class TensorConfig:
                     self.numpy_tensor = numpy.random.randint(0,2, size=self.shape).astype(self.dtype)
 
             elif api_config.api_name in ['paddle.nn.functional.upsample']:
-                if self.get_arg(api_config, 1, 'size') and (key != "x" or index >= 1):
+                if self.get_arg(api_config, 1, 'size') and not (key == "x" or index == 0):
                     self.numpy_tensor = numpy.random.randint(0,128, size=self.shape).astype(self.dtype)
                 if key == "scale_factor" or index == 2:
                     self.numpy_tensor = 0.5*numpy.ones(self.shape).astype(self.dtype)+numpy.abs(numpy.random.random(self.shape)).astype(self.dtype)

--- a/tester/api_config/config_analyzer.py
+++ b/tester/api_config/config_analyzer.py
@@ -1,3 +1,4 @@
+import random
 import re
 import collections
 import paddle
@@ -118,7 +119,7 @@ class TensorConfig:
             dims = numpy.random.choice(max_dim, size=self.shape[0], replace=False)
             mask = numpy.random.rand(self.shape[0]) > 0.5
             dims = numpy.where(mask, dims - max_dim, dims)
-            return numpy.array(final_dims, dtype=self.dtype)
+            return numpy.array(dims, dtype=self.dtype)
 
         raise ValueError(
             f"Invalid shape for 'axis' Tensor in {api_config.api_name}. "
@@ -266,11 +267,8 @@ class TensorConfig:
                 self.numpy_tensor = numpy.random.randint(0, 2048, size = self.shape)
 
             elif api_config.api_name in ["paddle.expand"]:
-                if index>0:
-                    if 'x' in api_config.kwargs:
-                        d=self.get_arg(api_config,arg_name='x')
-                    else:   
-                        d=self.get_arg(api_config,0)
+                if not (key == "x" or index == 0):
+                    d=self.get_arg(api_config, 0, "x")
                     s=d.shape
                     if len(s)==0 or s[index-1]==1:
                         self.numpy_tensor = (numpy.random.randint(1, 127, size=self.shape)).astype(self.dtype)
@@ -425,9 +423,9 @@ class TensorConfig:
                     self.numpy_tensor = self.generate_random_axes(api_config)
 
             elif api_config.api_name in ["paddle.multinomial"]:
-                if index==0:
+                if key == "x" or index == 0:
                     self.numpy_tensor = numpy.abs(numpy.random.random(self.shape)).astype(self.dtype)
-                if "num_samples" in api_config.kwargs and index==1:
+                if key == "num_samples" or index == 1:
                     if 'replacement' not in api_config.kwargs:
                         inputs=self.get_arg(api_config,0)
                         inputs=inputs.numpy_tensor
@@ -436,10 +434,9 @@ class TensorConfig:
                     
 
             elif api_config.api_name in ["paddle.multiplex"]:
-                if 'inputs' in api_config.kwargs:
-                    s=self.get_arg(api_config,arg_name='inputs')
-                    if index==len(s):
-                        self.numpy_tensor = (numpy.random.randint(0,len(s), size=self.shape)).astype(self.dtype)
+                s = self.get_arg(api_config, 0, 'inputs')
+                if key == "index" or index == 1:
+                    self.numpy_tensor = (numpy.random.randint(0,len(s), size=self.shape)).astype(self.dtype)
 
             elif api_config.api_name in ["paddle.multiply"]:
                 if self.dtype=='bfloat16':
@@ -449,25 +446,26 @@ class TensorConfig:
             # n
 
             elif api_config.api_name in ["paddle.nn.functional.adaptive_avg_pool2d",'paddle.nn.functional.adaptive_avg_pool3d']:
-                if index==1:
-                    s=self.get_arg(api_config,0)
+                if key == "output_size" or index == 1:
+                    s = self.get_arg(api_config, 0, "x")
                     s=s.shape
                     self.numpy_tensor = numpy.random.randint(1,2*max(s), size=self.shape).astype(self.dtype)
 
             elif api_config.api_name in ['paddle.nn.functional.affine_grid']:
-                s=self.get_arg(api_config,0)
-                s=s.shape
-                if index==1:
+                if key == "out_shape" or index == 1:
+                    s = self.get_arg(api_config, 0, "theta")
+                    s = s.shape
                     self.numpy_tensor = numpy.random.randint(1,128, size=self.shape).astype(self.dtype)
                     self.numpy_tensor[0]=s[0]
             
             elif api_config.api_name in ['paddle.nn.functional.alpha_dropout']:
-                if index==0 and self.dtype=='bfloat16':
-                    self.dtype='float32'
+                if key == "x" or index == 0:
+                    if self.dtype=='bfloat16':
+                        self.dtype='float32'
                     self.numpy_tensor = numpy.random.random(self.shape).astype(self.dtype)
 
             elif api_config.api_name in ['paddle.nn.functional.interpolate']:
-                if index>=1:
+                if not (key == "x" or index == 0):
                     self.numpy_tensor = numpy.random.randint(1,128, size=self.shape).astype(self.dtype)
 
             elif api_config.api_name in ['paddle.nn.functional.grid_sample']:
@@ -476,26 +474,25 @@ class TensorConfig:
                     self.numpy_tensor = numpy.random.random(self.shape).astype(self.dtype)
 
             elif api_config.api_name in ['paddle.nn.functional.hsigmoid_loss']:
-                nclass=self.get_arg(api_config,2)
-                weight=self.get_arg(api_config,3)
-                if index==1:
+                nclass = self.get_arg(api_config, 2, "num_classes")
+                weight = self.get_arg(api_config, 3, "weight")
+                if key == "label" or index == 1:
                     self.numpy_tensor = numpy.random.randint(0,nclass, size=self.shape).astype(self.dtype)
-                elif index==5:
+                elif key == "path_table" or index == 5:
                     self.numpy_tensor = numpy.random.randint(0,weight.shape[0], size=self.shape).astype(self.dtype)
-                elif index==6:
+                elif key == "path_code" or index == 6:
                     self.numpy_tensor = numpy.random.randint(0,2, size=self.shape).astype(self.dtype)
 
             elif api_config.api_name in ['paddle.nn.functional.upsample']:
-                if 'size' in api_config.kwargs:
-                    if self.get_arg(api_config,arg_name='size') and index>=1:
-                        self.numpy_tensor = numpy.random.randint(0,128, size=self.shape).astype(self.dtype)
-                if index==2 and 'scale_factor' in api_config.kwargs and self.get_arg(api_config,arg_name='scale_factor'):
+                if self.get_arg(api_config, 1, 'size') and (key != "x" or index >= 1):
+                    self.numpy_tensor = numpy.random.randint(0,128, size=self.shape).astype(self.dtype)
+                if key == "scale_factor" or index == 2:
                     self.numpy_tensor = 0.5*numpy.ones(self.shape).astype(self.dtype)+numpy.abs(numpy.random.random(self.shape)).astype(self.dtype)
  
 
             # o
             elif api_config.api_name in ["paddle.ones"]:
-                if api_config.api_name == "paddle.ones" and len(self.shape) == 0:
+                if len(self.shape) == 0:
                     self.numpy_tensor = numpy.array(random.randint(1, 2048), dtype=self.dtype)
                 else:
                     self.numpy_tensor = numpy.random.randint(1, 65535, size=self.shape).astype(self.dtype)
@@ -505,7 +502,7 @@ class TensorConfig:
                     self.numpy_tensor = self.generate_random_axes(api_config)
             # q
             elif api_config.api_name in ["paddle.quantile"]:
-                if index==1:
+                if not (key == "x" or index == 0):
                     self.numpy_tensor = numpy.random.rand(1).astype(self.dtype)
 
             # r                
@@ -566,17 +563,14 @@ class TensorConfig:
                 
             # s
             elif api_config.api_name in ["paddle.scatter"]:
-                if index==1:
-                    if 'x' in api_config.kwargs:
-                        d=self.get_arg(api_config,arg_name='x')
-                    else:
-                        d=self.get_arg(api_config,0)
+                if key == "index" or index == 1:
+                    d=self.get_arg(api_config, 0, "x")
                     s=d.shape[0]
                     self.numpy_tensor = numpy.random.randint(0, s, size=self.shape).astype(self.dtype)
 
             elif api_config.api_name in ["paddle.scatter_nd"]:
-                future_data=self.get_arg(api_config,2)     
-                if index==0 and future_data and len(future_data):
+                future_data=self.get_arg(api_config, 2, "shape")     
+                if (key == "index" or index == 0) and future_data and len(future_data):
                     self.numpy_tensor=numpy.zeros(self.shape)
                     s=self.shape
                     for ii in range(len(future_data)):  
@@ -585,17 +579,11 @@ class TensorConfig:
                         self.numpy_tensor[...,ii] = numpy.random.randint(-future_data[ii], future_data[ii], size=self.numpy_tensor[...,ii].shape).astype(self.dtype)
 
             elif api_config.api_name in ["paddle.scatter_nd_add"]:
-                if index==1:
-                    if 'x' in api_config.kwargs:
-                        org=self.get_arg(api_config,arg_name='x')
-                    else:
-                        org=self.get_arg(api_config,0)
+                if key == "index" or index == 1:
+                    org=self.get_arg(api_config, 0, "x")
                     org=org.shape
                     self.numpy_tensor=numpy.zeros(self.shape)
-                    if 'index' in api_config.kwargs:
-                        ind=self.get_arg(api_config,arg_name='index')
-                    else:
-                        ind=self.get_arg(api_config,1)
+                    ind=self.get_arg(api_config, 1, "index")
                     s=ind.shape
                     for ii in range(s[-1]):  
                         self.numpy_tensor[...,ii] = numpy.random.randint(-org[ii], org[ii], size=self.numpy_tensor[...,ii].shape).astype(self.dtype)
@@ -664,13 +652,13 @@ class TensorConfig:
                     
             elif api_config.api_name in ["paddle.Tensor.clip"]:
                 self.numpy_tensor=numpy.random.random()-0.5
-                if index==2:
-                    pre=self.get_arg(api_config,1)
+                if key == "max" or index == 2:
+                    pre=self.get_arg(api_config, 1, "min")
                     self.numpy_tensor=numpy.clip(self.numpy_tensor,pre.numpy_tensor,None)
             
             elif api_config.api_name in ["paddle.Tensor.expand"]:
-                if index>0:
-                    d=self.get_arg(api_config,0)
+                if not (key == "x" or index == 0):
+                    d=self.get_arg(api_config, 0, "shape")
                     s=d.shape
                     if len(s)==0 or s[index-1]==1:
                         self.numpy_tensor = (numpy.random.randint(1, 127, size=self.shape)).astype(self.dtype)
@@ -678,11 +666,8 @@ class TensorConfig:
                         self.numpy_tensor = numpy.array(s[index-1])
 
             elif api_config.api_name in ['paddle.Tensor.gather',"paddle.gather"]:
-                if index==1:
-                    if 'x' in api_config.kwargs:
-                        s=self.get_arg(api_config,arg_name='x')
-                    else:
-                        s=self.get_arg(api_config,0)
+                if key == "index" or index == 1:
+                    s=self.get_arg(api_config, 0, "x")
 
                     if 'axis' in api_config.kwargs:
                         tmp=self.get_arg(api_config,arg_name='axis')
@@ -692,11 +677,11 @@ class TensorConfig:
                     else:
                         tmp=0
                     self.numpy_tensor = (numpy.random.randint(0,s.shape[tmp], size=self.shape)).astype(self.dtype)
-                elif index==2:
+                elif key == "axis" or index == 2:
                     self.numpy_tensor = (numpy.random.randint(0,2, size=self.shape)).astype(self.dtype)
 
             elif api_config.api_name in ["paddle.Tensor.gather_nd","paddle.gather_nd"]:
-                if index==1:
+                if key == "index" or index == 1:
                     if 'x' in api_config.kwargs:
                         org=self.get_arg(api_config,arg_name='x')
                     else:
@@ -718,32 +703,27 @@ class TensorConfig:
                 else:
                     tarindex=1
                 if index==tarindex:
-                    if 'axis' in api_config.kwargs:
-                        axis=self.get_arg(api_config,arg_name='axis')
-                    else:
+                    axis=self.get_arg(api_config, 2, 'axis')
+                    if axis is None:
                         axis=0
-                    inputs=self.get_arg(api_config,0)
+                    inputs=self.get_arg(api_config, 0, "x")
                     self.numpy_tensor = numpy.random.randint(0,inputs.shape[axis], size=self.shape).astype(self.dtype)
 
             # u
             elif api_config.api_name in ["paddle.unsqueeze"]:
                 if self.check_arg(api_config, 1, "axis"):
-                    max_dim = len(self.get_arg(api_config, 0, "x").shape) + 1
-                    shape_len = len(self.shape)
-                    if shape_len == 0:
-                        dim = random.randint(0, max_dim - 1)
-                        if random.choice([True, False]):
+                    x_shape = self.get_arg(api_config, 0, "x").shape
+                    max_dim = len(x_shape) + 1
+                    if len(self.shape) == 0:
+                        dim = numpy.random.randint(0, max_dim)
+                        if numpy.random.rand() > 0.5:
                             dim -= max_dim
                         self.numpy_tensor = numpy.array(dim, dtype=self.dtype)
-                    elif shape_len == 1:
-                        all_dims = list(range(max_dim))
-                        random_dims = random.sample(all_dims, self.shape[0])
-                        final_dims = []
-                        for dim in random_dims:
-                            if random.choice([True, False]):
-                                dim -= max_dim
-                            final_dims.append(dim)
-                        self.numpy_tensor = numpy.array(final_dims, dtype=self.dtype)
+                    elif len(self.shape) == 1:
+                        dims = numpy.random.choice(max_dim, size=self.shape[0], replace=False)
+                        mask = numpy.random.rand(self.shape[0]) > 0.5
+                        dims = numpy.where(mask, dims - max_dim, dims)
+                        self.numpy_tensor = numpy.array(dims, dtype=self.dtype)
                     else:
                         raise ValueError(
                             f"Invalid shape for 'axis' Tensor in paddle.unsqueeze. "

--- a/tester/api_config/config_analyzer.py
+++ b/tester/api_config/config_analyzer.py
@@ -144,7 +144,7 @@ class TensorConfig:
             f"Expected a 0-D or 1-D Tensor, but got shape {self.shape}."
         )
 
-    def get_numpy_tensor(self, api_config,index=0,key="null"):
+    def get_numpy_tensor(self, api_config, index=None, key=None, **kwargs):
         if self.dtype in ["float8_e5m2", "float8_e4m3fn"]:
             print("Warning ", self.dtype, "not supported")
             return
@@ -769,14 +769,14 @@ class TensorConfig:
                         self.numpy_tensor = (numpy.random.random(self.shape) - 0.5).astype(dtype)
         return self.numpy_tensor
 
-    def get_paddle_tensor(self, api_config,index=0,key="null"):
+    def get_paddle_tensor(self, api_config, index=None, key=None, **kwargs):
         if self.dtype in ["float8_e5m2", "float8_e4m3fn"]:
             print("Warning ", self.dtype, "not supported")
             return
 
         if self.paddle_tensor is None:
             self.paddle_tensor = paddle.to_tensor(
-                self.get_numpy_tensor(api_config, index, key),
+                self.get_numpy_tensor(api_config, index, key, **kwargs),
                 dtype=self.dtype if self.dtype != 'bfloat16' else "float32",
             )
             self.paddle_tensor.stop_gradient = True
@@ -831,11 +831,11 @@ class TensorConfig:
 
     def check_arg(self, api_config, arg_pos=None, arg_name=None):
         """Checks if the argument in api_config matches this instance"""
-        if arg_pos is not None and 0 <= arg_pos < len(api_config.args):
-            return str(api_config.args[arg_pos]) == str(self)    
-        if arg_name and arg_name in api_config.kwargs:
-            return str(api_config.kwargs[arg_name]) == str(self)
-        return False
+        nonlocal index, key
+        return (
+            (arg_pos is not None and self.index == arg_pos)
+            or (arg_name is not None and self.key == arg_name)
+        )
 
     def get_arg(self, api_config, arg_pos=None, arg_name=None):
         """Get the argument value from the api_config"""

--- a/tester/api_config/config_analyzer.py
+++ b/tester/api_config/config_analyzer.py
@@ -145,6 +145,11 @@ class TensorConfig:
         )
 
     def get_numpy_tensor(self, api_config, index=None, key=None, **kwargs):
+        if index is not None:
+            self.index = index
+        if key is not None:
+            self.key = key
+
         if self.dtype in ["float8_e5m2", "float8_e4m3fn"]:
             print("Warning ", self.dtype, "not supported")
             return
@@ -770,6 +775,11 @@ class TensorConfig:
         return self.numpy_tensor
 
     def get_paddle_tensor(self, api_config, index=None, key=None, **kwargs):
+        if index is not None:
+            self.index = index
+        if key is not None:
+            self.key = key
+
         if self.dtype in ["float8_e5m2", "float8_e4m3fn"]:
             print("Warning ", self.dtype, "not supported")
             return
@@ -831,10 +841,9 @@ class TensorConfig:
 
     def check_arg(self, api_config, arg_pos=None, arg_name=None):
         """Checks if the argument in api_config matches this instance"""
-        nonlocal index, key
         return (
-            (arg_pos is not None and self.index == arg_pos)
-            or (arg_name is not None and self.key == arg_name)
+            (arg_pos is not None and hasattr(self, "index") and self.index == arg_pos)
+            or (arg_name is not None and hasattr(self, "key") and self.key == arg_name)
         )
 
     def get_arg(self, api_config, arg_pos=None, arg_name=None):

--- a/tester/base.py
+++ b/tester/base.py
@@ -241,14 +241,39 @@ class APITestBase:
 
         return True
     
-    def _handle_list_or_tuple(self, config_items, is_tuple=False, index=0, key="null"):
+    def _handle_list_or_tuple(self, config_items, is_tuple=False, index=None, key=None, list_index=[]):
         """处理 list 或 tuple """
-        tmp = [
-            item.get_paddle_tensor(self.api_config, i + index, key) if isinstance(item, TensorConfig) else item
-            for i, item in enumerate(config_items)
-        ]
-        if self.api_config.api_name in ["paddle.expand","paddle.Tensor.expand"] and isinstance(tmp[0], paddle.Tensor):
-            tmp[0]=int(tmp[0])
+
+        need_axes_handling = self.api_config.api_name in handle_axes_api
+        need_indices_handling = self.api_config.api_name == "paddle.index_put"
+
+        if need_indices_handling and (index == 1 or key == "indices"):
+            return self._handle_indices_arg(config_items, is_tuple)
+        elif need_axes_handling and (index == 1 or key == "axis"):
+            return self._handle_axis_arg(config_items, is_tuple)
+
+        tmp = []
+        for i, item in enumerate(config_items):
+            current_list_index = list_index + [i]
+            if isinstance(item, (list, tuple)):
+                is_nested_tuple = isinstance(item, tuple)
+                processed_item = self._handle_list_or_tuple(
+                    item, 
+                    is_tuple=is_nested_tuple, 
+                    index=index, 
+                    key=key, 
+                    list_index=current_list_index
+                )
+            elif isinstance(item, TensorConfig):
+                processed_item = item.get_paddle_tensor(
+                    self.api_config,
+                    index=index,
+                    key=key,
+                    list_index=current_list_index
+                )
+            else:
+                processed_item = item
+            tmp.append(processed_item)
         return tuple(tmp) if is_tuple else tmp
         
     def _handle_axis_arg(self, config_items, is_tuple=False):
@@ -292,7 +317,7 @@ class APITestBase:
                     tensor_idx += 1
         return tuple(tmp) if is_tuple else tmp
 
-    def _handle_indices_api(self, config_items, is_tuple=False):
+    def _handle_indices_arg(self, config_items, is_tuple=False):
         x = self.paddle_args_config[0] if len(self.paddle_args_config) > 0 else self.paddle_kwargs_config["x"]
         value = self.paddle_args_config[2] if len(self.paddle_args_config) > 2 else self.paddle_kwargs_config["value"]
         x_shape = x.shape
@@ -326,48 +351,25 @@ class APITestBase:
         self.paddle_kwargs = collections.OrderedDict()
         self.paddle_merged_kwargs = collections.OrderedDict()
 
-        need_axes_handling = self.api_config.api_name in handle_axes_api
-        need_indices_handling = self.api_config.api_name == "paddle.index_put"
-
-        cnt=0
-        for i in range(len(self.paddle_args_config)):
-            if isinstance(self.paddle_args_config[i], TensorConfig):
-                self.paddle_args.append(self.paddle_args_config[i].get_paddle_tensor(self.api_config, i))
-            elif isinstance(self.paddle_args_config[i], list):
-                if need_axes_handling and i == 1:
-                    self.paddle_args.append(self._handle_axis_arg(self.paddle_args_config[i]))
-                else:
-                    self.paddle_args.append(self._handle_list_or_tuple(self.paddle_args_config[i],index=i))
-            elif isinstance(self.paddle_args_config[i], tuple):
-                if need_axes_handling and i == 1:
-                    self.paddle_args.append(self._handle_axis_arg(self.paddle_args_config[i], is_tuple=True))
-                if need_indices_handling and i == 1:
-                    self.paddle_args.append(self._handle_indices_api(self.paddle_args_config[i], is_tuple=True))
-                else:
-                    self.paddle_args.append(self._handle_list_or_tuple(self.paddle_args_config[i], is_tuple=True,index=i))
-            else:
-                self.paddle_args.append(self.paddle_args_config[i])
-
-        cnt=len(self.paddle_args_config)
-        for key, arg_config in self.paddle_kwargs_config.items():
+        for i, arg_config in enumerate(self.paddle_args_config):
             if isinstance(arg_config, TensorConfig):
-                self.paddle_kwargs[key] = arg_config.get_paddle_tensor(self.api_config,cnt,key=key)
+                self.paddle_args.append(arg_config.get_paddle_tensor(self.api_config, index=i))
             elif isinstance(arg_config, list):
-                if need_axes_handling and key == "axis":
-                    self.paddle_kwargs[key] = self._handle_axis_arg(arg_config)
-                else:
-                    self.paddle_kwargs[key] = self._handle_list_or_tuple(arg_config,index=cnt,key=key)
-                    cnt+=len(self.paddle_kwargs[key])-1
+                self.paddle_args.append(self._handle_list_or_tuple(arg_config, index=i))
             elif isinstance(arg_config, tuple):
-                if need_axes_handling and key == "axis":
-                    self.paddle_kwargs[key] = self._handle_axis_arg(arg_config, is_tuple=True)
-                if need_indices_handling and key == "indices":
-                    self.paddle_args.append(self._handle_indices_api(self.paddle_args_config[i], is_tuple=True))
-                else:
-                    self.paddle_kwargs[key] = self._handle_list_or_tuple(arg_config, is_tuple=True,index=cnt,key=key)
+                self.paddle_args.append(self._handle_list_or_tuple(arg_config, is_tuple=True, index=i))
             else:
-                self.paddle_kwargs[key] = arg_config
-            cnt+=1
+                self.paddle_args.append(arg_config)
+
+        for key, kwarg_config in self.paddle_kwargs_config.items():
+            if isinstance(kwarg_config, TensorConfig):
+                self.paddle_kwargs[key] = kwarg_config.get_paddle_tensor(self.api_config, key=key)
+            elif isinstance(kwarg_config, list):
+                self.paddle_kwargs[key] = self._handle_list_or_tuple(kwarg_config, key=key)
+            elif isinstance(kwarg_config, tuple):
+                self.paddle_kwargs[key] = self._handle_list_or_tuple(kwarg_config, is_tuple=True, key=key)
+            else:
+                self.paddle_kwargs[key] = kwarg_config
 
         if len(self.paddle_args) == 0 and "paddle.Tensor." in self.api_config.api_name:
             self.paddle_args.append(self.paddle_kwargs.popitem(last=False)[1])


### PR DESCRIPTION
## 修改动机

目前 `base.py/gen_paddle_input()` 与 `config_analyzer.py/get_numpy_tensor()` 的代码逻辑比较混乱，代码质量较低，各位同学解决问题的方法不一致，也会造成 mentor 的 review 困难

因此本 pr 旨在统一代码逻辑，综合各位同学的修改方法，并提出一个最终的、可通用的、鲁棒性高的解决方案，且最大程度保留原本代码逻辑

## 代码历史

在 https://github.com/PFCCLab/PaddleAPITest/pull/17 中，@mzj104 引入了 cnt（位于 `base`）与 index （位于 `config_analyzer`），用于解决不同位置的相同 Tensor 的初始化问题，如：
```
paddle.clip(x, min=None, max=None, name=None)
paddle.Tensor.clip(Tensor([2, 2],"int32"), Tensor([1],"int32"), Tensor([1],"int32"), )
```

原有的 `check_arg()` 方法无法区分位于 `min` 或 `max` 位置的参数（见问题分析），因此引入了 index，并在后续的所有代码中仅使用 index 进行区分

在 https://github.com/PFCCLab/PaddleAPITest/pull/28 中，@cszdrg 尝试使用了 index

在 https://github.com/PFCCLab/PaddleAPITest/pull/24 中，@cszdrg 额外引入了 key（位于 `config_analyzer`），将关键字也进行传入

## 问题分析

原有的 `check_arg()` 方法在设计上确实有缺陷，我们无法断言每个参数的 Tensor 都不一样，使用 `== str(self)` 是不可靠的
```
    def check_arg(self, api_config, arg_pos=None, arg_name=None):
        """Checks if the argument in api_config matches this instance"""
        if arg_pos is not None and 0 <= arg_pos < len(api_config.args):
            return str(api_config.args[arg_pos]) == str(self)    
        if arg_name and arg_name in api_config.kwargs:
            return str(api_config.kwargs[arg_name]) == str(self)
        return False
```

因此，我们需要将 index 与 key 的逻辑重新整合并定义：
- index 用于区分 **位置参数**，对应于 `arg_pos` 与 `self.paddle_args_config` ，表示该 Tensor 位于 api 的第几个参数，在 base 中传入 config_analyzer
- key 用于区分 **关键字参数**，对应于 `arg_name` 与 `self.paddle_kwargs_config` ，表示该 Tensor 对应于 api 的哪一个具体参数，在 base 中传入 config_analyzer
- index 与 key 总有一个会被设置，默认为 None

`check_arg()` 修改为：
```
    def check_arg(self, api_config, arg_pos=None, arg_name=None):
        """Checks if the argument in api_config matches this instance"""
        return (
            (arg_pos is not None and hasattr(self, "index") and self.index == arg_pos)
            or (arg_name is not None and hasattr(self, "key") and self.key == arg_name)
        )
```

## 主要修改：

***base.py***

- 删去 gen_paddle_input 中的 cnt 计数，采用 enumerate
- 将处理 list 或 tuple 的逻辑统一移至 _handle_list_or_tuple 中处理，简化主干逻辑
- _handle_list_or_tuple 增加 list_index 用于区分列表内的不同 Tensor（仅设计，似乎并未用上）

***config_analyzer.py***
- 为 get_numpy_tensor 与 get_paddle_tensor 增加参数 index 与 key，默认为 None，并设置为成员变量
- 增加 **kwargs 便于拓展
- 修改 check_arg，使用 self.index 与 self.key 判断
- 将代码中所有仅使用 index 判断的代码进行修复，加强鲁棒性（最好建议使用 check_arg）

## 部分测试

api_config_merged_7.txt：修改了 generate_random_axes 与 paddle.unsqueeze 以修复 bug，修改后全部通过
![image](https://github.com/user-attachments/assets/1d0b5eb3-ef7a-44a1-9d2d-8ae813f127dc)

api_config_merged_9.txt：paddle.Tensor.expand、paddle.expand 未通过，原因需 @mzj104 进一步确认
![image](https://github.com/user-attachments/assets/b0037b59-f91e-4af8-90c8-1ef173cf7236)

api_config_merged_10.txt：paddle.chunk、paddle.ones 使用了 random 库（在 https://github.com/PFCCLab/PaddleAPITest/pull/21 被我移除），重新导入后全部通过
![image](https://github.com/user-attachments/assets/eb324ecf-647b-43f4-8eeb-81653e61733a)

api_config_merged_11.txt：全部通过
![image](https://github.com/user-attachments/assets/1a88ecb8-c009-432c-918f-00d50b8af5d1)

@wanghuancoder 
@cszdrg @mzj104 @Cutelemon6 @yuwu46 