### PR TITLE
[Accuracy diff No.124] Fix accuracy diff for paddle.nn.functional.log_softmax API

### DIFF
--- a/tester/paddle_to_torch/mapping.json
+++ b/tester/paddle_to_torch/mapping.json
@@ -1787,7 +1787,7 @@
         "torch_api": "torch.nn.functional.log_softmax",
         "paddle_torch_args_map": {
             "x": "input",
-            "dim": "dim",
+            "axis": "dim",
             "dtype": "dtype"
         }
     },


### PR DESCRIPTION
fix typos, `dim` -> `axis`
![图片](https://github.com/user-attachments/assets/7ff60703-68c9-4aaf-ac4c-f80ad58aa5e5)


测试通过
![图片](https://github.com/user-attachments/assets/9471ab8c-79a6-4196-a615-722e79026e49)
