### PR TITLE
[Accuracy diff No.126] Fix accuracy diff for paddle.nn.functional.rnnt_loss API

### DIFF
--- a/tester/accuracy.py
+++ b/tester/accuracy.py
@@ -69,6 +69,10 @@ class APITestAccuracy(APITestBase):
                 "result": None,
                 **self.torch_kwargs,
             }
+            if self.api_config.api_name == "paddle.nn.functional.rnnt_loss":
+                if paddle.device.get_device() == "cpu":
+                    exec_locals["fused_log_softmax"] = False
+
 
             # convert_result.is_torch_corresponding 为 True 时代表有对应的 Torch API
             # 执行 *_compiled 编译好的代码速度更快

--- a/tester/paddle_to_torch/rules.py
+++ b/tester/paddle_to_torch/rules.py
@@ -4828,7 +4828,8 @@ result = torchaudio.functional.rnnt_loss(
         logit_lengths=input_lengths,
         target_lengths=label_lengths,
         blank=blank,
-        reduction=reduction
+        reduction=reduction,
+        fused_log_softmax=False,
     )
 """
         code = Code(core=core.splitlines())

--- a/tester/paddle_to_torch/rules.py
+++ b/tester/paddle_to_torch/rules.py
@@ -4821,6 +4821,7 @@ import torchaudio
 blank = locals().get('blank', 0)
 fastemit_lambda = locals().get('fastemit_lambda', 0.001)
 reduction = locals().get('reduction', 'mean')
+fused_log_softmax = locals().get('fused_log_softmax', True)
 
 result = torchaudio.functional.rnnt_loss(
         logits=input,
@@ -4829,7 +4830,7 @@ result = torchaudio.functional.rnnt_loss(
         target_lengths=label_lengths,
         blank=blank,
         reduction=reduction,
-        fused_log_softmax=False,
+        fused_log_softmax=fused_log_softmax,
     )
 """
         code = Code(core=core.splitlines())


### PR DESCRIPTION
paddle cpu 时不会进行 fused_log_softmax 操作，需要手动对 logits 进行 log_softmax
