### PR TITLE
[0-size Tensor Job2 No.96] fix rules of reshape

### DIFF
--- a/tester/paddle_to_torch/rules.py
+++ b/tester/paddle_to_torch/rules.py
@@ -4712,10 +4712,7 @@ for i, s in enumerate(shape):
         shape[i] = elements
 """
         core = """
-if x.numel() == 0:
-    result = torch.zeros(shape, dtype=x.dtype)
-else:
-    result = torch.reshape(x, shape)
+result = torch.reshape(x, shape)
 """
         code = Code(preprocess=pre.splitlines(), core=core.splitlines())
         return ConvertResult.success(paddle_api, code)


### PR DESCRIPTION
当输入tensor的numel为0时，也应该正常调用torch.reshape函数，这样才能和paddle相对齐
<img width="594" height="110" alt="image" src="https://github.com/user-attachments/assets/f91c605b-f8a2-4efc-8897-24cb16896a89" />
