### PR TITLE
Fix redirect error, refine error_msg print

### DIFF
--- a/tester/api_config/log_writer.py
+++ b/tester/api_config/log_writer.py
@@ -138,7 +138,8 @@ def aggregate_logs(end=False):
                 try:
                     with file_path.open("r") as in_f:
                         out_f.writelines(in_f.read())
-                    os.remove(str(file_path))
+                    with file_path.open("w") as f:
+                        pass
                 except Exception as err:
                     print(f"Error reading {file_path}: {err}", flush=True)
     except Exception as err:

--- a/tester/base.py
+++ b/tester/base.py
@@ -124,6 +124,7 @@ class APITestBase:
         self.api_config = api_config
         self.outputs_grad_numpy = []
         torch.set_num_threads(20)
+        torch.set_printoptions(threshold=100)
 
     def need_skip(self, paddle_only=False):
         # not support
@@ -863,24 +864,13 @@ class APITestBase:
         converted_paddle_tensor = torch.utils.dlpack.from_dlpack(paddle_dlpack)
 
         def error_msg(msg):
-            total_count = converted_paddle_tensor.numel()
-            display_count = min(total_count, 100)
-            flat_paddle = converted_paddle_tensor.flatten()[:display_count]
-            flat_torch = torch_tensor.flatten()[:display_count]
-
-            # msg = "\n".join(msg.splitlines()[2:])
-            elements_text = (
-                f"First {display_count} elements"
-                if display_count < total_count
-                else "All elements"
-            )
             return (
                 f"Not equal to tolerance rtol={rtol}, atol={atol}\n"
                 f"{msg}\n"
                 f"ACTUAL: (shape={converted_paddle_tensor.shape}, dtype={converted_paddle_tensor.dtype})\n"
-                f"{elements_text}: {flat_paddle}\n"
+                f"{converted_paddle_tensor}\n"
                 f"DESIRED: (shape={torch_tensor.shape}, dtype={torch_tensor.dtype})\n"
-                f"{elements_text}: {flat_torch}"
+                f"{torch_tensor}"
             )
 
         try:


### PR DESCRIPTION
1. log_writer 直接使用 os.remove 移除临时文件会导致输出重定向失效，修改为清空文件内容
2. 优化 torch_assert_accuracy 的 msg 输出，使用 torch.set_printoptions 设置为打印100 个，效果更好：

![image](https://github.com/user-attachments/assets/4e96f8a7-9c16-4165-af78-bb877cc486dc)
