### PR TITLE
Improve the speed of get_numpy_tensor for distribute_fpn_proposals

### DIFF
--- a/tester/api_config/config_analyzer.py
+++ b/tester/api_config/config_analyzer.py
@@ -471,27 +471,35 @@ class TensorConfig:
                 return self.numpy_tensor
             elif api_config.api_name == "paddle.vision.ops.distribute_fpn_proposals":
                 if (index is not None and index == 0) or  (key is not None and key == "fpn_rois"):
+                    num = self.shape[0]
                     self.numpy_tensor = numpy.zeros(self.shape)
-                    for i in range(self.shape[0]):
-                        self.numpy_tensor[i][0] = numpy.random.randint(1,1024) + numpy.random.random()
-                        self.numpy_tensor[i][1] = numpy.random.randint(1,1024) + numpy.random.random()
-                        self.numpy_tensor[i][2] = self.numpy_tensor[i][0] + numpy.random.randint(1,1024) + numpy.random.random()
-                        self.numpy_tensor[i][3] = self.numpy_tensor[i][1] + numpy.random.randint(1,1024) + numpy.random.random()
+                    self.numpy_tensor = numpy.random.randint(1, 1024, [num, 4]).astype("float32") 
+                    self.numpy_tensor[:, 0] += numpy.random.random([num])
+                    self.numpy_tensor[:, 1] += numpy.random.random([num])
+                    self.numpy_tensor[:, 2] = self.numpy_tensor[:, 0] + numpy.random.randint(1, 1024, [num]).astype("float32")+numpy.random.random([num])
+                    self.numpy_tensor[:, 3] = self.numpy_tensor[:, 1] + numpy.random.randint(1, 1024, [num]).astype("float32")+numpy.random.random([num])
                     if not hasattr(api_config, "num"):
-                        api_config.num = self.shape[0]
+                        api_config.num = num
                 elif (index is not None and index == 6 ) or (key is not None and key == "rois_num"):
                     num = api_config.num
                     re = self.shape[0]
                     self.numpy_tensor =  numpy.zeros(self.shape)
-                    if num < re:
-                        indices = numpy.random.choice(re, num, replace=False)
-                        self.numpy_tensor[indices] = 1
+                    if num > 4096 or re > 4096:
+                        if num < re:
+                            self.numpy_tensor[:num] = 1
+                        else:
+                            self.numpy_tensor += num//re
+                            self.numpy_tensor[:num%re] += 1
                     else:
-                        for i in range(self.shape[0]-1):
-                            self.numpy_tensor[i] = numpy.random.randint(1, num - re + 2)
-                            num = num - self.numpy_tensor[i]
-                            re -= 1
-                        self.numpy_tensor[self.shape[0]-1] = num
+                        if num < re:
+                            indices = numpy.random.choice(re, num, replace=False)
+                            self.numpy_tensor[indices] = 1
+                        else:
+                            for i in range(self.shape[0]-1):
+                                self.numpy_tensor[i] = numpy.random.randint(1, num - re + 2)
+                                num = num - self.numpy_tensor[i]
+                                re -= 1
+                            self.numpy_tensor[self.shape[0]-1] = num
 
             elif api_config.api_name == "paddle.dot":
                 if "int" in self.dtype:


### PR DESCRIPTION
提升 distribute_fpn_proposals 创建 numpy_array 的速度。

fpn_rois 的生成结果与现有结果一致。
rois_num 的生成结果做了简化，生成的样本rois分布比较平均，可以大幅度提速，仅在尺寸超过4096时启用。