### PR TITLE
[Accuracy diff No.117] Fix accuracy diff for paddle.nn.functional.dice_loss API

### DIFF
--- a/tester/paddle_to_torch/rules.py
+++ b/tester/paddle_to_torch/rules.py
@@ -1413,8 +1413,10 @@ elif data_format == "NDHWC":
 class DiceLossRule(BaseRule):
     def apply(self, paddle_api: str) -> ConvertResult:
         core = """
+label = label.squeeze(-1)
+label = torch.nn.functional.one_hot(label, input.size()[-1])
 intersection = (input * label).sum(dim=1)
-union = input.square().sum(dim=1) + label.square().sum(dim=1)
+union = input.sum(dim=1) + label.sum(dim=1)
 
 dice = (2 * intersection + epsilon) / (union + epsilon)
 


### PR DESCRIPTION
根据 paddle 的实现修改 DiceLossRule

回测结果：
![image](https://github.com/user-attachments/assets/8dc0173f-ad2d-4df3-b46c-3812589613d0)
