### PR TITLE
[0-size Tensor No.257] Add 0-size Tensor support for paddle.signal.istft

### DIFF
--- a/report/0size_tensor_cpu/test_history/20250417/accuracy/error_log.txt
+++ b/report/0size_tensor_cpu/test_history/20250417/accuracy/error_log.txt
@@ -25450,7 +25450,6 @@ FatalError: `Segmentation fault` is detected by the operating system.
   [SignalInfo: *** SIGSEGV (@0x0) received by PID 32137 (TID 0x7f4480449700) from PID 0 ***]
 
 
-
 2025-04-17 10:04:11.945080 test begin: paddle.vstack(list[Tensor([0],"float64"),], name=None, )
 
 


### PR DESCRIPTION
0-size 测试用例中没有paddle.signal.istft
![image](https://github.com/user-attachments/assets/ad300025-6c8d-4d0c-a578-4b39b04af606)
