### PR TITLE
[Accuracy diff No.65, 66] Fix accuracy diff for paddle.Tensor.meidan API

### DIFF
--- a/tester/base.py
+++ b/tester/base.py
@@ -482,8 +482,6 @@ class APITestBase:
                 self.paddle_args[3] = "gels"
             elif "driver" in self.paddle_kwargs:
                 self.paddle_kwargs["driver"] = "gels"
-        if self.api_config.api_name == "paddle.Tensor.median":
-            self.paddle_kwargs["mode"] = "min"
 
         if self.need_check_grad():
             if (self.api_config.api_name[-1] == "_" and self.api_config.api_name[-2:] != "__") or self.api_config.api_name == "paddle.Tensor.__setitem__":

--- a/tester/base.py
+++ b/tester/base.py
@@ -482,6 +482,8 @@ class APITestBase:
                 self.paddle_args[3] = "gels"
             elif "driver" in self.paddle_kwargs:
                 self.paddle_kwargs["driver"] = "gels"
+        if self.api_config.api_name == "paddle.Tensor.median":
+            self.paddle_kwargs["mode"] = "min"
 
         if self.need_check_grad():
             if (self.api_config.api_name[-1] == "_" and self.api_config.api_name[-2:] != "__") or self.api_config.api_name == "paddle.Tensor.__setitem__":

--- a/tester/paddle_to_torch/mapping.json
+++ b/tester/paddle_to_torch/mapping.json
@@ -3100,9 +3100,7 @@
     },
     "paddle.Tensor.median": {
         "torch_api": "torch.Tensor.median",
-        "paddle_torch_args_map": {
-            "keepdim": "keepdim"
-        }
+        "Rule": "MedianRule"
     },
     "paddle.Tensor.mm": {
         "torch_api": "torch.Tensor.mm",


### PR DESCRIPTION
原结果梯度误差的原因是 paddle.Tensor.median 默认 mode 参数为 ‘avg’，元素个数为偶数时取中间两元素的均值，torch.Tensor.median 的行为是取中间两元素的较小值，所以需要将 mode 参数设置为 ‘min’。

回测结果：
GPU:
![image](https://github.com/user-attachments/assets/c319c240-3811-4957-931f-bbe339a703f8)
![image](https://github.com/user-attachments/assets/0b81d247-0890-455c-a03c-9c36d5b8937c)

CPU:
![image](https://github.com/user-attachments/assets/fb75aa6a-3bd3-4a95-8847-372921f8356d)
![image](https://github.com/user-attachments/assets/91af571c-1ba0-4570-a080-c4ffd4f2331a)
