### PR TITLE
[Accuracy diff No.109] Fix batch_norm mapping

### DIFF
--- a/tester/paddle_to_torch/mapping.json
+++ b/tester/paddle_to_torch/mapping.json
@@ -2466,11 +2466,11 @@
             "running_var": "running_var",
             "weight": "weight",
             "bias": "bias",
-            "epsilon": "eps",
-            "training": "training"
+            "epsilon": "eps"
         },
         "torch_kwargs": {
-            "momentum": "1 - momentum"
+            "momentum": "1 - momentum",
+            "training": "training and not use_global_stats"
         }
     },
     "paddle.nn.functional.bilinear": {


### PR DESCRIPTION
由于 pytorch 的batch_norm API 没有 use_global_stats 或 track_running_stats 参数（pytorch在class层面实现的），所以使用 training if use_global_stats is None else not use_global_stats 来替代 training 可以保证pytorch行为 与 paddle行为一致。
修改后 pytorch 行为如下
1
training = False
track_running_stats =True
使用全局
2
training = False
track_running_stats = False
不使用全局
3
training = True
track_running_stats = True
使用全局
4
training = True
track_running_stats = False
不使用全局
