### PR TITLE
[0-size Tensor No.109、105、107、204] Add 0-size Tensor support for paddle.linalg.matrix_norm

### DIFF
--- a/report/0size_tensor_cpu/test_history/20250417/accuracy/error_log.txt
+++ b/report/0size_tensor_cpu/test_history/20250417/accuracy/error_log.txt
@@ -15242,7 +15242,6 @@ Max relative difference among violations: inf
   [Hint: Expected x.numel() > 0, but received x.numel():0 <= 0:0.] (at /paddle/paddle/phi/kernels/impl/lerp_kernel_impl.h:86)
 
 
-
 2025-04-17 09:15:51.583012 test begin: paddle.lerp(Tensor([0, 1, 1],"float32"), Tensor([0, 8, 8],"float32"), 0.3, )
 
 [paddle error] paddle.lerp(Tensor([0, 1, 1],"float32"), Tensor([0, 8, 8],"float32"), 0.3, ) 


### PR DESCRIPTION
尝试修改，测试没有问题

109 paddle.linalg.matrix_norm 

PaddleAPITest测试
GPU
![image](https://github.com/user-attachments/assets/7062d112-daa9-49f2-b0f0-4f7658cfa872)

CPU
![image](https://github.com/user-attachments/assets/b56afe45-9835-4fd3-8fde-b4d39d00c760)

105 paddle.linalg.cov
PaddleAPITest测试
GPU
![image](https://github.com/user-attachments/assets/79e95375-182e-44ed-b36b-651bd02e6093)

CPU
![image](https://github.com/user-attachments/assets/aceee333-6368-4dc6-985d-60652443287d)

107 paddle.linalg.inv
PaddleAPITest测试
GPU
![image](https://github.com/user-attachments/assets/9b7bd3c9-973a-4610-be59-072eb22d8997)

CPU
![image](https://github.com/user-attachments/assets/b75db89a-27cc-4c04-a3bc-9785e8b6ac08)

204 paddle.nn.functional.normalize
PaddleAPITest测试
GPU
![image](https://github.com/user-attachments/assets/48f963e3-9a9f-417d-90fb-9918c5d05100)

CPU
![image](https://github.com/user-attachments/assets/f200fc52-7ddd-44d2-9a4e-8410f94c1065)
