### PR TITLE
[Accuracy diff No.134] Fix accuracy diff for paddle.prod API

### DIFF
--- a/tester/paddle_to_torch/rules.py
+++ b/tester/paddle_to_torch/rules.py
@@ -4822,6 +4822,8 @@ else:
     result = x
 """
             post = """
+if axis is None and keepdim:
+    result = result.view([1] * x.dim())
 if isinstance(axis, tuple) and not keepdim:
     result = torch.squeeze(result, dim=axis)
 """


### PR DESCRIPTION
For this failed case
```txt
paddle.prod(Tensor([3, 5],"float32"), keepdim=True, )
```
In paddle, when axis is None, and keepdim is True, it will be a tensor with an element and keep input rank
But for the torch.prod api
```
if axis is None:
	result = torch.prod(x, dtype = dtype)
```
it will return a 0 dims Tensor