### PR TITLE
[Accuracy diff No.125] Fix accuracy diff forpaddle.nn.functional.multi_margin_loss API

### DIFF
--- a/report/ci_ce_cpu/error_log.log
+++ b/report/ci_ce_cpu/error_log.log
@@ -50141,3 +50141,4 @@ Max absolute difference among violations: 3401
 Max relative difference among violations: 0.0698472
 ACTUAL: array([-31574,  34307, -47665, ...,  -9159,  31897,    895], dtype=int32)
 DESIRED: array([-31574,  34307, -47665, ...,  -9159,  31897,    895], dtype=int32)
+


### PR DESCRIPTION
paddle.nn.functional.multi_margin_loss 移除配置，配置只有一项

PaddleAPITest测试通过
![image](https://github.com/user-attachments/assets/a100bce4-4c5a-41da-809d-1a4fd4720c3c)

