### PR TITLE
[Accuracy diff No.115] support softmax=False and weight != None && soft_label==True  for cross_entropy

### DIFF
--- a/tester/api_config/config_analyzer.py
+++ b/tester/api_config/config_analyzer.py
@@ -1883,12 +1883,7 @@ class TensorConfig:
                 dtype="float32" if self.dtype == 'bfloat16' else self.dtype,
                 place=self.place
             )
-            if api_config.api_name == "paddle.nn.functional.cross_entropy":
-                if self.check_arg(api_config, 0, "input") and not self.get_arg(api_config, 8, "use_softmax", True):
-                    axis = self.get_arg(api_config, 7, "axis", -1)
-                    self.paddle_tensor = paddle.exp(self.paddle_tensor)
-                    self.paddle_tensor = self.paddle_tensor / self.paddle_tensor.sum(axis=axis, keepdim=True)
-                    
+
             self.paddle_tensor.stop_gradient = False
             if self.dtype == "bfloat16":
                 self.paddle_tensor = paddle.cast(self.paddle_tensor, dtype="uint16")

--- a/tester/api_config/config_analyzer.py
+++ b/tester/api_config/config_analyzer.py
@@ -1880,6 +1880,12 @@ class TensorConfig:
                 dtype="float32" if self.dtype == 'bfloat16' else self.dtype,
                 place=self.place
             )
+            if api_config.api_name == "paddle.nn.functional.cross_entropy":
+                if self.check_arg(api_config, 0, "input") and not self.get_arg(api_config, 8, "use_softmax", True):
+                    axis = self.get_arg(api_config, 7, "axis", -1)
+                    self.paddle_tensor = paddle.exp(self.paddle_tensor)
+                    self.paddle_tensor = self.paddle_tensor / self.paddle_tensor.sum(axis=axis, keepdim=True)
+                    
             self.paddle_tensor.stop_gradient = False
             if self.dtype == "bfloat16":
                 self.paddle_tensor = paddle.cast(self.paddle_tensor, dtype="uint16")

--- a/tester/api_config/config_analyzer.py
+++ b/tester/api_config/config_analyzer.py
@@ -1054,6 +1054,9 @@ class TensorConfig:
                         self.numpy_tensor = soft_labels.astype(self.dtype)
                     else:
                         self.numpy_tensor = numpy.random.randint(0, num_classes, size=self.shape).astype(self.dtype)
+                elif self.check_arg(api_config, 3, "weight"):
+                    self.numpy_tensor = numpy.random.random(size=self.shape)
+                    self.numpy_tensor = self.numpy_tensor / self.numpy_tensor.sum()
 
             elif api_config.api_name == "paddle.nn.functional.ctc_loss":
                 if self.check_arg(api_config, 1, "labels"):

--- a/tester/base.py
+++ b/tester/base.py
@@ -374,6 +374,21 @@ class APITestBase:
                 self.paddle_args[3] = "gels"
             elif "driver" in self.paddle_kwargs:
                 self.paddle_kwargs["driver"] = "gels"
+        elif self.api_config.api_name == "paddle.nn.functional.cross_entropy":
+            use_softmax = True
+            if 0 <= 8 < len(self.api_config.args):
+                use_softmax = self.api_config.args[8]
+            elif "use_softmax" in self.api_config.kwargs:
+                use_softmax = self.api_config.kwargs["use_softmax"]
+            
+            if not use_softmax:
+                axis = -1
+                if 0 <= 7 < len(self.api_config.args):
+                    axis = self.api_config.args[7]
+                elif "axis" in self.api_config.kwargs:
+                    axis = self.api_config.kwargs["axis"]
+                self.paddle_args[0] = paddle.exp(self.paddle_args[0])
+                self.paddle_args[0] = self.paddle_args[0] / self.paddle_args[0].sum(axis=axis, keepdim=True)
 
         if self.need_check_grad():
             if (self.api_config.api_name[-1] == "_" and self.api_config.api_name[-2:] != "__") or self.api_config.api_name == "paddle.Tensor.__setitem__":

