### PR TITLE
[0-size Tensor Job2 No.5] Add 0-size Tensor support for paddle.cdist

### DIFF
--- a/tester/accuracy.py
+++ b/tester/accuracy.py
@@ -393,6 +393,7 @@ class APITestAccuracy(APITestBase):
             elif self.api_config.api_name in {
                 "paddle.combinations",
                 "paddle.nn.utils.parameters_to_vector",
+                "paddle.cdist",
             }:
                 paddle_out_grads = []
                 torch_out_grads = []

--- a/tester/api_config/5_accuracy/accuracy_gpu_error_grads_diff.txt
+++ b/tester/api_config/5_accuracy/accuracy_gpu_error_grads_diff.txt
@@ -15959,3 +15959,7 @@ paddle.nn.functional.kl_div(Tensor([5, 2],"float32"), label=Tensor([5, 2],"float
 paddle.nn.functional.kl_div(Tensor([5, 2],"float64"), Tensor([5, 2],"float64"), "mean", False, )
 paddle.nn.functional.kl_div(Tensor([],"float64"), Tensor([],"float64"), "batchmean", False, )
 paddle.nn.functional.kl_div(input=Tensor([32, 128, 128],"float32"), label=Tensor([32, 128, 128],"float32"), reduction="batchmean", )
+paddle.cdist(Tensor([8550, 0],"float32"), Tensor([1, 0],"float32"), p=1, )
+paddle.cdist(Tensor([8550, 4],"float32"), Tensor([0, 4],"float32"), p=1, )
+paddle.cdist(Tensor([900, 0],"float32"), Tensor([1, 0],"float32"), p=1, )
+paddle.cdist(Tensor([900, 4],"float32"), Tensor([0, 4],"float32"), p=1, )


### PR DESCRIPTION
paddle.cdist为python端算子，使用paddle.empty, paddle.zeros，反向为空
![image](https://github.com/user-attachments/assets/0e568eb5-358f-4c39-9dfd-dbfa2d665819)

复制配置到 tester/api_config/5_accuracy/accuracy_gpu_error_grads_diff.txt

PaddleAPITest 测试通过
![image](https://github.com/user-attachments/assets/5abf7bb7-6d27-4744-85d7-73b8aba8413f)
