### PR TITLE
[Accuracy diff No.151、154] Fix accuracy diff for vander fpn

### DIFF
--- a/tester/accuracy.py
+++ b/tester/accuracy.py
@@ -218,8 +218,7 @@ class APITestAccuracy(APITestBase):
             print("[cuda error]", self.api_config.config, "\n", str(err), flush=True)
             write_to_log("paddle_error", self.api_config.config)
             return
-        print(paddle_output)
-        print(torch_output)
+
         if self.api_config.api_name == "paddle.incubate.nn.functional.fused_rms_norm": 
             paddle_output = paddle_output[0]
         if self.api_config.api_name == "paddle.unique": 

--- a/tester/accuracy.py
+++ b/tester/accuracy.py
@@ -218,7 +218,8 @@ class APITestAccuracy(APITestBase):
             print("[cuda error]", self.api_config.config, "\n", str(err), flush=True)
             write_to_log("paddle_error", self.api_config.config)
             return
-        
+        print(paddle_output)
+        print(torch_output)
         if self.api_config.api_name == "paddle.incubate.nn.functional.fused_rms_norm": 
             paddle_output = paddle_output[0]
         if self.api_config.api_name == "paddle.unique": 
@@ -229,6 +230,9 @@ class APITestAccuracy(APITestBase):
         if self.api_config.api_name in {"paddle.mode", "paddle.Tensor.mode"}: 
             paddle_output = paddle_output[0]
             torch_output = torch_output[0]
+        if self.api_config.api_name in ["paddle.strided_slice", "paddle.vander"] and any(s < 0 for s in paddle_output.strides):
+            # torch's from_dlpack now don't support negative strides
+            paddle_output = paddle_output.contiguous()
 
         if isinstance(paddle_output, paddle.Tensor):
             if isinstance(torch_output, torch.Tensor):

--- a/tester/paddle_to_torch/rules.py
+++ b/tester/paddle_to_torch/rules.py
@@ -1457,7 +1457,7 @@ restore_ind = torch.empty(fpn_rois.shape[0], 1)
 rois_num_per_level = []
 for i in range(num_level):
     rois_num_per_level.append(
-        torch.zeros([rois_num.numel()])
+        torch.zeros([rois_num.numel()]).to(torch.int32)
     )
 # 计算结果
 index = 0
@@ -1483,7 +1483,7 @@ for i in range(num_level):
             restore_ind[j] = index
             index += 1
 
-result = (multi_rois, restore_ind, rois_num_per_level)
+result = (multi_rois, restore_ind.to(torch.int32), rois_num_per_level)
 """
         code = Code(core=core.splitlines())
         return ConvertResult.success(paddle_api, code, is_torch_corresponding=False)


### PR DESCRIPTION
- fpn 输出的type类型不一致
- vander from_dlpack 不支持负数的步长