### PR TITLE
[Accuracy diff No.152、153] Fix accuracy diff for paddle.vision.ops.deform_conv2d API

### DIFF
--- a/tester/accuracy.py
+++ b/tester/accuracy.py
@@ -194,6 +194,12 @@ class APITestAccuracy(APITestBase):
             if not self.gen_paddle_input():
                 print("gen_paddle_input failed")
                 return
+            if self.api_config.api_name == "paddle.vision.ops.deform_conv2d":
+                # Ensure mask is after weight
+                if "weight" in self.paddle_kwargs and "mask" in self.paddle_kwargs:
+                    mask = self.paddle_kwargs["mask"]
+                    del self.paddle_kwargs["mask"]
+                    self.paddle_kwargs["mask"] = mask
             if "paddle.Tensor." in self.api_config.api_name:
                 api = getattr(self.paddle_args[0], self.api_config.api_name[self.api_config.api_name.rindex(".")+1:])
                 if self.test_amp:


### PR DESCRIPTION
paddle.vision.ops.deform_conv2d paddle 中 mask和weight如果都为关键字参数，mask需要排在weight后，反向计算grad时是按顺序作为索引
<img width="1201" height="164" alt="image" src="https://github.com/user-attachments/assets/9fdaf3de-e319-4179-835f-3df03d9708c6" />

PaddleAPITest 测试通过，错误为torch error
GPU
<img width="1326" height="384" alt="image" src="https://github.com/user-attachments/assets/b2b9fdbc-ed5d-4def-bb46-b3978804fe5f" />

CPU
<img width="1319" height="404" alt="image" src="https://github.com/user-attachments/assets/8fcede6b-1b58-46fd-94a8-3c8c5e58cf69" />
