### PR TITLE
[Accuracy diff No.28-29] Fix accuracy diff for paddle.linalg.norm API

### DIFF
--- a/tester/paddle_to_torch/rules.py
+++ b/tester/paddle_to_torch/rules.py
@@ -3797,6 +3797,11 @@ elif len(x.shape)>2 and axis is None:
             result = x.abs().amin()
     else:
         result = {self.torch_api}(**_kwargs)
+elif len(x.shape)==2 and axis is None:
+    _kwargs["input"] = x.flatten()
+    result = {self.torch_api}(**_kwargs)
+    if keepdim:
+        result = result.unsqueeze(0)
 else:
     result = {self.torch_api}(**_kwargs)
 """

--- a/tester/paddle_to_torch/rules.py
+++ b/tester/paddle_to_torch/rules.py
@@ -3784,7 +3784,7 @@ if p==0:
         result = (x!= 0).sum(dim=axis, keepdim=True).to(x.dtype)
     else:
         result = (x!= 0).sum(dim=axis).to(x.dtype)
-elif len(x.shape)>2 and axis is None:
+elif len(x.shape)>=2 and axis is None:
     if p==math.inf:
         if keepdim:
             result = x.abs().amax().reshape([1] * x.ndim)
@@ -3796,12 +3796,10 @@ elif len(x.shape)>2 and axis is None:
         else:
             result = x.abs().amin()
     else:
+        _kwargs["input"] = x.flatten()
         result = {self.torch_api}(**_kwargs)
-elif len(x.shape)==2 and axis is None:
-    _kwargs["input"] = x.flatten()
-    result = {self.torch_api}(**_kwargs)
-    if keepdim:
-        result = result.unsqueeze(0)
+        if keepdim:
+            result = result.reshape([1] * x.ndim)
 else:
     result = {self.torch_api}(**_kwargs)
 """


### PR DESCRIPTION
- https://github.com/PaddlePaddle/Paddle/issues/72667
- 适配转换规则

在 Paddle 中，如果 axis 为 None，x 会被压缩成一维向量然后计算**向量范数**。在 pytorch 中 axis为 None，输入可以允许为 1D（**向量范数**） 或 2D（矩阵范数）。我们只需要将 x flatten 1D 之后传入对应的 torch 函数，if keepdim, reshape 会原来的形状
