### PR TITLE
[BIT] Support atol rtol param

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -61,13 +61,24 @@ def main():
         default=False,
         help="Whether to test CPU mode",
     )
-
+    parser.add_argument(
+        "--atol",
+        type=float,
+        default=1e-2,
+        help="Absolute tolerance for accuracy tests",
+    )
+    parser.add_argument(
+        "--rtol",
+        type=float,
+        default=1e-2,
+        help="Relative tolerance for accuracy tests",
+    )
     options = parser.parse_args()
     set_cfg(options)  # Set the command line arguments in the config module
 
     if options.test_cpu:
-       paddle.device.set_device("cpu")
-   
+        paddle.device.set_device("cpu")
+
     test_class = APITestAccuracy
     if options.paddle_only:
         test_class = APITestPaddleOnly
@@ -85,7 +96,15 @@ def main():
             print("[config parse error]", options.api_config, str(err))
             return
 
-        case = test_class(api_config, options.test_amp)
+        if options.accuracy:
+            case = test_class(
+                api_config,
+                test_amp=options.test_amp,
+                atol=options.atol,
+                rtol=options.rtol,
+            )
+        else:
+            case = test_class(api_config, test_amp=options.test_amp)
         case.test()
         case.clear_tensor()
         del case
@@ -108,7 +127,15 @@ def main():
                 print("[config parse error]", api_config_str, str(err))
                 continue
 
-            case = test_class(api_config, options.test_amp)
+            if options.accuracy:
+                case = test_class(
+                    api_config,
+                    test_amp=options.test_amp,
+                    atol=options.atol,
+                    rtol=options.rtol,
+                )
+            else:
+                case = test_class(api_config, test_amp=options.test_amp)
             try:
                 case.test()
             except Exception as err:

--- a/engineV2-README.md
+++ b/engineV2-README.md
@@ -66,6 +66,8 @@
 | `--test_cpu`                | bool  | 启用 Paddle CPU 模式测试（默认 False）                                                 |
 | `--use_cached_numpy`        | bool  | 启用 Numpy 缓存（默认 False）                                                          |
 | `--log_dir`                 | str   | 日志输出路径（默认 "tester/api_config/test_log"）                                      |
+| `--atol`                    | float | 精度测试的绝对误差容忍度（默认 1e-2）                                                  |
+| `--rtol`                    | float | 精度测试的相对误差容忍度（默认 1e-2）                                                  |
 
 ### 示例命令
 

--- a/engineV2.py
+++ b/engineV2.py
@@ -279,7 +279,15 @@ def run_test_case(api_config_str, options):
     elif options.accuracy:
         test_class = APITestAccuracy
 
-    case = test_class(api_config, options.test_amp)
+    if options.accuracy:
+        case = test_class(
+            api_config,
+            test_amp=options.test_amp,
+            atol=options.atol,
+            rtol=options.rtol,
+        )
+    else:
+        case = test_class(api_config, test_amp=options.test_amp)
     try:
         case.test()
     except Exception as err:
@@ -370,6 +378,18 @@ def main():
         default="",
         help="Log directory",
     )
+    parser.add_argument(
+        "--atol",
+        type=float,
+        default=1e-2,
+        help="Absolute tolerance for accuracy tests",
+    )
+    parser.add_argument(
+        "--rtol",
+        type=float,
+        default=1e-2,
+        help="Relative tolerance for accuracy tests",
+    )
     options = parser.parse_args()
     print(f"Options: {vars(options)}", flush=True)
 
@@ -398,7 +418,15 @@ def main():
         elif options.accuracy:
             test_class = APITestAccuracy
 
-        case = test_class(api_config, options.test_amp)
+        if options.accuracy:
+            case = test_class(
+                api_config,
+                test_amp=options.test_amp,
+                atol=options.atol,
+                rtol=options.rtol,
+            )
+        else:
+            case = test_class(api_config, test_amp=options.test_amp)
         try:
             case.test()
         except Exception as err:

--- a/engineV2.py
+++ b/engineV2.py
@@ -535,8 +535,6 @@ def main():
             ],
         )
 
