### PR TITLE
[BIT] fix   nn.functional.pad    Tensor.__setitem__      nn.functional.cross_entropy

### DIFF
--- a/tester/api_config/config_analyzer.py
+++ b/tester/api_config/config_analyzer.py
@@ -1779,6 +1779,9 @@ class TensorConfig:
                 arr = self.get_arg(api_config, 0, "arr")
                 min_dim = min(arr.shape)
                 indices = (numpy.random.randint(0, min_dim, size=self.numel())).astype("int64")
+                if self.dtype == 'bool':
+                    ind = numpy.random.choice(self.numel(), self.get_arg(api_config, 2, "value").shape[0], replace=False)
+                    indices[ind] = 1
                 self.numpy_tensor = indices.reshape(self.shape)
             
             elif api_config.api_name == "paddle.poisson":

--- a/tester/paddle_to_torch/rules.py
+++ b/tester/paddle_to_torch/rules.py
@@ -716,6 +716,8 @@ use_softmax = locals().get('use_softmax',True)
 _kwargs['target'] = _kwargs['target'].squeeze(-1)
 if "weight" in _kwargs:
     _kwargs['weight'].requires_grad = False
+if _kwargs['target'].dtype == torch.int32:
+    _kwargs['target'] = _kwargs['target'].long()
 """
         core = """
 result = torch.nn.functional.cross_entropy(**_kwargs)

--- a/tester/paddle_to_torch/rules.py
+++ b/tester/paddle_to_torch/rules.py
@@ -4245,6 +4245,15 @@ if not pad_from_left_axis:
         right = _kwargs["pad"][2 * i + 1]
         new_pad = [right, left] + new_pad
     _kwargs["pad"] = new_pad
+elif len(_kwargs["pad"]) == 2 * _kwargs['input'].ndim:
+    num_dims = len(_kwargs["pad"]) // 2
+    new_pad = []
+    for i in range(num_dims):
+        left = _kwargs["pad"][2 * i]
+        right = _kwargs["pad"][2 * i + 1]
+        new_pad.insert(0, right)
+        new_pad.insert(0, left)
+    _kwargs["pad"] = new_pad
 """
         core = """
 result = torch.nn.functional.pad(**_kwargs)


### PR DESCRIPTION
# 修复0620回测出现的问题

## paddle.nn.functional.pad 

发现在pad的长度恰为输出维度的2倍时，paddle和torch的行为存在差异，故在rules中添加对这一情况的判断

经测试，新增的5个配置和原有的1811的配置均能正确运行

![image](https://github.com/user-attachments/assets/e48ff23a-c90a-4091-8bd6-1073768d7aa9)

## paddle.Tensor.__setitem__

发现之前的配置没有三个参数都是tensor的情况，故需要在config_analyzer中完善对indice的初始化，当indices为bool类型时，它里面true的个数，应该等于value（第三个参数）中第一维度的长度

## paddle.nn.functional.cross_entropy

错误原因为，新配置中label的变量类型为int32，torch不支持这种变量类型，故在rules中实现转换

if _kwargs['target'].dtype == torch.int32:
    _kwargs['target'] = _kwargs['target'].long()
