### PR TITLE
[0-size Tensor No.12、71] Add 0-size Tensor support for paddle.frac

### DIFF
--- a/report/0size_tensor_gpu/test_history/20250526/accuracy/error_log.log
+++ b/report/0size_tensor_gpu/test_history/20250526/accuracy/error_log.log
@@ -19415,6 +19415,7 @@ ACTUAL: (shape=torch.Size([]), dtype=torch.float32)
 All elements: tensor([-0.])
 DESIRED: (shape=torch.Size([]), dtype=torch.float32)
 All elements: tensor([nan])
+
 [Worker 2] Completed Task 1415
 
 [Worker 2] Processing Task 1416: paddle.linalg.norm(x=Tensor([0, 3, 3],"float64"), axis=list[1,2,], p=1, )


### PR DESCRIPTION
71 paddle.frac
paddle.frac 使用subtract, subtract已在 https://github.com/PaddlePaddle/Paddle/pull/72914 修改

PaddleAPITest测试通过
![image](https://github.com/user-attachments/assets/05d0c439-a043-43a8-aecd-49473f0984f1)

12 paddle.as_real
paddle.as_real 没有找到关联PR，测试没有问题
![image](https://github.com/user-attachments/assets/bf223aae-7099-4f93-91cd-b527a3e7aea0)
