### PR TITLE
Add paddle error dismiss

### DIFF
--- a/tester/base_config.yaml
+++ b/tester/base_config.yaml
@@ -15,6 +15,8 @@ paddle_error_dismiss:
   paddle.vision.ops.distribute_fpn_proposals:
     - "(PreconditionNotMet) The number of proposals in FPN "
     - "(PreconditionNotMet) The number of images "
+  paddle.incubate.nn.functional.variable_length_memory_efficient_attention: "(InvalidArgument) the kernel should not be launched"
+  paddle.Tensor.inverse: "(Unimplemented) cublasMatInv does not support batch_size > 65536."
 
 # some accuracy error can be considered tolerable
 special_accuracy_atol_rtol:


### PR DESCRIPTION
paddle.Tensor.inverse和paddle.incubate.nn.functional.variable_length_memory_efficient_attention的paddle error dismiss，参见pr：[pr74089](https://github.com/PaddlePaddle/Paddle/pull/74089) [pr74065](https://github.com/PaddlePaddle/Paddle/pull/74065)