### PR TITLE
[Accuracy diff No.25] Fix accuracy diff for paddle.linalg.eigh API

### DIFF
--- a/tester/accuracy.py
+++ b/tester/accuracy.py
@@ -246,17 +246,13 @@ class APITestAccuracy(APITestBase):
             torch_eigvectors = torch_output.pop(1).transpose(-1, -2).reshape((-1, eigvector_len))
             for i in range(paddle_eigvectors.shape[0]):
                 coef_vector = paddle.to_tensor(paddle_eigvectors[i].numpy()/torch_eigvectors[i].numpy(), dtype=paddle_eigvectors[i].dtype)
+                coef_vector = coef_vector.round(2)
                 coef_0 = paddle_eigvectors[i].numpy()[0]/torch_eigvectors[i].numpy()[0]
                 coef_vector_approx = torch.tensor([coef_0] * eigvector_len)
                 abs_coef = coef_vector.abs().astype("float64")[0]
                 one = torch.tensor(1.0, dtype=torch.float64)
-                try:
-                    self.torch_assert_accuracy(coef_vector, coef_vector_approx, 0.1, 0.1)
-                    self.torch_assert_accuracy(abs_coef, one, 1e-2, 1e-2)
-                except Exception as err:
-                    print("[accuracy error]", self.api_config.config, "\n", str(err), flush=True)
-                    write_to_log("accuracy_error", self.api_config.config)
-                    return
+                paddle_output.append([coef_vector, abs_coef])
+                torch_output.append([coef_vector_approx, one])
 
 
         if isinstance(paddle_output, paddle.Tensor):

--- a/tester/accuracy.py
+++ b/tester/accuracy.py
@@ -219,6 +219,8 @@ class APITestAccuracy(APITestBase):
             write_to_log("paddle_error", self.api_config.config)
             return
 
+        paddle_output_cache = []
+        torch_output_cache = []
         if self.api_config.api_name == "paddle.incubate.nn.functional.fused_rms_norm": 
             paddle_output = paddle_output[0]
         if self.api_config.api_name == "paddle.unique": 
@@ -232,6 +234,28 @@ class APITestAccuracy(APITestBase):
         if self.api_config.api_name in {"paddle.strided_slice", "paddle.vander"} and any(s < 0 for s in paddle_output.strides):
             # torch's from_dlpack now don't support negative strides
             paddle_output = paddle_output.contiguous()
+        if self.api_config.api_name == "paddle.linalg.eigh":
+            # The output of eigen vectors are not unique, because multiplying an eigen vector by -1 in the real case 
+            # or by e^(i*\theta) in the complex case produces another set of valid eigen vectors of the matrix.
+            # So we test whether the elements of each coef_vector (i.e. paddle_output / torch_output for each eigen vector) 
+            # are all the same and whether the |coef| == 1 for simplicity.
+            paddle_output, torch_output = list(paddle_output), list(torch_output)
+            paddle_output_cache = [i.clone() for i in paddle_output]
+            torch_output_cache = [i.clone() for i in torch_output]
+            eigvector_len = paddle_output[1].shape[-2]
+            paddle_eigvectors = paddle_output.pop(1).matrix_transpose().reshape([-1, eigvector_len])
+            torch_eigvectors = torch_output.pop(1).transpose(-1, -2).reshape((-1, eigvector_len))
+            for i in range(paddle_eigvectors.shape[0]):
+                coef_vector = paddle.to_tensor(paddle_eigvectors[i].numpy()/torch_eigvectors[i].numpy(), dtype=paddle_eigvectors[i].dtype)
+                abs_coef_vector = coef_vector.abs().astype("float64")
+                coef_0 = paddle_eigvectors[i].numpy()[0]/torch_eigvectors[i].numpy()[0]
+                coef_vector_approx = torch.tensor([coef_0] * eigvector_len)
+                unitary_vector = torch.tensor([1.0] * eigvector_len, dtype=torch.float64)
+                paddle_output.append(coef_vector)
+                paddle_output.append(abs_coef_vector)
+                torch_output.append(coef_vector_approx)
+                torch_output.append(unitary_vector)
+
 
         if isinstance(paddle_output, paddle.Tensor):
             if isinstance(torch_output, torch.Tensor):
