### PR TITLE
[BIT] Enhance engineV2: add --api_config_file_pattern para, fix log_writer

### DIFF
--- a/engineV2.py
+++ b/engineV2.py
@@ -369,9 +369,7 @@ def main():
 
             if "*" in options.api_config_file_pattern:
                 all_files = glob.glob(options.api_config_file_pattern)
-                regex_pattern = re.sub(
-                    r"\*([^*]*)$", r"\d+\1", options.api_config_file_pattern
-                )
+                regex_pattern = re.sub(r'\*([^*]*)$', r'\\d+\1', options.api_config_file_pattern)
                 config_files = [
                     file for file in all_files if re.fullmatch(regex_pattern, file)
                 ]

--- a/engineV2.py
+++ b/engineV2.py
@@ -280,6 +280,11 @@ def main():
 
     parser = argparse.ArgumentParser(description="API Test")
     parser.add_argument("--api_config_file", default="")
+    parser.add_argument(
+        "--api_config_file_pattern",
+        default="",
+        help="Pattern to match multiple config files (e.g., 'tester/api_config/api_config_support2torch_*.txt')",
+    )
     parser.add_argument("--api_config", default="")
     parser.add_argument(
         "--paddle_only",
@@ -357,34 +362,64 @@ def main():
         finally:
             case.clear_tensor()
             del case
-    elif options.api_config_file:
+    elif options.api_config_file or options.api_config_file_pattern:
+        if options.api_config_file_pattern:
+            import glob
+            import re
+
+            if "*" in options.api_config_file_pattern:
+                all_files = glob.glob(options.api_config_file_pattern)
+                regex_pattern = re.sub(
+                    r"\*([^*]*)$", r"\d+\1", options.api_config_file_pattern
+                )
+                config_files = [
+                    file for file in all_files if re.fullmatch(regex_pattern, file)
+                ]
+                if not config_files:
+                    print(
+                        f"No config files found: {options.api_config_file_pattern}",
+                        flush=True,
+                    )
+                    return
+            else:
+                config_files = [options.api_config_file_pattern]
+            print("\nConfig files to be tested:")
+            for i, config_file in enumerate(sorted(config_files), 1):
+                print(f"{i}. {config_file}")
+        else:
+            config_files = [options.api_config_file]
+
         # Batch execution
         finish_configs = read_log("checkpoint")
         print(len(finish_configs), "cases have been tested.", flush=True)
-        try:
-            with open(options.api_config_file, "r") as f:
-                lines = [line.strip() for line in f if line.strip()]
-                print(len(lines), "cases in total.", flush=True)
-                api_configs = set(lines)
-                dup_case = len(lines) - len(api_configs)
-                if dup_case > 0:
-                    print(dup_case, "cases are duplicates and removed.", flush=True)
-        except FileNotFoundError:
-            print(
-                f"Error: api config file {options.api_config_file} not found",
-                flush=True,
-            )
-            return
 
-        api_configs_origin_count = len(api_configs)
+        api_config_count = 0
+        api_configs = set()
+        for config_file in config_files:
+            try:
+                with open(config_file, "r") as f:
+                    lines = [line.strip() for line in f if line.strip()]
+                    api_config_count += len(lines)
+                    api_configs.update(lines)
+            except FileNotFoundError:
+                print(
+                    f"Error: config file {config_file} not found",
+                    flush=True,
+                )
+        print(api_config_count, "cases in total.", flush=True)
+        dup_case = api_config_count - len(api_configs)
+        if dup_case > 0:
+            print(dup_case, "cases are duplicates and removed.", flush=True)
+
+        api_config_count = len(api_configs)
         api_configs = sorted(api_configs - finish_configs)
         all_case = len(api_configs)
         fail_case = 0
-        tested_case = api_configs_origin_count - all_case
+        tested_case = api_config_count - all_case
         if tested_case:
             print(tested_case, "cases already tested.", flush=True)
         print(all_case, "cases will be tested.", flush=True)
-        del finish_configs, api_configs_origin_count, tested_case
+        del api_config_count, dup_case, tested_case
 
         if options.num_gpus != 0 or options.gpu_ids:
             # Multi GPUs

--- a/run.sh
+++ b/run.sh
@@ -2,7 +2,8 @@
 
 # 配置参数
 # NUM_GPUS!=0 时，engineV2 不受外部 "CUDA_VISIBLE_DEVICES" 影响
-INPUT_FILE="tester/api_config/api_config_support2torch_1.txt"
+INPUT_FILE="tester/api_config/api_config_paddleonly_1.txt"
+FILE_PATTERN="tester/api_config/api_config_paddleonly_*.txt"
 LOG_DIR="tester/api_config/test_log"
 NUM_GPUS=-1
 NUM_WORKERS_PER_GPU=-1
@@ -12,8 +13,8 @@ REQUIRED_MEMORY=10
 mkdir -p "$LOG_DIR" || { echo "无法创建日志目录 $LOG_DIR"; exit 1; }
 
 # 执行程序
-nohup python engineV2.py --accuracy=True \
-        --api_config_file="$INPUT_FILE" \
+nohup python engineV2.py --paddle_only=True \
+        --api_config_file_pattern="$FILE_PATTERN" \
         --num_gpus=$NUM_GPUS \
         --num_workers_per_gpu=$NUM_WORKERS_PER_GPU \
         >> "$LOG_DIR/log.log" 2>&1 &

--- a/tester/api_config/log_writer.py
+++ b/tester/api_config/log_writer.py
@@ -24,19 +24,23 @@ LOG_PREFIXES = {
 
 is_engineV2 = False
 
-    
+
 # Command line arguments configuration
+# Used in engine.py
 CMD_CONFIG = None
+
 
 def get_cfg():
     global CMD_CONFIG
     return CMD_CONFIG
 
+
 def set_cfg(cfg):
     global CMD_CONFIG
     if cfg.id != "":
-        cfg.id = "_"+cfg.id
+        cfg.id = "_" + cfg.id
     CMD_CONFIG = cfg
+
 
 def set_engineV2():
     global is_engineV2
@@ -48,9 +52,12 @@ def get_log_file(log_type: str):
     """获取指定日志类型和PID对应的日志文件路径"""
     global is_engineV2
     prefix = LOG_PREFIXES.get(log_type)
-    id = get_cfg().id
     if not is_engineV2:
-        return TEST_LOG_PATH / f"{prefix + id}.txt"
+        cfg = get_cfg()
+        if cfg:
+            return TEST_LOG_PATH / f"{prefix + cfg.id}.txt"
+        else:
+            return TEST_LOG_PATH / f"{prefix}.txt"
     pid = os.getpid()
     return TMP_LOG_PATH / f"{prefix}_{pid}.txt"
 
@@ -74,8 +81,11 @@ def read_log(log_type):
     """读取文件所有行，返回集合"""
     if log_type not in LOG_PREFIXES:
         raise ValueError(f"Invalid log type: {log_type}")
-    id = get_cfg().id
-    file_path = TEST_LOG_PATH / f"{LOG_PREFIXES[log_type] + id}.txt"
+    cfg = get_cfg()
+    if cfg:
+        file_path = TEST_LOG_PATH / f"{LOG_PREFIXES[log_type] + cfg.id}.txt"
+    else:
+        file_path = TEST_LOG_PATH / f"{LOG_PREFIXES[log_type]}.txt"
     try:
         with file_path.open("r") as f:
             return set(line.strip() for line in f if line.strip())
@@ -119,11 +129,12 @@ def aggregate_logs(mkdir=False):
     if mkdir:
         TMP_LOG_PATH.mkdir(exist_ok=True)
 
+
 def print_log_info(all_case, fail_case):
     """打印日志统计信息"""
     log_counts = {}
     recorded_count = 0
-    
+
     for log_type, prefix in LOG_PREFIXES.items():
         log_file = TEST_LOG_PATH / f"{prefix}.txt"
         if not log_file.exists():
@@ -138,17 +149,19 @@ def print_log_info(all_case, fail_case):
             print(f"Error reading {log_file}: {err}", flush=True)
 
     skipped_case = all_case - recorded_count - fail_case
-    assert skipped_case >= 0, f"skipped_case should be non-negative, but got {skipped_case}"
-    
+    assert (
+        skipped_case >= 0
+    ), f"skipped_case should be non-negative, but got {skipped_case}"
+
     # 打印统计信息
-    print("\n" + "="*50)
+    print("\n" + "=" * 50)
     print("Test Case Statistics".center(50))
-    print("="*50)
+    print("=" * 50)
     print(f"{'Total cases':<30}: {all_case}")
     print(f"{'Failed cases':<30}: {fail_case}")
     print(f"{'Skipped cases':<30}: {skipped_case}")
-    print("-"*50)
+    print("-" * 50)
     print("Log Type Breakdown:")
     for log_type, count in log_counts.items():
         print(f"  {log_type:<28}: {count}")
-    print("="*50 + "\n")
+    print("=" * 50 + "\n")


### PR DESCRIPTION
## 修改内容

1. 修复 https://github.com/PFCCLab/PaddleAPITest/pull/141 修改后造成的 engineV2 不兼容问题（需手动调用 set_cfg ）
2. engineV2 新增 --api_config_file_pattern 参数，可合并测试所有如 `tester/api_config/api_config_paddleonly_*.txt` 的文件！

![image](https://github.com/user-attachments/assets/5b60c7ab-1599-4f3a-bd98-48bb55cd3e40)

![image](https://github.com/user-attachments/assets/35717658-33d4-4609-829e-302c87bc34c4)
