### PR TITLE
[BIT] 引擎补齐：refine stocastic_behavior_apis

### DIFF
--- a/tester/base.py
+++ b/tester/base.py
@@ -67,6 +67,7 @@ stochastic_behavior_apis =[
     "paddle.incubate.nn.functional.fused_bias_dropout_residual_layer_norm",
     "paddle.incubate.nn.functional.fused_dropout_add",
     "paddle.incubate.nn.functional.moe_dispatch",
+    "paddle.nn.functional.alpha_dropout", 
     "paddle.nn.functional.fused_feedforward",
     "paddle.nn.functional.dropout",
     "paddle.nn.functional.dropout2d",


### PR DESCRIPTION
refine PR #40, 增加了一个 api 到 stochastic_behavior_apis：`paddle.nn.functional.alpha_dropout`