### PR TITLE
[BIT] Remove illeagal max_unpool2d config

### DIFF
--- a/report/0size_tensor_cpu/error_config.txt
+++ b/report/0size_tensor_cpu/error_config.txt
@@ -8053,8 +8053,6 @@ paddle.nn.functional.max_unpool2d(Tensor([2, 4, 11, 0],"float64"), Tensor([2, 4,
 paddle.nn.functional.max_unpool2d(Tensor([2, 4, 11, 0],"float64"), Tensor([2, 4, 11, 11],"int32"), kernel_size=4, stride=None, padding=2, data_format="NCHW", output_size=None, name=None, )
 paddle.nn.functional.max_unpool2d(Tensor([2, 4, 21, 0],"float32"), Tensor([2, 4, 21, 0],"int32"), kernel_size=4, stride=2, padding=2, data_format="NCHW", output_size=None, name=None, )
 paddle.nn.functional.max_unpool2d(Tensor([2, 4, 21, 0],"float32"), Tensor([2, 4, 21, 21],"int32"), kernel_size=4, stride=2, padding=2, data_format="NCHW", output_size=None, name=None, )
-paddle.nn.functional.max_unpool2d(Tensor([2, 4, 21, 0],"float64"), Tensor([2, 4, 21, 0],"int32"), kernel_size=4, stride=2, padding=2, data_format="NCHW", output_size=None, name=None, )
-paddle.nn.functional.max_unpool2d(Tensor([2, 4, 21, 0],"float64"), Tensor([2, 4, 21, 21],"int32"), kernel_size=4, stride=2, padding=2, data_format="NCHW", output_size=None, name=None, )
 paddle.nn.functional.multi_margin_loss(Tensor([5, 0],"float64"), Tensor([5],"int64"), p=1, margin=1.0, weight=Tensor([2],"float64"), reduction="mean", name=None, )
 paddle.nn.functional.multi_margin_loss(Tensor([5, 0],"float64"), Tensor([5],"int64"), p=2, margin=1.0, weight=None, reduction="mean", name=None, )
 paddle.nn.functional.multi_margin_loss(input=Tensor([5, 0],"float64"), label=Tensor([5],"int64"), p=1, margin=1.0, weight=Tensor([2],"float64"), reduction="mean", )

--- a/report/0size_tensor_gpu/error_config.txt
+++ b/report/0size_tensor_gpu/error_config.txt
@@ -11433,8 +11433,6 @@ paddle.nn.functional.max_unpool2d(Tensor([2, 4, 20, 0],"float64"), Tensor([2, 4,
 paddle.nn.functional.max_unpool2d(Tensor([2, 4, 20, 0],"float64"), Tensor([2, 4, 20, 20],"int32"), kernel_size=2, stride=None, padding=0, data_format="NCHW", output_size=None, name=None, )
 paddle.nn.functional.max_unpool2d(Tensor([2, 4, 21, 0],"float32"), Tensor([2, 4, 21, 0],"int32"), kernel_size=4, stride=2, padding=2, data_format="NCHW", output_size=None, name=None, )
 paddle.nn.functional.max_unpool2d(Tensor([2, 4, 21, 0],"float32"), Tensor([2, 4, 21, 21],"int32"), kernel_size=4, stride=2, padding=2, data_format="NCHW", output_size=None, name=None, )
-paddle.nn.functional.max_unpool2d(Tensor([2, 4, 21, 0],"float64"), Tensor([2, 4, 21, 0],"int32"), kernel_size=4, stride=2, padding=2, data_format="NCHW", output_size=None, name=None, )
-paddle.nn.functional.max_unpool2d(Tensor([2, 4, 21, 0],"float64"), Tensor([2, 4, 21, 21],"int32"), kernel_size=4, stride=2, padding=2, data_format="NCHW", output_size=None, name=None, )
 paddle.nn.functional.max_unpool2d(Tensor([3, 0, 5, 5],"float64"), Tensor([3, 0, 5, 5],"int32"), list[4,4,], stride=list[2,2,], padding=list[0,0,], data_format="NCHW", output_size=list[12,12,], name=None, )
 paddle.nn.functional.max_unpool2d(Tensor([3, 0, 5, 5],"float64"), Tensor([3, 0, 5, 5],"int64"), list[4,4,], stride=list[2,2,], padding=list[0,0,], data_format="NCHW", output_size=list[12,12,], name=None, )
 paddle.nn.functional.max_unpool2d(Tensor([3, 0, 5, 5],"float64"), Tensor([3, 2, 5, 5],"int32"), list[4,4,], stride=list[2,2,], padding=list[0,0,], data_format="NCHW", output_size=list[12,12,], name=None, )


### PR DESCRIPTION
两条配置在 torch，paddle 情况下均报错，提示参数不合法，从 tester/api_config/7_0_size/0_size_tensor_1_8_1.txt 中删除。
```python
import paddle
import numpy as np
import paddle.signal as signal
import paddle.incubate.nn.functional as F
from pathlib import Path
import inspect
import torch
import numpy
from typing import Optional, List
import paddle.nn as nn

import numpy 

# test max_unpool 0-szie input, cases:
# paddle.nn.functional.max_unpool2d(Tensor([2, 4, 21, 0],"float64"), Tensor([2, 4, 21, 0],"int32"), kernel_size=4, stride=2, padding=2, data_format="NCHW", output_size=None, name=None, )
# paddle.nn.functional.max_unpool2d(Tensor([2, 4, 21, 0],"float64"), Tensor([2, 4, 21, 21],"int32"), kernel_size=4, stride=2, padding=2, data_format="NCHW", output_size=None, name=None, )

x = numpy.random.randn(2, 4, 21, 0)
idx = numpy.zeros((2, 4, 21, 21)).astype(numpy.int64)
kernel_size = 4
stride = 2
padding = 2
data_format = 'NCHW'
output_size = None
name = None 

px = paddle.to_tensor(x)
pidx = paddle.to_tensor(idx)

tx = torch.tensor(x)
tidx = torch.tensor(idx)


# torch error (case 1):
# Traceback (most recent call last):
#   File "/root/PaddleAPITest/example.py", line 35, in <module>
#     tout = torch.nn.functional.max_unpool2d(tx, tidx, kernel_size=kernel_size, stride=stride, padding=padding, output_size=output_size)
#   File "/usr/local/lib/python3.9/dist-packages/torch/nn/functional.py", line 1040, in max_unpool2d
#     return torch._C._nn.max_unpool2d(input, indices, output_size)
# RuntimeError: max_unpooling2d_forward_out_cpu(): Expected input to have non-zero size for non-batch dimensions, but got [2, 4, 21, 0] with dimension 3 being empty.

# case 2
# Traceback (most recent call last):
#   File "/root/PaddleAPITest/example.py", line 42, in <module>
#     tout = torch.nn.functional.max_unpool2d(tx, tidx, kernel_size=kernel_size, stride=stride, padding=padding, output_size=output_size)
#   File "/usr/local/lib/python3.9/dist-packages/torch/nn/functional.py", line 1040, in max_unpool2d
#     return torch._C._nn.max_unpool2d(input, indices, output_size)
# RuntimeError: Expected shape of indices to be same as that of the input tensor ([2, 4, 21, 0]) but got indices tensor with shape: [2, 4, 21, 21]
tout = torch.nn.functional.max_unpool2d(tx, tidx, kernel_size=kernel_size, stride=stride, padding=padding, output_size=output_size)

# case 1, paddle error:
# Traceback (most recent call last):
#   File "/root/PaddleAPITest/example.py", line 45, in <module>
#     pout = paddle.nn.functional.max_unpool2d(px, pidx, kernel_size=kernel_size, stride=stride, padding=padding, data_format=data_format, output_size=None, name=None)
#   File "/usr/local/lib/python3.9/dist-packages/paddle/nn/functional/pooling.py", line 980, in max_unpool2d
#     output = _C_ops.unpool(
# RuntimeError: (PreconditionNotMet) The meta data must be valid when call the mutable data function.
#   [Hint: Expected valid() == true, but received valid():0 != true:1.] (at ../paddle/phi/core/dense_tensor.cc:113)

# case 2, paddle error (same as torch case 2):
# Traceback (most recent call last):
#   File "/root/PaddleAPITest/example.py", line 62, in <module>
#     pout = paddle.nn.functional.max_unpool2d(px, pidx, kernel_size=kernel_size, stride=stride, padding=padding, data_format=data_format, output_size=None, name=None)
#   File "/usr/local/lib/python3.9/dist-packages/paddle/nn/functional/pooling.py", line 980, in max_unpool2d
#     output = _C_ops.unpool(
# ValueError: (InvalidArgument) The dimensions of Input(X) must equal to bethe dimensions of Input(Indices), but receiveddimensions of Input(X) is [2, 4, 21, 0], received dimensionsof Input(Indices) is [2, 4, 21, 21]
#   [Hint: Expected in_x_dims == in_y_dims, but received in_x_dims:2, 4, 21, 0 != in_y_dims:2, 4, 21, 21.] (at ../paddle/phi/infermeta/binary.cc:4457)
pout = paddle.nn.functional.max_unpool2d(px, pidx, kernel_size=kernel_size, stride=stride, padding=padding, data_format=data_format, output_size=None, name=None)

print(f"> case 1: \n paddle out: {pout}\n torch out: {tout}")
```