### PR TITLE
[BIT]回测问题修复：paddle.var

### DIFF
--- a/tester/paddle_to_torch/mapping.json
+++ b/tester/paddle_to_torch/mapping.json
@@ -2616,7 +2616,6 @@
         }
     },
     "paddle.var": {
-        "Rule": "VarRule",
         "torch_api": "torch.var",
         "paddle_torch_args_map": {
             "x": "input",

--- a/tester/paddle_to_torch/rules.py
+++ b/tester/paddle_to_torch/rules.py
@@ -6040,19 +6040,6 @@ else:
 
 
 # v
-class VarRule(BaseRule):
-    def apply(self, paddle_api: str) -> ConvertResult:
-        defaults_code, map_code = self.apply_generic()
-        core = f"""
-if x.dim() == 0:
-    result = torch.zeros([], dtype=x.dtype, device=x.device)
-else:
-    result = {self.torch_api}(**_kwargs)
-"""
-        code = Code(preprocess=defaults_code + map_code, core=core.splitlines())
-        return ConvertResult.success(paddle_api, code)
-
-
 class VanderRule(BaseRule):
     def apply(self, paddle_api: str) -> ConvertResult:
         pre = """


### PR DESCRIPTION
### 修复情况

本次修复的是以下accuracy error配置:
`paddle.var(Tensor([],"float32"), )`
`paddle.var(Tensor([],"float32"), list[], )`

在最新版本的paddle中，对于var中为标量的情况，已符合计算实际情况，输出为`nan`，无须再编写rule，直接映射就可与torch对齐。
故删除rule，对于所有的var配置均能通过，未引入新的错误。
<img width="960" alt="截屏2025-06-05 16 55 29" src="https://github.com/user-attachments/assets/0ff94874-3033-4e8c-b555-a58709bb49bc" />
上述两条配置本身就属于accuracy_8.txt，无需移动。