### PR TITLE
[0-size Tensor No.278-280] Add 0-size Tensor support for __pow__

### DIFF
--- a/report/0size_tensor_gpu/test_history/20250319/paddle_only/error_log.log
+++ b/report/0size_tensor_gpu/test_history/20250319/paddle_only/error_log.log
@@ -4,6 +4,7 @@
  (External) CUDA error(9), invalid configuration argument. 
   [Hint: 'cudaErrorInvalidConfiguration'. This indicates that a kernel launch is requesting resources that can never be satisfied by the current device. Requestingmore shared memory per block than the device supports will trigger this error, as will requesting too many threads or blocks.See cudaDeviceProp for more device limitations.] (at ../paddle/fluid/pybind/eager_functions.cc:1388)
 
+
 2025-03-03 17:02:28.866555 test begin: paddle.allclose(Tensor([0, 13, 128],"float32"), Tensor([0, 13, 128],"float32"), rtol=0.0001, atol=0.0001, )
 
 [cuda error] paddle.allclose(Tensor([0, 13, 128],"float32"), Tensor([0, 13, 128],"float32"), rtol=0.0001, atol=0.0001, ) 


### PR DESCRIPTION
278 paddle.Tensor.__pow__
修改pow PR https://github.com/PaddlePaddle/Paddle/pull/73204
PaddleAPITest 测试通过
![image](https://github.com/user-attachments/assets/0cd2f685-8040-4e7c-8a9c-5215c7ff70ee)

279 paddle.Tensor.__rmatmul__
修改matmul PR https://github.com/PaddlePaddle/Paddle/pull/73094
PaddleAPITest 测试通过， 使用paddle_only=True
![image](https://github.com/user-attachments/assets/3bdadf34-340e-46c5-ad36-aadcaec595a4)

280 paddle.Tensor.__rpow__
修改pow PR https://github.com/PaddlePaddle/Paddle/pull/73204
PaddleAPITest 测试通过
![image](https://github.com/user-attachments/assets/3287d83b-07e8-4c00-b280-c17040b4f953)


