### PR TITLE
[Accuracy diff No.19] Fix accuracy diff for paddle.dot API

### DIFF
--- a/report/ci_ce_gpu/test_history/20250319/error_log.log
+++ b/report/ci_ce_gpu/test_history/20250319/error_log.log
@@ -16575,6 +16575,7 @@ Max relative difference: 1.5597023
  y: array([[[-314.75308 ,   38.42414 ]],
 
        [[  87.148766,   77.98037 ]],...
+
 2025-03-10 10:16:05.147512 test begin: paddle.minimum(Tensor([3, 1, 2],"float32"), Tensor([283905, 2],"float32"), )
 
 [accuracy error] backward  paddle.minimum(Tensor([3, 1, 2],"float32"), Tensor([283905, 2],"float32"), ) 


### PR DESCRIPTION
paddle.dot

PaddleAPITest  测试通过，测试用例为0-size
```
paddle.dot(Tensor([0],"float32"), Tensor([0],"float32"), )
```
![image](https://github.com/user-attachments/assets/c620a5cc-e608-4968-a9dd-5283e6ee6be8)

0-size在PR修改 https://github.com/PaddlePaddle/Paddle/pull/73450
需要合并PR的修改后测试