### PR TITLE
[Accuracy diff No.97] Fix accuracy diff for paddle.incubate.softmax_mask_fuse API

### DIFF
--- a/tester/accuracy.py
+++ b/tester/accuracy.py
@@ -406,6 +406,7 @@ class APITestAccuracy(APITestBase):
             elif self.api_config.api_name in {
                 "paddle.Tensor.fill_diagonal_tensor",
                 "paddle.diagonal_scatter",
+                "paddle.incubate.softmax_mask_fuse",
                 "paddle.nn.functional.binary_cross_entropy",
                 "paddle.nn.functional.binary_cross_entropy_with_logits",
                 "paddle.nn.functional.sigmoid_focal_loss",


### PR DESCRIPTION
Paddle 中 softmax_mask_fuse 的反向只返回 x_grad，手写的 rule 会返回 x_grad 和 mask_grad

![image](https://github.com/user-attachments/assets/94d70e67-7c34-4075-9c04-8e01c6eddec5)
