### PR TITLE
[PHI] Support paddle_error_dismiss, special_accuracy_atol_rtol, modify error_stat

### DIFF
--- a/tester/accuracy.py
+++ b/tester/accuracy.py
@@ -210,6 +210,10 @@ class APITestAccuracy(APITestBase):
             if (self.api_config.api_name[-1] == "_" and self.api_config.api_name[-2:] != "__") or self.api_config.api_name == "paddle.Tensor.__setitem__":
                 paddle_output = self.paddle_args[0] if len(self.paddle_args) > 0 else next(iter(self.paddle_kwargs.values()))
         except Exception as err:
+            if self.should_ignore_paddle_error(str(err)):
+                print("[Pass]", self.api_config.config, flush=True)
+                write_to_log("pass", self.api_config.config)
+                return
             print("[paddle error]", self.api_config.config, "\n", str(err), flush=True)
             write_to_log("paddle_error", self.api_config.config)
             if "CUDA error" in str(err) or "memory corruption" in str(err):
@@ -377,6 +381,10 @@ class APITestAccuracy(APITestBase):
                     paddle_out_grads = paddle.grad(result_outputs, inputs_list, grad_outputs=result_outputs_grads,allow_unused=True)
                 del inputs_list, result_outputs, result_outputs_grads
             except Exception as err:
+                if self.should_ignore_paddle_error(str(err)):
+                    print("[Pass]", self.api_config.config, flush=True)
+                    write_to_log("pass", self.api_config.config)
+                    return
                 print("[paddle error]", self.api_config.config, "\n", str(err), flush=True)
                 write_to_log("paddle_error", self.api_config.config)
                 if "CUDA error" in str(err) or "memory corruption" in str(err):

--- a/tester/paddle_cinn_vs_dygraph.py
+++ b/tester/paddle_cinn_vs_dygraph.py
@@ -68,6 +68,10 @@ class APITestCINNVSDygraph(APITestBase):
             #         out_grads_static = func_backward_static(result_outputs, inputs_list, result_outputs_grads)
             #         print("out_grads_static = ", out_grads_static)
         except Exception as err:
+            if self.should_ignore_paddle_error(str(err)):
+                print("[Pass]", self.api_config.config, flush=True)
+                write_to_log("pass", self.api_config.config)
+                return
             if "gradient_accumulator.cc" in str(err) or "Out of memory" in str(err):
                 return
             print("[paddle error]", self.api_config.config, "\n", str(err), flush=True)

--- a/tester/paddle_gpu_performance.py
+++ b/tester/paddle_gpu_performance.py
@@ -109,10 +109,13 @@ class APITestPaddleGPUPerformance(APITestBase):
             result_outputs_grads = None
             out_grads = None
             print(self.api_config.api_name, "\t", self.api_config.config, "\tforward\t", numel, "\t", test_loop, "\t", "faild")
+            if self.should_ignore_paddle_error(str(err)):
+                return
             if "CUDA error" in str(err) or "memory corruption" in str(err):
                 raise err
             if "CUDA out of memory" in str(err) or "Out of memory error" in str(err):
                 raise err
+            return
 
         try:
             if self.need_check_grad():
@@ -133,11 +136,12 @@ class APITestPaddleGPUPerformance(APITestBase):
             result_outputs_grads = None
             out_grads = None
             print(self.api_config.api_name, "\t", self.api_config.config, "\tbackward\t", numel, "\t", test_loop, "\t", "faild")
+            if self.should_ignore_paddle_error(str(err)):
+                return
             if "CUDA error" in str(err) or "memory corruption" in str(err):
                 raise err
             if "CUDA out of memory" in str(err) or "Out of memory error" in str(err):
                 raise err
-
             return
 
         paddle_output = None

--- a/tester/paddle_only.py
+++ b/tester/paddle_only.py
@@ -50,6 +50,10 @@ class APITestPaddleOnly(APITestBase):
             result_outputs = None
             result_outputs_grads = None
             out_grads = None
+            if self.should_ignore_paddle_error(str(err)):
+                print("[Pass]", self.api_config.config, flush=True)
+                write_to_log("pass", self.api_config.config)
+                return
             if "gradient_accumulator.cc" in str(err) or "Out of memory" in str(err):
                 return
             print("[paddle error]", self.api_config.config, "\n", str(err), flush=True)

--- a/tools/error_stat_0_size.py
+++ b/tools/error_stat_0_size.py
@@ -92,6 +92,8 @@ for content in logs:
         "CUDA out of memory" in content
         or "Out of memory error" in content
         or "[torch error]" in content
+        or "[numpy error]" in content
+        or "[paddle_to_torch]" in content
         or "(NotFound)" in content
         or "output type diff error" in content
     ):

--- a/tools/error_stat_big_tensor.py
+++ b/tools/error_stat_big_tensor.py
@@ -92,28 +92,24 @@ for content in logs:
         "CUDA out of memory" in content
         or "Out of memory error" in content
         or "[torch error]" in content
-        or "Invalid TensorConfig" in content
-        or "cannot reshape" in content
-        or "Unable to allocate" in content
-        or "(ResourceExhausted)" in content
-        or "(NotFound)" in content
-        or "Cannot take a larger sample" in content
+        or "[numpy error]" in content
+        or "[paddle_to_torch]" in content
         or "(Cannot allocate memory)" in content
-        or "Too large tensor to get cached numpy" in content
-        or "config_analyzer.py" in content
-        or "output type diff error" in content
         or "(InvalidArgument)" in content
+        or "(NotFound)" in content
+        or "(ResourceExhausted)" in content
         or "(Unimplemented)" in content
+        or "Invalid TensorConfig" in content
+        or "Unable to allocate" in content
+        or "Cannot take a larger sample" in content
+        or "output type diff error" in content
         or "should be" in content
         or "must equal" in content
         or "received:" in content
         or "incorrect shape" in content
         or "variance is of incorrect shape" in content
-        or "'numpy.int64' object is not iterable" in content
-        or "low >= high" in content
         or "The data type of input Variable" in content
         or "should satisfy" in content
-        or "[numpy error]" in content
     ):
         invalid_logs[key] = content
     else:


### PR DESCRIPTION
## New Features:

### 一、报错放行机制
1. 新增 paddle_error_dismiss 列表，注册需要报错放行的 paddle api 与 error message
2. 新增 should_ignore_paddle_error 函数，获取是否放行
3. 在 tester/accuracy.py、tester/paddle_cinn_vs_dygraph.py、tester/paddle_gpu_performance.py、tester/paddle_only.py 新增放行判断

### 二、特殊精度放行机制
1. 新增 special_accuracy_atol_rtol 列表，注册需要精度放行的 paddle api 与 atol、rtol
2. 修改 np_assert_accuracy、torch_assert_accuracy 获取放行精度

## Bug fixes:

1. 修改 tools/error_stat_big_tensor.py、tools/error_stat_0_size.py 匹配测试需求

## Tests:
paddle.nn.functional.conv1d 在 0713 版本测试中仍有 CUDA700 报错：
<img width="954" height="152" alt="image" src="https://github.com/user-attachments/assets/f775829b-d171-42f3-9bfc-95f1dc91f9a6" />

其余配置无效，需修改配置，torch 报错：
<img width="970" height="422" alt="image" src="https://github.com/user-attachments/assets/1578471c-3482-4ebc-9544-eeab85d1ae88" />
