### PR TITLE
[Accuracy diff No.116] Fix accuracy diff for paddle.nn.functional.ctc_loss API

### DIFF
--- a/tester/paddle_to_torch/rules.py
+++ b/tester/paddle_to_torch/rules.py
@@ -809,7 +809,7 @@ for paddle_param, torch_param in {
 }.items():
     if paddle_param in locals() and not locals()[paddle_param] is None:
         _kwargs[torch_param] = locals()[paddle_param]
-_kwargs['log_probs'] = torch.nn.functional.log_softmax(_kwargs['log_probs'])
+_kwargs['log_probs'] = torch.nn.functional.log_softmax(_kwargs['log_probs'], dim=-1)
 _kwargs['zero_infinity'] = True
 """
         core = """


### PR DESCRIPTION
显式传递 dim=-1，torch 的 log_softmax 具有默认参数 None，已经被标记废弃，并且和 paddle 默认的 -1 不一致
测试通过
![图片](https://github.com/user-attachments/assets/6644105c-814e-4262-b876-3fa5aa7d585f)
