### PR TITLE
[PHI] Fix paddle.linalg.det input from random to non-singular

### DIFF
--- a/tester/api_config/config_analyzer.py
+++ b/tester/api_config/config_analyzer.py
@@ -816,7 +816,14 @@ class TensorConfig:
                     # Construct a non-singular matrix: A = random_matrix + n*I
                     # strict diagonal dominant matrix is non-singular. https://en.wikipedia.org/wiki/Diagonally_dominant_matrix
                     self.numpy_tensor += eye_matrix
-                    
+                elif api_config.api_name.endswith("det"):
+                    if self.check_arg(api_config, 0, "x"):
+                        assert len(self.shape) >= 2, "Input must be at least 2D."
+                        assert self.shape[-1] == self.shape[-2], "Input must be square matrices."
+                        n = self.shape[-1]
+                        A = numpy.random.uniform(low=0.5, high=1.0, size=self.shape).astype(self.dtype)
+                        A_T = numpy.swapaxes(A, -1, -2)
+                        self.numpy_tensor = numpy.matmul(A, A_T) + numpy.eye(n, dtype=self.dtype)
             elif api_config.api_name == "paddle.linspace":
                 if "int" in self.dtype:
                     self.numpy_tensor = (numpy.random.randint(0, 65535, size=self.shape)).astype(self.dtype)


### PR DESCRIPTION
与以下 PR 相同：
- https://github.com/PFCCLab/PaddleAPITest/pull/357

当输入拥有奇异矩阵时，`paddle.linalg.det` 会导致矩阵求逆错误：
![image](https://github.com/user-attachments/assets/f408a1b4-d88e-430c-a0a1-146da34b0dce)

虽然 https://github.com/PaddlePaddle/Paddle/pull/73751 已经解决报错问题，但反向结果仍与理论值相差较大，等待后续修复

因此在仅关注 bigtensor 的情况下，先构造输入，从随机矩阵改为非奇异矩阵，以此规避奇异问题，验证 bigtensor 是否正确；修改后，所有测试均已通过：
![image](https://github.com/user-attachments/assets/fce5b6d1-00bc-43a2-8469-59e087d0b651)