### PR TITLE
[Accuracy diff No.53] Fix accuracy diff for paddle.rsqrt API

### DIFF
--- a/report/ci_ce_gpu/test_history/20250319/error_log.log
+++ b/report/ci_ce_gpu/test_history/20250319/error_log.log
@@ -41808,6 +41808,7 @@ Max relative difference: 0.02384507
  y: array([[[[ 0.429503, -0.315528],
          [-0.264698,  0.      ],
          [ 0.      ,  0.      ],...
+
 2025-03-10 09:50:23.655795 test begin: paddle.maximum(Tensor([8, 7, 1, 2],"float32"), Tensor([8, 1, 8400, 2],"float32"), )
 
 [accuracy error] backward  paddle.maximum(Tensor([8, 7, 1, 2],"float32"), Tensor([8, 1, 8400, 2],"float32"), ) 


### PR DESCRIPTION
paddle.rsqrt 

PaddleAPITest 测试通过，配置中测试用例只有
```
paddle.rsqrt(Tensor([32, 1],"float16"), )
```
GPU
![image](https://github.com/user-attachments/assets/2b13b7de-5ae8-4eb9-a0fa-f9ab858d5541)