@@ -331,6 +355,10 @@ class APITestAccuracy(APITestBase):
                             print("[accuracy error]", self.api_config.config, "\n", str(err), flush=True)
                             write_to_log("accuracy_error", self.api_config.config)
                             return
+
+        if self.api_config.api_name == "paddle.linalg.eigh":
+            paddle_output = paddle_output_cache
+            torch_output = torch_output_cache
 
         if self.need_check_grad() and torch_grad_success:
             try:

--- a/tester/accuracy.py
+++ b/tester/accuracy.py
@@ -233,14 +233,12 @@ class APITestAccuracy(APITestBase):
             # torch's from_dlpack now don't support negative strides
             paddle_output = paddle_output.contiguous()
 
-        paddle_output_cache = []
         if self.api_config.api_name == "paddle.linalg.eigh":
             # The output of eigen vectors are not unique, because multiplying an eigen vector by -1 in the real case 
             # or by e^(i*\theta) in the complex case produces another set of valid eigen vectors of the matrix.
             # So we test whether the elements of each coef_vector (i.e. paddle_output / torch_output for each eigen vector) 
             # are all the same and whether the |coef| == 1 for simplicity.
             paddle_output, torch_output = list(paddle_output), list(torch_output)
-            paddle_output_cache = [i.clone() for i in paddle_output]
             eigvector_len = paddle_output[1].shape[-2]
             paddle_eigvectors = paddle_output.pop(1).matrix_transpose().reshape([-1, eigvector_len])
             torch_eigvectors = torch_output.pop(1).transpose(-1, -2).reshape((-1, eigvector_len))
@@ -353,9 +351,6 @@ class APITestAccuracy(APITestBase):
                             print("[accuracy error]", self.api_config.config, "\n", str(err), flush=True)
                             write_to_log("accuracy_error", self.api_config.config)
                             return
-
-        if self.api_config.api_name == "paddle.linalg.eigh":
-            paddle_output = paddle_output_cache
 
         if self.need_check_grad() and torch_grad_success:
             try:

--- a/tester/accuracy.py
+++ b/tester/accuracy.py
@@ -219,8 +219,6 @@ class APITestAccuracy(APITestBase):
             write_to_log("paddle_error", self.api_config.config)
             return
 
-        paddle_output_cache = []
-        torch_output_cache = []
         if self.api_config.api_name == "paddle.incubate.nn.functional.fused_rms_norm": 
             paddle_output = paddle_output[0]
         if self.api_config.api_name == "paddle.unique": 

--- a/tester/base.py
+++ b/tester/base.py
@@ -1105,6 +1105,7 @@ class APITestBase:
             "distributed_push_sparse",
             "dpsgd",
             "edit_distance",
+            "eigh",
             "eigvals",
             "embedding_grad_dense",
             "embedding_with_eltwise_add_xpu",


### PR DESCRIPTION
问题的原因是实对称矩阵或hermitian matrix的特征向量是不唯一的，可能因为底层实现的不同导致了 paddle 和 torch 的输出不同，所以应该对 paddle.linalg.eigh 的特征向量输出做单独的精度判断：一个简单的判断办法是将 paddle 和 torch 对应输出的特征向量相除，得到的应该是  e^{i \theta} *  vec[1, 1, ..., 1]^T  ，所以判断相除所得向量的所有元素(大致)相等，以及相除所得向量每个元素的模长为1即可。

另外由于 eigh_grad 的计算依赖于前向计算得到的特征向量，因此反向计算的结果也会有差异，所以建议不测 eigh 的反向算子
![image](https://github.com/user-attachments/assets/5a0912f1-11ac-44d2-852a-684055919507)

回测结果：
GPU:
![image](https://github.com/user-attachments/assets/91a32284-bcda-4ed1-afbe-84b597aa6806)
CPU:
![image](https://github.com/user-attachments/assets/d20a5af3-36dc-48ac-9f34-0f0ec53091d4)
