### PR TITLE
[PHI] fix grid_sample

### DIFF
--- a/tester/api_config/config_analyzer.py
+++ b/tester/api_config/config_analyzer.py
@@ -1681,6 +1681,10 @@ class TensorConfig:
             elif api_config.api_name == "paddle.tile":
                 if self.check_arg(api_config, 1, "repeat_times"):
                     self.numpy_tensor = numpy.random.randint(1, 128, size=self.shape).astype(self.dtype)
+            
+            elif api_config.api_name == "paddle.nn.functional.grid_sample":
+                if self.check_arg(api_config, 1, "grid"):
+                    self.numpy_tensor = numpy.random.uniform(-1, 1, size=self.shape).astype(self.dtype)
 
             elif api_config.api_name in {"paddle.topk", "paddle.Tensor.topk"}:
                 if self.check_arg(api_config, 0, "x"):


### PR DESCRIPTION
虽然[PR-72628](https://github.com/PaddlePaddle/Paddle/pull/72628) 和 [PR-73253](https://github.com/PaddlePaddle/Paddle/pull/73253) 对grid_sample的2D+3D进行了修复，但是测试还是存在精度问题，经过分析发现存在两个方面的原因。
1. 上面PR只进行了前向Kernel的修复，并没有修复反向Kernel。
2. PaddleAPITest对grid tensor变量初始化存在问题，api要求grid的取值大多数在[-1, 1]，所以需要进行修复。
<img width="1460" height="234" alt="image" src="https://github.com/user-attachments/assets/25b903bd-be42-447c-bc75-fb02deee9fcc" />