### PR TITLE
Fix the binding order of paddle kwargs

### DIFF
--- a/tester/accuracy.py
+++ b/tester/accuracy.py
@@ -199,12 +199,6 @@ class APITestAccuracy(APITestBase):
             if not self.gen_paddle_input():
                 print("gen_paddle_input failed")
                 return
-            if self.api_config.api_name == "paddle.vision.ops.deform_conv2d":
-                # Ensure mask is after weight
-                if "weight" in self.paddle_kwargs and "mask" in self.paddle_kwargs:
-                    mask = self.paddle_kwargs["mask"]
-                    del self.paddle_kwargs["mask"]
-                    self.paddle_kwargs["mask"] = mask
             if "paddle.Tensor." in self.api_config.api_name:
                 api = getattr(self.paddle_args[0], self.api_config.api_name[self.api_config.api_name.rindex(".")+1:])
                 if self.test_amp:


### PR DESCRIPTION
## 错误复现：
`paddle.vision.ops.deform_conv2d` 出现关键字参数（ `kwargs` ）顺序不同，导致的反向报错：
- https://github.com/PFCCLab/PaddleAPITest/pull/366

尝试改变 configs 中的 `kwargs` 顺序，当 `TensorConfig` 先后顺序改变后，反向报错：
```
paddle.nn.functional.layer_norm(Tensor([7, 165, 1024],"float32"), 1024, bias=Tensor([1024],"float32"), epsilon=1e-05, weight=Tensor([1024],"float32"), )
paddle.nn.functional.layer_norm(Tensor([7, 165, 1024],"float32"), 1024, bias=Tensor([1024],"float32"), weight=Tensor([1024],"float32"), epsilon=1e-05, )
paddle.nn.functional.layer_norm(Tensor([7, 165, 1024],"float32"), 1024, epsilon=1e-05, bias=Tensor([1024],"float32"), weight=Tensor([1024],"float32"), )

paddle.nn.functional.layer_norm(Tensor([7, 165, 1024],"float32"), 1024, epsilon=1e-05, weight=Tensor([1024],"float32"), bias=Tensor([1024],"float32"), )
paddle.nn.functional.layer_norm(Tensor([7, 165, 1024],"float32"), 1024, weight=Tensor([1024],"float32"), bias=Tensor([1024],"float32"), epsilon=1e-05, )
paddle.nn.functional.layer_norm(Tensor([7, 165, 1024],"float32"), 1024, weight=Tensor([1024],"float32"), epsilon=1e-05, bias=Tensor([1024],"float32"), )
```

<img width="1494" height="802" alt="image" src="https://github.com/user-attachments/assets/42a7e6f4-a2f1-4202-b3c8-1b804f48b620" />

## 问题定位：

原因是任何 API 的关键字参数可以随机排列，但是在进行精度比较时， torch 的参数均经过 `paddle_sig.bind` 绑定，其关键字顺序被固定，导致 paddle 与 torch 的参数顺序产生 diff : https://github.com/PFCCLab/PaddleAPITest/blob/main/tester/base.py#L718

执行反向前，会构造输入列表 `get_torch_input_list()` 、 `get_paddle_input_list()` ，并依次比较梯度，参数不一致即会导致反向报错

## 解决方案：
修改 `get_paddle_input_list()` : 
- 按照绑定后的 `paddle_merged_kwargs_config` 顺序构造 `kwargs` 输入列表；
- 位置参数（ `args` ）顺序一定固定，且位于 `kwargs` 之前，不必修改

## 测试：
修改后，测试全部通过：
<img width="1482" height="258" alt="image" src="https://github.com/user-attachments/assets/4dc66035-8bd9-4e2d-84a2-d2c05a679d50" />
