### PR TITLE
[Accuracy diff No.1] Fix accuracy diff for paddle.add_n API

### DIFF
--- a/tester/accuracy.py
+++ b/tester/accuracy.py
@@ -270,7 +270,18 @@ class APITestAccuracy(APITestBase):
                         paddle_output = paddle.cast(paddle_output, dtype="float32")
                         torch_output = torch_output.to(dtype=torch.float32)
                     # self.np_assert_accuracy(paddle_output.numpy(), torch_output.numpy(), atol=self.atol, rtol=self.rtol)
-                    self.torch_assert_accuracy(paddle_output, torch_output, atol=self.atol, rtol=self.rtol)
+
+                    atol = self.atol
+                    rtol = self.rtol
+                    if self.api_config.api_name == "paddle.add_n":
+                        input_list_len = len(self.paddle_args[0])
+                        if input_list_len > 0:
+                            input_list_first = self.paddle_args[0][0]
+                            # cpu place, float16 dtype
+                            if paddle.device.get_device() == "cpu" and input_list_first.dtype == paddle.float16:
+                                atol = input_list_len * atol
+                                rtol = input_list_len * rtol
+                    self.torch_assert_accuracy(paddle_output, torch_output, atol=atol, rtol=rtol)
                 except Exception as err:
                     print("[accuracy error]", self.api_config.config, "\n", str(err), flush=True)
                     write_to_log("accuracy_error", self.api_config.config)


### PR DESCRIPTION
```
paddle.add_n(list[Tensor([16, 256],"float16"),Tensor([16, 256],"float16"),Tensor([16, 256],"float16"),Tensor([16, 256],"float16"),Tensor([16, 256],"float16"),Tensor([16, 256],"float16"),Tensor([16, 256],"float16"),Tensor([16, 256],"float16"),Tensor([16, 256],"float16"),Tensor([16, 256],"float16"),Tensor([16, 256],"float16"),Tensor([16, 256],"float16"),Tensor([16, 256],"float16"),Tensor([16, 256],"float16"),Tensor([16, 256],"float16"),Tensor([16, 256],"float16"),Tensor([16, 256],"float16"),Tensor([16, 256],"float16"),Tensor([16, 256],"float16"),Tensor([16, 256],"float16"),Tensor([16, 256],"float16"),Tensor([16, 256],"float16"),Tensor([16, 256],"float16"),Tensor([16, 256],"float16"),Tensor([16, 256],"float16"),Tensor([16, 256],"float16"),Tensor([16, 256],"float16"),Tensor([16, 256],"float16"),Tensor([16, 256],"float16"),Tensor([16, 256],"float16"),Tensor([16, 256],"float16"),Tensor([16, 256],"float16"),], )
```
问题是列表中元素较多，CPU float16类型有精度误差，需要修改精度* 元素数量

PaddleAPITest 测试通过
![image](https://github.com/user-attachments/assets/efe89465-8bc2-4501-937b-a844a266f0c9)

其他测试用例错误为，如果列表中元素类型不一致，包含float32, float16，会有类型错误
类型转换没有合适的规则，这里没有修改
![image](https://github.com/user-attachments/assets/b1cf60ec-e574-44a1-a604-1eb6e3c7ad23)
