### PR TITLE
Add tool  find_api_config

### DIFF
--- a/test_pipline/README.md
+++ b/test_pipline/README.md
@@ -16,6 +16,8 @@
 `test_pipline` 目录旨在组织针对不同测试目标、环境或类型的辅助脚本和配置文件。每个子目录代表一个特定的测试场景。这种结构有助于保持相关工具的集中和清晰。
 
 以下是当前的子目录及其用途说明：
+*   **`cpu_0size/`**: <a name="cpu_0size"></a>
+    *   **用途**: 存放 CPU 环境下处理 PaddlePaddle API 0-size tensor 报错信息的python脚本。
 
 *   **`gpu_0size/`**: <a name="gpu_0size"></a>
     *   **用途**: 存放与在 GPU 环境下测试 PaddlePaddle API 处理 0-size tensor 相关的工具和脚本。

--- a/tools/find_API_config.py
+++ b/tools/find_API_config.py
@@ -1,0 +1,70 @@
+import argparse
+
+def main():
+    # 创建参数解析器
+    parser = argparse.ArgumentParser(description="从日志中提取指定API的错误信息(出错的配置和日志信息)")
+    
+    # 添加命令行参数
+    parser.add_argument(
+        "--input-log",
+        type=str,
+        required=True,
+        help="输入日志文件路径"
+    )
+    parser.add_argument(
+        "--api",
+        type=str,
+        required=True,
+        help="要查找的目标API"
+    )
+    parser.add_argument(
+        "--output-error-log",
+        type=str,
+        default="api_error_log.txt",
+        help="目标API的错误日志输出路径（默认: %(default)s）"
+    )
+
+    parser.add_argument(
+        "--output-error-config",
+        type=str,
+        default="api_error_config.txt",
+        help="目标API的错误配置输出路径（默认: %(default)s）"
+    )
+
+    # 解析参数
+    args = parser.parse_args()
+
+    error_configs = set()
+    error_apis = set()
+    target_api = args.api
+
+    # 处理错误日志
+    with open(args.output_error_log, "w") as error_log:
+        with open(args.input_log, "r") as file:
+            lines = file.readlines()
+            log_str = ""
+            config = ""
+            for line in lines:
+                if "test begin" in line :
+                    # 检测错误关键词
+                    if any(keyword in log_str for keyword in [
+                        "accuracy error", "paddle error", "cudaErrorIllegalAddress",
+                        "cudaErrorLaunchFailure", "cuda error", "CUDA error",
+                        "CUDNN error", "TID", "PID"
+                    ]) and target_api in log_str:
+                        error_log.write(log_str)
+                        error_configs.add(config)
+                    # 提取配置和API信息
+                    log_str = line
+                    config = line[line.index("test begin: ")+12:]
+                    api = config[0:config.index("(")] if "(" in config else config
+                else:
+                    log_str += line
+
+    # 写入错误配置
+    with open(args.output_error_config, "w") as error_config_file:
+        error_config_file.write("\n".join(error_configs))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
- find_api_config可以从error_log海量的日志中找到指定API对应的错误日志及其出错时的api_config。在PaddleAPITest进行单独的API回测时，可以方便的整理出目标API对应的错误配置和日志信息。
- 具体用法请见 ``` python find_api_config.py -h ```

![image](https://github.com/user-attachments/assets/c23e22cd-a9ce-400d-b443-0b0ba7215ec0)


