### PR TITLE
[Accuracy diff No.15] Fix accuracy diff for cumprod API

### DIFF
--- a/tester/paddle_to_torch/rules.py
+++ b/tester/paddle_to_torch/rules.py
@@ -824,12 +824,11 @@ dtype = locals().get('dtype', torch.int64)
 
 class CumprodRule(BaseRule):
     def apply(self, paddle_api: str) -> ConvertResult:
-        pre = f"""
+        pre = """
 dim = locals().get('dim')
-if dim is None:
-    x = x.flatten()
-    axis = 0
 dtype = locals().get('dtype')
+if dtype is None:
+    dtype = x.dtype
 """
         core = "result = torch.cumprod(input=x, dim=dim, dtype=dtype)"
         code = Code(preprocess=pre.splitlines(), core=[core])


### PR DESCRIPTION
- https://github.com/PaddlePaddle/Paddle/pull/72897#

Torch 和 numpy 在 dtype 为 None，处理输入时，如果输入整数精度小于平台的默认整数时，会使用平台默认整数，cast 成 int64，所以直接设定 dtype 为 x.dtype