### PR TITLE
[Accuracy diff No.102] Fix accuracy diff for paddle.lstsq API

### DIFF
--- a/tester/paddle_to_torch/rules.py
+++ b/tester/paddle_to_torch/rules.py
@@ -3532,7 +3532,10 @@ class LstsqRule(BaseRule):
     def apply(self, paddle_api: str) -> ConvertResult:
         defaults_code, map_code = self.apply_generic()
         pre = """
-driver='gels'
+# if driver isn't gels, it only can run in cpu mode.
+if driver != 'gels':
+    locals()['x'] = locals()['x'].cpu()
+    locals()['y'] = locals()['y'].cpu()
 """
         core = f"result = {self.torch_api}(**_kwargs)"
         code = Code(preprocess=defaults_code + pre.splitlines() + map_code, core=[core])

--- a/tester/paddle_to_torch/rules.py
+++ b/tester/paddle_to_torch/rules.py
@@ -3534,8 +3534,8 @@ class LstsqRule(BaseRule):
         pre = """
 # if driver isn't gels, it only can run in cpu mode.
 if driver != 'gels':
-    locals()['x'] = locals()['x'].cpu()
-    locals()['y'] = locals()['y'].cpu()
+    x = x.cpu()
+    y = y.cpu()
 """
         core = f"result = {self.torch_api}(**_kwargs)"
         code = Code(preprocess=defaults_code + pre.splitlines() + map_code, core=[core])


### PR DESCRIPTION
lstsq cpu
- [x] 修复 rules 转换规则
- [x] 在 Paddle 中对齐 residuals 是否返回空向量的逻辑 https://github.com/PaddlePaddle/Paddle/pull/74160
- ~rank 返回值类型 int32 和 int64 不一致~

<img width="1178" height="463" alt="图片" src="https://github.com/user-attachments/assets/054a0d2b-5235-46bd-99c1-cbc1b673ae73" />