--- a/tester/base.py
+++ b/tester/base.py
@@ -375,18 +375,9 @@ class APITestBase:
             elif "driver" in self.paddle_kwargs:
                 self.paddle_kwargs["driver"] = "gels"
         elif self.api_config.api_name == "paddle.nn.functional.cross_entropy":
-            use_softmax = True
-            if 0 <= 8 < len(self.api_config.args):
-                use_softmax = self.api_config.args[8]
-            elif "use_softmax" in self.api_config.kwargs:
-                use_softmax = self.api_config.kwargs["use_softmax"]
-            
+            use_softmax = get_arg(self.api_config, 8, "use_softmax", True)
             if not use_softmax:
-                axis = -1
-                if 0 <= 7 < len(self.api_config.args):
-                    axis = self.api_config.args[7]
-                elif "axis" in self.api_config.kwargs:
-                    axis = self.api_config.kwargs["axis"]
+                axis = get_arg(self.api_config, 7, "axis", -1)
                 self.paddle_args[0] = paddle.exp(self.paddle_args[0])
                 self.paddle_args[0] = self.paddle_args[0] / self.paddle_args[0].sum(axis=axis, keepdim=True)
 

--- a/tester/paddle_to_torch/mapping.json
+++ b/tester/paddle_to_torch/mapping.json
@@ -2683,7 +2683,9 @@
         "Rule": "CrossEntropyRule",
         "torch_api": "torch.nn.functional.cross_entropy",
         "set_defaults": {
-            "weight": "None"
+            "weight": "None",
+            "reduction": "'mean'",
+            "label_smoothing": "0.0"
         },
         "paddle_torch_args_map": {
             "input": "input",
@@ -2691,7 +2693,8 @@
             "weight": "weight",
             "ignore_index": "ignore_index",
             "reduction": "reduction",
-            "label_smoothing": "label_smoothing"
+            "label_smoothing": "label_smoothing",
+            "sum_weight": "sum_weight"
         }
     },
     "paddle.nn.functional.ctc_loss": {

--- a/tester/paddle_to_torch/mapping.json
+++ b/tester/paddle_to_torch/mapping.json
@@ -2680,7 +2680,19 @@
         }
     },
     "paddle.nn.functional.cross_entropy": {
-        "Rule": "CrossEntropyRule"
+        "Rule": "CrossEntropyRule",
+        "torch_api": "torch.nn.functional.cross_entropy",
+        "set_defaults": {
+            "weight": "None"
+        },
+        "paddle_torch_args_map": {
+            "input": "input",
+            "label": "target",
+            "weight": "weight",
+            "ignore_index": "ignore_index",
+            "reduction": "reduction",
+            "label_smoothing": "label_smoothing"
+        }
     },
     "paddle.nn.functional.ctc_loss": {
         "Rule": "CtcLossRule"

--- a/tester/paddle_to_torch/mapping.json
+++ b/tester/paddle_to_torch/mapping.json
@@ -2685,16 +2685,17 @@
         "set_defaults": {
             "weight": "None",
             "reduction": "'mean'",
-            "label_smoothing": "0.0"
+            "soft_label": "False",
+            "label_smoothing": "0.0",
+            "reduction_original":"None"
         },
         "paddle_torch_args_map": {
             "input": "input",
             "label": "target",
             "weight": "weight",
-            "ignore_index": "ignore_index",
             "reduction": "reduction",
-            "label_smoothing": "label_smoothing",
-            "sum_weight": "sum_weight"
+            "ignore_index": "ignore_index",
+            "label_smoothing": "label_smoothing"
         }
     },
     "paddle.nn.functional.ctc_loss": {

--- a/tester/paddle_to_torch/rules.py
+++ b/tester/paddle_to_torch/rules.py
@@ -676,10 +676,16 @@ label = label.squeeze(-1)
 if weight is not None:
     weight.requires_grad = False
 if label.dtype == torch.int32:
-    label= label.long()
+    label = label.long()
+if reduction == "mean" and soft_label and weight is not None and shp == input.shpae:
+    sum_weight = (label@weight).sum()
+    reduction = "sum"
+else:
+    sum_weight = 1
 """
-        core = """
-result = torch.nn.functional.cross_entropy(**_kwargs)
+        core = f"""
+sum_weight = _kwargs.pop("sum_weight")
+result = {self.torch_api}(**_kwargs)/sum_weight
 """
         post = """
 if "reduction" in _kwargs and _kwargs['reduction'] == "none":

--- a/tester/paddle_to_torch/rules.py
+++ b/tester/paddle_to_torch/rules.py
@@ -664,30 +664,19 @@ if input2.dim() == 1:
 
 class CrossEntropyRule(BaseRule):
     def apply(self, paddle_api: str) -> ConvertResult:
+        defaults_code, map_code = self.apply_generic()
         pre = """
-_kwargs = {}
-for paddle_param, torch_param in {
-    "input": "input",
-    "label": "target",
-    "weight": "weight",
-    "ignore_index": "ignore_index",
-    "reduction": "reduction",
-    "label_smoothing": "label_smoothing"
-}.items():
-    if paddle_param in locals() and locals()[paddle_param] is not None:
-        _kwargs[torch_param] = locals()[paddle_param]
-shp = _kwargs['target'].shape
-if len(_kwargs["input"].shape) > 2:
-    perm = [0] + [len(_kwargs["input"].shape)-1]+ [i for i in range(1,len(_kwargs["input"].shape)-1)]
-    _kwargs['input'] = _kwargs['input'].permute(*perm)
+shp = label.shape
+if len(input.shape) > 2:
+    perm = [0] + [len(input.shape)-1]+ [i for i in range(1,len(input.shape)-1)]
+    input = input.permute(*perm)
 soft_label = locals().get('soft_label',False)
 axis = locals().get('axis',-1)
-use_softmax = locals().get('use_softmax',True)
-_kwargs['target'] = _kwargs['target'].squeeze(-1)
-if "weight" in _kwargs:
-    _kwargs['weight'].requires_grad = False
-if _kwargs['target'].dtype == torch.int32:
-    _kwargs['target'] = _kwargs['target'].long()
+label = label.squeeze(-1)
+if weight is not None:
+    weight.requires_grad = False
+if label.dtype == torch.int32:
+    label= label.long()
 """
         core = """
 result = torch.nn.functional.cross_entropy(**_kwargs)
@@ -700,7 +689,7 @@ if "reduction" in _kwargs and _kwargs['reduction'] == "none":
         result = result.reshape(shp)
 """
         code = Code(
-            preprocess=pre.splitlines(),
+            preprocess=defaults_code + pre.splitlines() + map_code,
             core=core.splitlines(),
             postprocess=post.splitlines(),
         )
@@ -948,7 +937,7 @@ else:
     result = torch.clamp(**_kwargs)
 """
         elif paddle_api == "paddle.Tensor.clip":
-                core = """
+            core = """
 if min is None and max is None:
     result = x
 else:
@@ -958,7 +947,10 @@ else:
             return ConvertResult.error(
                 paddle_api, f"Unsupported clip api: {paddle_api}"
             )
-        code = Code(preprocess=defaults_code + pre.splitlines() + map_code, core=core.splitlines())
+        code = Code(
+            preprocess=defaults_code + pre.splitlines() + map_code,
+            core=core.splitlines(),
+        )
         return ConvertResult.success(paddle_api, code)
 
 

--- a/tester/paddle_to_torch/rules.py
+++ b/tester/paddle_to_torch/rules.py
@@ -677,7 +677,7 @@ if weight is not None:
     weight.requires_grad = False
 if label.dtype == torch.int32:
     label = label.long()
-if reduction == "mean" and soft_label and weight is not None and shp == input.shpae:
+if reduction == "mean" and soft_label and weight is not None and shp == input.shape:
     sum_weight = (label@weight).sum()
     reduction = "sum"
 else:


### PR DESCRIPTION
weight 需要满足和为一。

softmax=False 时需要按照文档要求对输入手动进行softmax操作。
因为 torch tensor 自带了 softmax，所以只paddle的输入进行 softmax操作。

PyTorch 的对应 API 不支持使用 soft_label时添加weight，需要手动实现对齐 Paddle。

