### PR TITLE
[Accuracy diff No.87] Fix accuracy diff for paddle.geometric.send_ue_recv API

### DIFF
--- a/tester/api_config/config_analyzer.py
+++ b/tester/api_config/config_analyzer.py
@@ -609,7 +609,7 @@ class TensorConfig:
                     num_nodes = self.get_arg(api_config, 0, "x").shape[0]
                     self.numpy_tensor = numpy.random.randint(0, num_nodes, size=self.shape).astype(self.dtype)
                 elif self.check_arg(api_config, 3, "dst_index"):
-                    num_nodes = self.get_arg(api_config, 1, "y").shape[0]
+                    num_nodes = self.get_arg(api_config, 0, "x").shape[0]
                     self.numpy_tensor = numpy.random.randint(0, num_nodes, size=self.shape).astype(self.dtype)
             elif api_config.api_name in {"paddle.index_add", "paddle.index_fill"}:
                 if self.check_arg(api_config, 1, "index"):

--- a/tester/paddle_to_torch/rules.py
+++ b/tester/paddle_to_torch/rules.py
@@ -5058,7 +5058,7 @@ elif message_op == 'sub':
 elif message_op == 'mul':
     msg = x_src * y
 elif message_op == 'div':
-    msg = x_src / y
+    msg = x_src / (y + 1e-12)
 
 out_shape[-1] = msg.shape[-1]
 


### PR DESCRIPTION
- 修改 send_ue_recv 的 numpy 数据生成，对于 send_ue_recv 来说，x 是点，y 是边，dst_index 和 src_index 都是对于点的，所以使用 x.shape[0]
```diff
--- a/tester/api_config/config_analyzer.py
+++ b/tester/api_config/config_analyzer.py
@@ -609,7 +609,7 @@
                     num_nodes = self.get_arg(api_config, 0, "x").shape[0]
                     self.numpy_tensor = numpy.random.randint(0, num_nodes, size=self.shape).astype(self.dtype)
                 elif self.check_arg(api_config, 3, "dst_index"):
-                    num_nodes = self.get_arg(api_config, 1, "y").shape[0]
+                    num_nodes = self.get_arg(api_config, 0, "x").shape[0]
                     self.numpy_tensor = numpy.random.randint(0, num_nodes, size=self.shape).astype(self.dtype)
             elif api_config.api_name in {"paddle.index_add", "paddle.index_fill"}:
                 if self.check_arg(api_config, 1, "index"):
```
- 参照源码顺便修改了一下 SendUERecvRule
```diff
--- a/tester/paddle_to_torch/rules.py
+++ b/tester/paddle_to_torch/rules.py
@@ -5058,7 +5058,7 @@
 elif message_op == 'mul':
     msg = x_src * y
 elif message_op == 'div':
-    msg = x_src / y
+    msg = x_src / (y + 1e-12)
 
 out_shape[-1] = msg.shape[-1]
```

#### TODO
- [ ] aistudio 没时间了，下周验证一下 `api_config.api_name.startswith("paddle.geometric.send_"):` 的配置项