### PR TITLE
【BIT】修复引擎能力补齐的问题：paddle.index_put

### DIFF
--- a/tester/base.py
+++ b/tester/base.py
@@ -290,9 +290,9 @@ class APITestBase:
                         true_needed.append(value_shape[value_shape_index])
                         value_shape_index += 1
                 for i in range(len(true_needed) - 1, 0, -1):
-                    if true_needed[i] > value_shape[i]:
-                        true_needed[i - 1] *= true_needed[i] // value_shape[i]
-                        true_needed[i] = value_shape[i]
+                    if true_needed[i] > item.shape[i]:
+                        true_needed[i - 1] *= true_needed[i] // item.shape[i]
+                        true_needed[i] = item.shape[i]
                 mask = numpy.zeros(item.shape, dtype=bool)
                 indices = [
                     numpy.random.choice(dim_size, size=needed, replace=False)


### PR DESCRIPTION
根据 @yuwu46 的错误报告，依次检查，发现大部分已经正常处理并已报告 fresh_report，api 分别对应 pr：

paddle.linalg.eigh
paddle.linalg.matrix_power
paddle.linalg.norm
paddle.linalg.solve
paddle.linalg.svdvals
详见 https://github.com/PFCCLab/PaddleAPITest/pull/15

paddle.nn.functional.cross_entropy
详见 https://github.com/PFCCLab/PaddleAPITest/pull/36

paddle.index_put
详见 https://github.com/PFCCLab/PaddleAPITest/pull/54

其中 paddle.index_put 有两条尚未支持的配置，修改生成方法后，全部 paddle.index_put 通过测试：

![image](https://github.com/user-attachments/assets/8acb2ab8-5715-4190-a58c-276c6ea43b0f)
