### PR TITLE
[Accuracy diff No.23、24] Fix accuracy diff for paddle.linalg.cholesky_solve API

### DIFF
--- a/tester/api_config/config_analyzer.py
+++ b/tester/api_config/config_analyzer.py
@@ -1804,6 +1804,14 @@ class TensorConfig:
                 if self.check_arg(api_config, 1, "label"):
                     self.numpy_tensor = numpy.random.randint(low=0, high=2, size=self.shape).astype(self.dtype)
 
+            elif api_config.api_name.endswith("cholesky_solve"):
+                if self.check_arg(api_config, 1, "y"):
+                    is_upper = self.get_arg(api_config, 2, "upper")
+                    if is_upper:
+                        self.numpy_tensor = numpy.triu(self.get_random_numpy_tensor(self.shape, self.dtype))
+                    else:
+                        self.numpy_tensor = numpy.tril(self.get_random_numpy_tensor(self.shape, self.dtype))
+
             if self.numpy_tensor is None:
                 if USE_CACHED_NUMPY and self.dtype not in ["int64", "float64"]:
                     self.numpy_tensor = self.get_cached_numpy(self.dtype, self.shape)


### PR DESCRIPTION
输入tensor y 应限定为上三角或下三角矩阵

回测结果：
case:
![image](https://github.com/user-attachments/assets/e5cb1064-31fb-44cd-896a-5b86990714f3)

CPU:
![image](https://github.com/user-attachments/assets/d4b3a137-6d7e-41da-aa61-1686cee9fb7f)

GPU:
![image](https://github.com/user-attachments/assets/cc31192e-90f7-4ae9-baaf-6e5b8692fccd)
