### PR TITLE
Fix cross_entropy grad config

### DIFF
--- a/tester/accuracy.py
+++ b/tester/accuracy.py
@@ -418,6 +418,7 @@ class APITestAccuracy(APITestBase):
                 "paddle.incubate.softmax_mask_fuse",
                 "paddle.nn.functional.binary_cross_entropy",
                 "paddle.nn.functional.binary_cross_entropy_with_logits",
+                "paddle.nn.functional.cross_entropy",
                 "paddle.nn.functional.sigmoid_focal_loss",
                 "paddle.nn.functional.gaussian_nll_loss",
                 "paddle.nn.functional.kl_div",


### PR DESCRIPTION
运行配置
```
python engineV2.py --accuracy=True --api_config='paddle.nn.functional.cross_
entropy(Tensor([1, 3],"float64"), Tensor([1, 3],"float64"), soft_label=True, axis=-1, weight=None, reduction="mean", )'
```
反向应取一项

https://github.com/PaddlePaddle/Paddle/blob/develop/paddle/phi/kernels/gpu/cross_entropy_grad_kernel.cu
<img width="817" height="401" alt="image" src="https://github.com/user-attachments/assets/1bbd571d-9cba-4c05-a7e0-bf780a171238" />
