### PR TITLE
[BIT] Fix fused_rotary_position_embedding to support bfloat16

### DIFF
--- a/tester/api_config/config_analyzer.py
+++ b/tester/api_config/config_analyzer.py
@@ -635,7 +635,7 @@ class TensorConfig:
                             k_shape[-2] = 2 
                     else:
                         k_shape = [2, 8, 2, 8] 
-                    new_k = TensorConfig(k_shape, "float32")
+                    new_k = TensorConfig(k_shape, original_dtype)
                     if len(api_config.args) > 1:
                         api_config.args[1] = new_k
                     elif "k" in api_config.kwargs:
@@ -652,7 +652,7 @@ class TensorConfig:
                             v_shape[-2] = 2 
                     else:
                         v_shape = [2, 8, 2, 8]  
-                    new_v = TensorConfig(v_shape, "float32")
+                    new_v = TensorConfig(v_shape, original_dtype)
                     if len(api_config.args) > 2:
                         api_config.args[2] = new_v
                     elif "v" in api_config.kwargs:


### PR DESCRIPTION
原来的`paddle.incubate.nn.functional.fused_rotary_position_embedding`在config_analyzer.py文件中参数不支持bfloat16类型，需要对该情况做转化。
修复后未引入新的问题，原配置和bfloat16配置均能通过paddle_only测试，
<img width="921" alt="截屏2025-06-18 15 55 57" src="https://github.com/user-attachments/assets/4fe91bda-55a4-47ff-b312-992034104177" />
accuracy测试也可以进行，但依旧存在精度问题。