-        from tester import APIConfig
-
         def cleanup_handler(*args):
             cleanup(pool)
             sys.exit(1)

--- a/engineV3.py
+++ b/engineV3.py
@@ -104,7 +104,7 @@ def worker_process(gpu_id, task_queue, result_queue, idx, args_mode):
                     import torch
 
                     api_config = APIConfig(api_config_str.strip())
-                    case = test_class(api_config, False)
+                    case = test_class(api_config)
                     case.test()
                     case.clear_tensor()
 

--- a/run-example.sh
+++ b/run-example.sh
@@ -20,8 +20,8 @@ TEST_MODE_ARGS=(
 	# --test_amp=True
 	# --test_cpu=True
 	# --use_cached_numpy=True
-    --atol=1e-2
-    --rtol=1e-2
+    # --atol=1e-2
+    # --rtol=1e-2
 )
 
 IN_OUT_ARGS=(

--- a/run-example.sh
+++ b/run-example.sh
@@ -20,8 +20,8 @@ TEST_MODE_ARGS=(
 	# --test_amp=True
 	# --test_cpu=True
 	# --use_cached_numpy=True
-    # --atol=1e-2
-    # --rtol=1e-2
+	# --atol=1e-2
+	# --rtol=1e-2
 )
 
 IN_OUT_ARGS=(

--- a/run-example.sh
+++ b/run-example.sh
@@ -20,6 +20,8 @@ TEST_MODE_ARGS=(
 	# --test_amp=True
 	# --test_cpu=True
 	# --use_cached_numpy=True
+    --atol=1e-2
+    --rtol=1e-2
 )
 
 IN_OUT_ARGS=(

--- a/tester/accuracy.py
+++ b/tester/accuracy.py
@@ -75,7 +75,6 @@ class APITestAccuracy(APITestBase):
                 if paddle.device.get_device() == "cpu":
                     exec_locals["fused_log_softmax"] = False
 
-
             # convert_result.is_torch_corresponding 为 True 时代表有对应的 Torch API
             # 执行 *_compiled 编译好的代码速度更快
             code = convert_result.code
@@ -246,9 +245,9 @@ class APITestAccuracy(APITestBase):
             paddle_output = paddle_output.contiguous()
 
         if self.api_config.api_name == "paddle.linalg.eigh":
-            # The output of eigen vectors are not unique, because multiplying an eigen vector by -1 in the real case 
+            # The output of eigen vectors are not unique, because multiplying an eigen vector by -1 in the real case
             # or by e^(i*\theta) in the complex case produces another set of valid eigen vectors of the matrix.
-            # So we test whether the elements of each coef_vector (i.e. paddle_output / torch_output for each eigen vector) 
+            # So we test whether the elements of each coef_vector (i.e. paddle_output / torch_output for each eigen vector)
             # are all the same and whether the |coef| == 1 for simplicity.
             paddle_output, torch_output = list(paddle_output), list(torch_output)
             eigvector_len = paddle_output[1].shape[-2]
@@ -264,14 +263,13 @@ class APITestAccuracy(APITestBase):
                 paddle_output.append([coef_vector, abs_coef])
                 torch_output.append([coef_vector_approx, one])
 
-
         if isinstance(paddle_output, paddle.Tensor):
             if isinstance(torch_output, torch.Tensor):
                 try:
                     if paddle_output.dtype == paddle.bfloat16:
                         paddle_output = paddle.cast(paddle_output, dtype="float32")
                         torch_output = torch_output.to(dtype=torch.float32)
-                    # self.np_assert_accuracy(paddle_output.numpy(), torch_output.numpy(), 1e-2, 1e-2, self.api_config)
+                    # self.np_assert_accuracy(paddle_output.numpy(), torch_output.numpy(), atol=self.atol, rtol=self.rtol)
                     self.torch_assert_accuracy(paddle_output, torch_output, atol=self.atol, rtol=self.rtol)
                 except Exception as err:
                     print("[accuracy error]", self.api_config.config, "\n", str(err), flush=True)
@@ -292,7 +290,7 @@ class APITestAccuracy(APITestBase):
                     if paddle_output.dtype == paddle.bfloat16:
                         paddle_output = paddle.cast(paddle_output, dtype="float32")
                         torch_output = torch_output.to(dtype=torch.float32)
-                    # self.np_assert_accuracy(paddle_output.numpy(), torch_output.numpy(), 1e-2, 1e-2, self.api_config)
+                    # self.np_assert_accuracy(paddle_output.numpy(), torch_output.numpy(), atol=self.atol, rtol=self.rtol)
                     self.torch_assert_accuracy(paddle_output, torch_output, atol=self.atol, rtol=self.rtol)
                 except Exception as err:
                     print("[accuracy error]", self.api_config.config, "\n", str(err), flush=True)
@@ -333,7 +331,7 @@ class APITestAccuracy(APITestBase):
                             if item_paddle.dtype == paddle.bfloat16:
                                 item_paddle = paddle.cast(item_paddle, dtype="float32")
                                 item_torch = item_torch.to(dtype=torch.float32)
-                            # self.np_assert_accuracy(item_paddle.numpy(), item_torch.cpu().detach().numpy(), 1e-2, 1e-2, self.api_config)
+                            # self.np_assert_accuracy(item_paddle.numpy(), item_torch.cpu().detach().numpy(), atol=self.atol, rtol=self.rtol)
                             self.torch_assert_accuracy(item_paddle, item_torch, atol=self.atol, rtol=self.rtol)
                     except Exception as err:
                         print("[accuracy error]", self.api_config.config, "\n", str(err), flush=True)
@@ -341,9 +339,9 @@ class APITestAccuracy(APITestBase):
                         return                    
                 else:
                     if isinstance(paddle_output[i], int):
-                        self.np_assert_accuracy(numpy.array(paddle_output[i]), numpy.array(torch_output[i]), 1e-2, 1e-2, self.api_config)
+                        self.np_assert_accuracy(numpy.array(paddle_output[i]), numpy.array(torch_output[i]), atol=self.atol, rtol=self.rtol)
                     elif 'tolist' in self.api_config.api_name:
-                        self.np_assert_accuracy(numpy.array(paddle_output[i]), numpy.array(torch_output[i]), 1e-2, 1e-2, self.api_config)
+                        self.np_assert_accuracy(numpy.array(paddle_output[i]), numpy.array(torch_output[i]), atol=self.atol, rtol=self.rtol)
                     elif not isinstance(paddle_output[i], paddle.Tensor):
                         print("[not compare] ", paddle_output[i], torch_output[i], flush=True)
                         write_to_log("accuracy_error", self.api_config.config)
@@ -357,7 +355,7 @@ class APITestAccuracy(APITestBase):
                             if paddle_output[i].dtype == paddle.bfloat16:
                                 paddle_output[i] = paddle.cast(paddle_output[i], dtype="float32")
                                 torch_output[i] = torch_output[i].to(dtype=torch.float32)
-                            # self.np_assert_accuracy(paddle_output[i].numpy(), torch_output[i].numpy(), 1e-2, 1e-2, self.api_config)
+                            # self.np_assert_accuracy(paddle_output[i].numpy(), torch_output[i].numpy(), atol=self.atol, rtol=self.rtol)
                             self.torch_assert_accuracy(paddle_output[i], torch_output[i], atol=self.atol, rtol=self.rtol)
                         except Exception as err:
                             print("[accuracy error]", self.api_config.config, "\n", str(err), flush=True)
@@ -425,7 +423,7 @@ class APITestAccuracy(APITestBase):
                         if paddle_out_grads.dtype == paddle.bfloat16:
                             paddle_out_grads = paddle.cast(paddle_out_grads, dtype="float32")
                             torch_out_grads = torch_out_grads.to(dtype=torch.float32)
-                        # self.np_assert_accuracy(paddle_out_grads.numpy(), torch_out_grads.numpy(), 1e-2, 1e-2, self.api_config)
+                        # self.np_assert_accuracy(paddle_out_grads.numpy(), torch_out_grads.numpy(), atol=self.atol, rtol=self.rtol)
                         self.torch_assert_accuracy(paddle_out_grads, torch_out_grads, atol=self.atol, rtol=self.rtol)
                     except Exception as err:
                         print("[accuracy error] backward ", self.api_config.config, "\n", str(err), flush=True)
@@ -449,7 +447,7 @@ class APITestAccuracy(APITestBase):
                     return
                 for i in range(len(paddle_out_grads)):
                     if isinstance(paddle_out_grads[i], int):
-                        self.np_assert_accuracy(numpy.array(paddle_out_grads[i]), numpy.array(torch_out_grads[i]), 1e-2, 1e-2, self.api_config)
+                        self.np_assert_accuracy(numpy.array(paddle_out_grads[i]), numpy.array(torch_out_grads[i]), atol=self.atol, rtol=self.rtol)
                     elif not isinstance(paddle_out_grads[i], paddle.Tensor):
                         print("[not compare] ", paddle_out_grads[i], torch_out_grads[i], flush=True)
                         write_to_log("accuracy_error", self.api_config.config)
@@ -463,7 +461,7 @@ class APITestAccuracy(APITestBase):
                             if paddle_out_grads[i].dtype == paddle.bfloat16:
                                 paddle_out_grads[i] = paddle.cast(paddle_out_grads[i], dtype="float32")
                                 torch_out_grads[i] = torch_out_grads[i].to(dtype=torch.float32)
-                            # self.np_assert_accuracy(paddle_out_grads[i].numpy(), torch_out_grads[i].numpy(), 1e-2, 1e-2, self.api_config)
+                            # self.np_assert_accuracy(paddle_out_grads[i].numpy(), torch_out_grads[i].numpy(), atol=self.atol, rtol=self.rtol)
                             self.torch_assert_accuracy(paddle_out_grads[i], torch_out_grads[i], atol=self.atol, rtol=self.rtol)
                         except Exception as err:
                             print("[accuracy error] backward ", self.api_config.config, "\n", str(err), flush=True)

--- a/tester/accuracy.py
+++ b/tester/accuracy.py
@@ -12,9 +12,11 @@ from .paddle_to_torch import get_converter
 
 
 class APITestAccuracy(APITestBase):
-    def __init__(self, api_config, test_amp):
+    def __init__(self, api_config, **kwargs):
         super().__init__(api_config)
-        self.test_amp = test_amp
+        self.test_amp = kwargs.get("test_amp", False)
+        self.atol = kwargs.get("atol", 1e-2)
+        self.rtol = kwargs.get("rtol", 1e-2)
         self.converter = get_converter()
 
     # @func_set_timeout(600)
@@ -270,7 +272,7 @@ class APITestAccuracy(APITestBase):
                         paddle_output = paddle.cast(paddle_output, dtype="float32")
                         torch_output = torch_output.to(dtype=torch.float32)
                     # self.np_assert_accuracy(paddle_output.numpy(), torch_output.numpy(), 1e-2, 1e-2, self.api_config)
-                    self.torch_assert_accuracy(paddle_output, torch_output, 1e-2, 1e-2)
+                    self.torch_assert_accuracy(paddle_output, torch_output, atol=self.atol, rtol=self.rtol)
                 except Exception as err:
                     print("[accuracy error]", self.api_config.config, "\n", str(err), flush=True)
                     write_to_log("accuracy_error", self.api_config.config)
@@ -291,7 +293,7 @@ class APITestAccuracy(APITestBase):
                         paddle_output = paddle.cast(paddle_output, dtype="float32")
                         torch_output = torch_output.to(dtype=torch.float32)
                     # self.np_assert_accuracy(paddle_output.numpy(), torch_output.numpy(), 1e-2, 1e-2, self.api_config)
-                    self.torch_assert_accuracy(paddle_output, torch_output, 1e-2, 1e-2)
+                    self.torch_assert_accuracy(paddle_output, torch_output, atol=self.atol, rtol=self.rtol)
                 except Exception as err:
                     print("[accuracy error]", self.api_config.config, "\n", str(err), flush=True)
                     write_to_log("accuracy_error", self.api_config.config)
@@ -332,7 +334,7 @@ class APITestAccuracy(APITestBase):
                                 item_paddle = paddle.cast(item_paddle, dtype="float32")
                                 item_torch = item_torch.to(dtype=torch.float32)
                             # self.np_assert_accuracy(item_paddle.numpy(), item_torch.cpu().detach().numpy(), 1e-2, 1e-2, self.api_config)
-                            self.torch_assert_accuracy(item_paddle, item_torch, 1e-2, 1e-2)
+                            self.torch_assert_accuracy(item_paddle, item_torch, atol=self.atol, rtol=self.rtol)
                     except Exception as err:
                         print("[accuracy error]", self.api_config.config, "\n", str(err), flush=True)
                         write_to_log("accuracy_error", self.api_config.config)
@@ -356,7 +358,7 @@ class APITestAccuracy(APITestBase):
                                 paddle_output[i] = paddle.cast(paddle_output[i], dtype="float32")
                                 torch_output[i] = torch_output[i].to(dtype=torch.float32)
                             # self.np_assert_accuracy(paddle_output[i].numpy(), torch_output[i].numpy(), 1e-2, 1e-2, self.api_config)
-                            self.torch_assert_accuracy(paddle_output[i], torch_output[i], 1e-2, 1e-2)
+                            self.torch_assert_accuracy(paddle_output[i], torch_output[i], atol=self.atol, rtol=self.rtol)
                         except Exception as err:
                             print("[accuracy error]", self.api_config.config, "\n", str(err), flush=True)
                             write_to_log("accuracy_error", self.api_config.config)
@@ -424,7 +426,7 @@ class APITestAccuracy(APITestBase):
                             paddle_out_grads = paddle.cast(paddle_out_grads, dtype="float32")
                             torch_out_grads = torch_out_grads.to(dtype=torch.float32)
                         # self.np_assert_accuracy(paddle_out_grads.numpy(), torch_out_grads.numpy(), 1e-2, 1e-2, self.api_config)
-                        self.torch_assert_accuracy(paddle_out_grads, torch_out_grads, 1e-2, 1e-2)
+                        self.torch_assert_accuracy(paddle_out_grads, torch_out_grads, atol=self.atol, rtol=self.rtol)
                     except Exception as err:
                         print("[accuracy error] backward ", self.api_config.config, "\n", str(err), flush=True)
                         write_to_log("accuracy_error", self.api_config.config)
@@ -462,7 +464,7 @@ class APITestAccuracy(APITestBase):
                                 paddle_out_grads[i] = paddle.cast(paddle_out_grads[i], dtype="float32")
                                 torch_out_grads[i] = torch_out_grads[i].to(dtype=torch.float32)
                             # self.np_assert_accuracy(paddle_out_grads[i].numpy(), torch_out_grads[i].numpy(), 1e-2, 1e-2, self.api_config)
-                            self.torch_assert_accuracy(paddle_out_grads[i], torch_out_grads[i], 1e-2, 1e-2)
+                            self.torch_assert_accuracy(paddle_out_grads[i], torch_out_grads[i], atol=self.atol, rtol=self.rtol)
                         except Exception as err:
                             print("[accuracy error] backward ", self.api_config.config, "\n", str(err), flush=True)
                             write_to_log("accuracy_error", self.api_config.config)

--- a/tester/base.py
+++ b/tester/base.py
@@ -889,7 +889,7 @@ class APITestBase:
             # ),
         )
 
-    def torch_assert_accuracy(self, paddle_tensor, torch_tensor, atol, rtol):
+    def torch_assert_accuracy(self, paddle_tensor, torch_tensor, atol=1e-2, rtol=1e-2):
         is_check_dtype = self.api_config.api_name not in not_check_dtype
 
         if not paddle_tensor.is_contiguous():

--- a/tester/base.py
+++ b/tester/base.py
@@ -846,47 +846,17 @@ class APITestBase:
         torch.cuda.empty_cache()
         return True
 
-    def np_assert_accuracy(
-        self,
-        np_paddle,
-        np_torch,
-        atol,
-        rtol,
-        api,
-    ):
+    def np_assert_accuracy(self, np_paddle, np_torch, atol=1e-2, rtol=1e-2):
         if np_paddle.dtype == numpy.bool_:
             numpy.testing.assert_equal(np_paddle, np_torch)
             return
-        # max_atol_idx = numpy.argmax(numpy.abs(np_paddle - np_torch))
-        # np_paddle_flatten = np_paddle.flatten()
-        # np_torch_flatten = np_torch.flatten()
-        # sub_res = np_paddle_flatten - np_torch_flatten
-        # nonzero_idx = numpy.nonzero(np_torch_flatten)
-        # sub_res = sub_res.take(nonzero_idx)
-        # np_torch_flatten_nonzero = np_torch_flatten.take(nonzero_idx).flatten()
-        # np_paddle_flatten_nonzero = np_paddle_flatten.take(nonzero_idx).flatten()
-        # if sub_res.size ==0:
-        #     max_rtol_idx = 0
-        # else:
-        #     max_rtol_idx = numpy.argmax(numpy.abs(sub_res / np_torch_flatten_nonzero))
+
         numpy.testing.assert_allclose(
             np_paddle,
             np_torch,
-            atol,
-            rtol,
-            # err_msg=(
-            #     '{api}: compare failed,\n'.format(
-            #         api=api,
-            #     )
-            #     + 'max_atol value, paddle_value: {value_paddle}, torch_value: {value_torch},\n'.format(
-            #         value_paddle=str(np_paddle_flatten[max_atol_idx].item()),
-            #         value_torch=str(np_torch_flatten[max_atol_idx].item()),
-            #     )
-            #     + 'max_rtol value , torch_value: {value_paddle}, paddle_value: {value_torch},\n'.format(
-            #         value_paddle=str(np_paddle_flatten_nonzero[max_rtol_idx].item()) if max_rtol_idx < len(np_paddle_flatten_nonzero) else '',
-            #         value_torch=str(np_torch_flatten_nonzero[max_rtol_idx].item()) if max_rtol_idx < len(np_torch_flatten_nonzero) else '',
-            #     )
-            # ),
+            rtol=rtol,
+            atol=atol,
+            equal_nan=True,
         )
 
     def torch_assert_accuracy(self, paddle_tensor, torch_tensor, atol=1e-2, rtol=1e-2):
@@ -931,7 +901,6 @@ class APITestBase:
                     torch_tensor.numpy(),
                     atol,
                     rtol,
-                    self.api_config,
                 )
             else:
                 raise

--- a/tester/paddle_cinn_vs_dygraph.py
+++ b/tester/paddle_cinn_vs_dygraph.py
@@ -8,9 +8,10 @@ from .base import APITestBase
 
 
 class APITestCINNVSDygraph(APITestBase):
-    def __init__(self, api_config, test_amp):
+    def __init__(self, api_config, **kwargs):
         super().__init__(api_config)
-        self.test_amp = test_amp
+        self.test_amp = kwargs.get("test_amp", False)
+
     #@func_set_timeout(600)
     def test(self):
         

--- a/tester/paddle_only.py
+++ b/tester/paddle_only.py
@@ -7,9 +7,9 @@ from .base import APITestBase
 
 
 class APITestPaddleOnly(APITestBase):
-    def __init__(self, api_config, test_amp):
+    def __init__(self, api_config, **kwargs):
         super().__init__(api_config)
-        self.test_amp = test_amp
+        self.test_amp = kwargs.get("test_amp", False)
     
     #@func_set_timeout(600)
     def test(self):


### PR DESCRIPTION
1. 在V1、V2中新增atol、rtol参数
2. 更改测试类传参为**kwargs
3. 更改torch_assert_accuracy、np_assert_accuracy使用atol、rtol参数