### PR TITLE
【BIT】引擎能力补齐：paddle.index_put

### DIFF
--- a/report/fresh_report/test_log_paddle.index_put.txt
+++ b/report/fresh_report/test_log_paddle.index_put.txt
@@ -1,0 +1,15 @@
+paddle.index_put(Tensor([16, 21],"float64"), tuple(Tensor([16, 21],"bool"),), Tensor([2, 1],"float64"), False, )
+paddle.index_put(Tensor([16, 21],"float64"), tuple(Tensor([16, 21],"bool"),), Tensor([2, 1],"float64"), True, )
+
+2025-04-17 03:35:52.558828 test begin: paddle.index_put(Tensor([16, 21],"float64"), tuple(Tensor([16, 21],"bool"),), Tensor([2, 1],"float64"), False, )
+terminate called after throwing an instance of 'std::length_error'
+  what():  vector::_M_fill_insert
+
+--------------------------------------
+C++ Traceback (most recent call last):
+--------------------------------------
+0   paddle::pybind::ThrowExceptionToPython(std::__exception_ptr::exception_ptr)
+
+----------------------
+Error Message Summary:
+----------------------

--- a/tester/base.py
+++ b/tester/base.py
@@ -294,27 +294,46 @@ class APITestBase:
         value = self.paddle_args_config[2] if len(self.paddle_args_config) > 2 else self.paddle_kwargs_config["value"]
         x_shape = x.shape
         value_shape = value.shape
-        if len(config_items) > len(x_shape):
-            raise ValueError(f"The number of indices ({len(config_items)}) must not exceed the dimension of the input ({len(x_shape)})")
 
         tmp = []
+        matched_axis = 0
         indices_shape_len = 0
-        for i, item in enumerate(config_items):
-            if item.dtype == "bool":
-                if len(x_shape) - len(config_items) + indices_shape_len + len(item.shape) - 1 == len(value_shape):
-                    true_needed = 1
-                else:
-                    true_needed = value_shape[indices_shape_len]
-                if true_needed > numpy.prod(item.shape):
-                    raise ValueError(f"Number of True values required ({true_needed}) exceeds boolean index size ({numpy.prod(item.shape)})")
-                mask = numpy.zeros(item.shape, dtype=bool)
-                indices = numpy.random.choice(numpy.prod(item.shape), size=int(true_needed), replace=False)
-                mask.flat[indices] = True
-                item.numpy_tensor = mask
-            else:
-                x_dim = x_shape[i]
-                item.numpy_tensor = numpy.random.randint(-x_dim, x_dim, size=item.shape, dtype=item.dtype)
+        for item in config_items:
+            if item.dtype != "bool":
+                matched_axis += 1
                 indices_shape_len = max(indices_shape_len, len(item.shape))
+
+        expected = indices_shape_len + len(x_shape) - matched_axis
+        reduced = expected - len(value_shape)
+        x_shape_index = 0
+        value_shape_index = indices_shape_len
+
+        for item in config_items:
+            if item.dtype == "bool":
+                true_needed = []
+                for i in range(len(item.shape)):
+                    if reduced > 0:
+                        reduced -= 1
+                        true_needed.append(1)
+                    else:
+                        true_needed.append(value_shape[value_shape_index])
+                        value_shape_index += 1
+                for i in range(len(true_needed) - 1, 0, -1):
+                    if true_needed[i] > value_shape[i]:
+                        true_needed[i - 1] *= true_needed[i] // value_shape[i]
+                        true_needed[i] = value_shape[i]
+                mask = numpy.zeros(item.shape, dtype=bool)
+                indices = [
+                    numpy.random.choice(dim_size, size=needed, replace=False)
+                    for dim_size, needed in zip(item.shape, true_needed)
+                ]
+                mask[numpy.ix_(*indices)] = True
+                item.numpy_tensor = mask
+                x_shape_index += len(item.shape)
+            else:
+                x_dim = x_shape[x_shape_index]
+                item.numpy_tensor = numpy.random.randint(-x_dim, x_dim, size=item.shape, dtype=item.dtype)
+                x_shape_index += 1
             tmp.append(item.get_paddle_tensor(self.api_config))
         return tuple(tmp) if is_tuple else tmp
 


### PR DESCRIPTION
在 https://github.com/PFCCLab/PaddleAPITest/pull/49 中有两条 paddle.index_put 被误操作，因此重新检查；

经检查发现是内核崩溃错误，尝试重新撰写处理代码后，此两条仍不通过测试，因此认定是内核问题，移至 fresh_report 中；

新的 paddle.index_put 生成代码更好，且其他配置均通过测试，测试结果如下：

![image](https://github.com/user-attachments/assets/bd470d2b-c287-4f25-9d01-c372a9fbf923)

修复了一个小的书写错误

修改内容: 
`base.py/_handle_indices_arg()`

用于合并处理索引参数的列表或元组（目前仅有 index_put 使用），其核心是根据输入x和值value的形状计算indices参数的填充值:

1. 首先统计indices参数匹配到的x维度数量 (matched_axis)
2. 计算索引形状的最大长度 (indices_shape_len)
3. 计算预期的输出形状 (expected)
4. 计算形状缩减量 (reduced)（输出形状会被indices中的bool类型的true值数量影响）
5. 处理每个配置项:
    1. bool类型索引:
        1. 计算每个索引维度需要的true值数量 true_needed
        2. 调整true值数量，避免超过维度大小
        3. 创建全 False 的布尔掩码
        4. 随机选择位置设置为 True
        5. 将生成的掩码赋给配置项
    2. 整数类型索引:
        1. 根据输入x的对应维度大小生成随机整数索引
        2. 索引范围在 [-x_dim, x_dim) 之间