### PR TITLE
[0-size Tensor No.55] Add 0-size Tensor support for expand

### DIFF
--- a/report/0size_tensor_gpu/error_api_paddleonly.txt
+++ b/report/0size_tensor_gpu/error_api_paddleonly.txt
@@ -16,7 +16,6 @@ paddle.allclose
 paddle.cummax
 paddle.cummin
 paddle.einsum
-paddle.expand
 paddle.flip
 paddle.frac
 paddle.frexp

--- a/report/0size_tensor_gpu/error_config_paddleonly.txt
+++ b/report/0size_tensor_gpu/error_config_paddleonly.txt
@@ -1253,7 +1253,6 @@ paddle.einsum("i..., i...", Tensor([0, 3, 2],"float64"), Tensor([10],"float64"),
 paddle.einsum("i..., i...", Tensor([0, 3, 2],"float64"), Tensor([1],"float64"), )
 paddle.einsum("i..., i...", Tensor([1, 0, 2],"float64"), Tensor([1],"float64"), )
 paddle.einsum("i..., i...", Tensor([1, 3, 0],"float64"), Tensor([1],"float64"), )
-paddle.expand(x=Tensor([1, 1, 1],"int64"), shape=Tensor([0],"int32"), )
 paddle.flip(Tensor([0, 3, 112, 112],"float32"), axis=-1, )
 paddle.flip(Tensor([0, 3],"float32"), 1, )
 paddle.flip(Tensor([2, 0],"float32"), 1, )


### PR DESCRIPTION
paddle.expand 在配置文件 report/0size_tensor_gpu/test_history/20250528/paddleonly/error_config.txt
测试为torch error
```
python engine.py --accuracy=True --api_config='paddle.expand(x=Tensor([1, 1, 1],"int64"), shape=Tensor([0],"int32"), )'
```

![image](https://github.com/user-attachments/assets/2fd33fee-558d-4cc2-b336-922e7b9195fc)
