### PR TITLE
[Accuracy diff No. 110, 111] Fix accuracy diff for paddle.nn.functional.binary_cross_entropy, paddle.nn.functional.binary_cross_entropy_with_logits API

### DIFF
--- a/tester/accuracy.py
+++ b/tester/accuracy.py
@@ -377,6 +377,12 @@ class APITestAccuracy(APITestBase):
             if self.api_config.api_name == "paddle.nn.utils.parameters_to_vector":
                 paddle_out_grads = []
                 torch_out_grads = []
+            if self.api_config.api_name == "paddle.nn.functional.binary_cross_entropy":
+                paddle_out_grads = paddle_out_grads[0]
+                torch_out_grads = torch_out_grads[0]
+            if self.api_config.api_name == "paddle.nn.functional.binary_cross_entropy_with_logits":
+                paddle_out_grads = paddle_out_grads[0]
+                torch_out_grads = torch_out_grads[0]
                 
             if isinstance(paddle_out_grads, paddle.Tensor):
                 if isinstance(torch_out_grads, torch.Tensor):


### PR DESCRIPTION
目前 paddle.nn.functional.binary_cross_entropy, paddle.nn.functional.binary_cross_entropy_with_logits 对应的反向算子只计算 x_grad 不计算 label_grad，而 torch 计算 x_grad 和 target_grad (label_grad)：
![image](https://github.com/user-attachments/assets/1757bf42-76ca-4b28-89e7-b6c1a3cecac0)
![image](https://github.com/user-attachments/assets/6a6e7d3e-fada-46d5-b1d1-f18bcd913db2)

第一次回测结果：
![image](https://github.com/user-attachments/assets/50f34c08-3d4b-40e6-bf9a-e951b9187c57)

paddle.nn.functional.binary_cross_entropy_with_logits 能全部通过
paddle.nn.functional.binary_cross_entropy 有两个 case 未通过：
```bash
paddle.nn.functional.binary_cross_entropy(Tensor([195840, 80],"float16"), Tensor([195840, 80],"float16"), reduction="none", )
paddle.nn.functional.binary_cross_entropy(Tensor([87040, 80],"float16"), Tensor([87040, 80],"float16"), reduction="none", )
```

对这两个 case 二次回测结果：
![image](https://github.com/user-attachments/assets/371061b9-ad71-4287-8708-363d8a75195b)
