### PR TITLE
[PHI] Fix `bf16` in comparison and grads

### DIFF
--- a/tester/accuracy.py
+++ b/tester/accuracy.py
@@ -155,42 +155,21 @@ class APITestAccuracy(APITestBase):
         else:
             del self.torch_args, self.torch_kwargs
 
-        if isinstance(torch_output, torch.Tensor):
-            if torch_output.dtype == torch.bfloat16:
-                torch_output = torch_output.to(dtype=torch.float32)
-            torch_output = torch_output.cpu().detach()
-        elif isinstance(torch_output, (torch.return_types.max, torch.return_types.min)):
-            torch_output = torch_output.values
-            if torch_output.dtype == torch.bfloat16:
-                torch_output = torch_output.to(dtype=torch.float32)
-            torch_output = torch_output.cpu().detach()
-        elif isinstance(torch_output, (list, tuple)):
-            if isinstance(torch_output, tuple):
-                torch_output = list(torch_output)
-            for i in range(len(torch_output)):
-                if isinstance(torch_output[i], torch.Tensor):
-                    if torch_output[i].dtype == torch.bfloat16:
-                        torch_output[i] = torch_output[i].to(dtype=torch.float32)
-                    torch_output[i] = torch_output[i].cpu().detach()
+        def process_torch_outputs(obj):
+            if isinstance(obj, (torch.return_types.max, torch.return_types.min)):
+                obj = obj.values
+            if isinstance(obj, torch.Tensor):
+                obj = obj.cpu().detach()
+            elif isinstance(obj, (list, tuple)):
+                obj = list(obj)
+                for i in range(len(obj)):
+                    if isinstance(obj[i], torch.Tensor):
+                        obj[i] = obj[i].cpu().detach()
+            return obj
 
+        torch_output = process_torch_outputs(torch_output)
         if torch_grad_success:
-            if isinstance(torch_out_grads, torch.Tensor):
-                if torch_out_grads.dtype == torch.bfloat16:
-                    torch_out_grads = torch_out_grads.to(dtype=torch.float32)
-                torch_out_grads = torch_out_grads.cpu().detach()
-            elif isinstance(torch_out_grads, (torch.return_types.max, torch.return_types.min)):
-                torch_out_grads = torch_out_grads.values
-                if torch_out_grads.dtype == torch.bfloat16:
-                    torch_out_grads = torch_out_grads.to(dtype=torch.float32)
-                torch_out_grads = torch_out_grads.cpu().detach()
-            elif isinstance(torch_out_grads, (list, tuple)):
-                if isinstance(torch_out_grads, tuple):
-                    torch_out_grads = list(torch_out_grads)
-                for i in range(len(torch_out_grads)):
-                    if isinstance(torch_out_grads[i], torch.Tensor):
-                        if torch_out_grads[i].dtype == torch.bfloat16:
-                            torch_out_grads[i] = torch_out_grads[i].to(dtype=torch.float32)
-                        torch_out_grads[i] = torch_out_grads[i].cpu().detach()
+            torch_out_grads = process_torch_outputs(torch_out_grads)
 
         gc.collect()
         torch.cuda.empty_cache()
@@ -275,105 +254,66 @@ class APITestAccuracy(APITestBase):
                 paddle_output.append([coef_vector, abs_coef])
                 torch_output.append([coef_vector_approx, one])
 
+
         self.is_backward = False
+        def compare_paddle_and_torch(paddle_output, torch_output) -> bool:
+            try:
+                # self.np_assert_accuracy(paddle_output.numpy(), torch_output.numpy(), atol=self.atol, rtol=self.rtol)
+                self.torch_assert_accuracy(paddle_output, torch_output, atol=self.atol, rtol=self.rtol)
+            except Exception as err:
+                if self.is_backward:
+                    print(f"[accuracy error] backward {self.api_config.config}\n{str(err)}", flush=True)
+                else:
+                    print(f"[accuracy error] {self.api_config.config}\n{str(err)}", flush=True)
+                write_to_log("accuracy_error", self.api_config.config)
+                return False
+            return True
+
         if isinstance(paddle_output, paddle.Tensor):
             if isinstance(torch_output, torch.Tensor):
-                try:
-                    if paddle_output.dtype == paddle.bfloat16:
-                        paddle_output = paddle.cast(paddle_output, dtype="float32")
-                        torch_output = torch_output.to(dtype=torch.float32)
-                    # self.np_assert_accuracy(paddle_output.numpy(), torch_output.numpy(), atol=self.atol, rtol=self.rtol)
-                    self.torch_assert_accuracy(paddle_output, torch_output, atol=self.atol, rtol=self.rtol)
-                except Exception as err:
-                    print("[accuracy error]", self.api_config.config, "\n", str(err), flush=True)
-                    write_to_log("accuracy_error", self.api_config.config)
+                if not compare_paddle_and_torch(paddle_output, torch_output):
                     return
             elif isinstance(torch_output, bool):
                 try:
                     assert paddle_output.dtype == paddle.bool, "paddle_output dtype is not bool"
                     assert paddle_output.shape == [], "paddle_output shape is not []"
-                    assert bool(paddle_output) == torch_output, f"paddle_output{bool(paddle_output)} is not equal to torch_output{torch_output}"
+                    assert bool(paddle_output) == torch_output, f"paddle_output {bool(paddle_output)} is not equal to torch_output {torch_output}"
                 except Exception as err:
                     print("[accuracy error]", self.api_config.config, "\n", str(err), flush=True)
                     write_to_log("accuracy_error", self.api_config.config)
                     return
             elif isinstance(torch_output, (torch.return_types.max, torch.return_types.min)):
-                try:
-                    torch_output = torch_output.values
-                    if paddle_output.dtype == paddle.bfloat16:
-                        paddle_output = paddle.cast(paddle_output, dtype="float32")
-                        torch_output = torch_output.to(dtype=torch.float32)
-                    # self.np_assert_accuracy(paddle_output.numpy(), torch_output.numpy(), atol=self.atol, rtol=self.rtol)
-                    self.torch_assert_accuracy(paddle_output, torch_output, atol=self.atol, rtol=self.rtol)
-                except Exception as err:
-                    print("[accuracy error]", self.api_config.config, "\n", str(err), flush=True)
-                    write_to_log("accuracy_error", self.api_config.config)
+                torch_output = torch_output.values
+                if not compare_paddle_and_torch(paddle_output, torch_output):
                     return
             else:
                 print("[accuracy error]", self.api_config.config, "\n[output type diff error1], ", type(torch_output), flush=True)
                 write_to_log("accuracy_error", self.api_config.config)
                 return
         elif isinstance(paddle_output, (list, tuple)):
-            if isinstance(paddle_output, tuple):
-                paddle_output = list(paddle_output)
             if not isinstance(torch_output, (list, tuple)):
                 print("[output type diff error]", self.api_config.config, flush=True)
                 return
-            if isinstance(torch_output, tuple):
-                torch_output = list(torch_output)
+            paddle_output = list(paddle_output)
+            torch_output = list(torch_output)
             if len(paddle_output) != len(torch_output):
                 print("[accuracy error]", self.api_config.config, "\n[output type diff error2], ", len(paddle_output), len(torch_output), flush=True)
                 write_to_log("accuracy_error", self.api_config.config)
                 return
-            for i in range(len(paddle_output)):
-                flag = False
-                if isinstance(paddle_output[i], (tuple,list)) and isinstance(torch_output[i], (tuple,list)):
-                    flag =True
-                    for item in paddle_output[i]:
-                        if not isinstance(item, paddle.Tensor):
-                            flag = False
-                            break
-                    for item in torch_output[i]:
-                        if not isinstance(item, torch.Tensor):
-                            flag = False
-                            break
-                if flag:
-                    try:
-                        for index, item_paddle in enumerate(paddle_output[i]):
-                            item_torch = torch_output[i][index]
-                            if item_paddle.dtype == paddle.bfloat16:
-                                item_paddle = paddle.cast(item_paddle, dtype="float32")
-                                item_torch = item_torch.to(dtype=torch.float32)
-                            # self.np_assert_accuracy(item_paddle.numpy(), item_torch.cpu().detach().numpy(), atol=self.atol, rtol=self.rtol)
-                            self.torch_assert_accuracy(item_paddle, item_torch, atol=self.atol, rtol=self.rtol)
-                    except Exception as err:
-                        print("[accuracy error]", self.api_config.config, "\n", str(err), flush=True)
-                        write_to_log("accuracy_error", self.api_config.config)
-                        return                    
+            for paddle_item, torch_item in zip(paddle_output, torch_output):
+                if isinstance(paddle_item, int) or self.api_config.api_name.endswith('tolist'):
+                    self.np_assert_accuracy(numpy.array(paddle_item), numpy.array(torch_item), atol=self.atol, rtol=self.rtol)
+                elif not isinstance(paddle_item, paddle.Tensor):
+                    print("[not compare]", paddle_item, torch_item, flush=True)
+                    write_to_log("accuracy_error", self.api_config.config)
+                    return
+                elif not isinstance(torch_item, torch.Tensor):
+                    print("[accuracy error]", self.api_config.config, "\n[output type diff error3], ", type(torch_item), flush=True)
+                    write_to_log("accuracy_error", self.api_config.config)
+                    return
                 else:
-                    if isinstance(paddle_output[i], int):
-                        self.np_assert_accuracy(numpy.array(paddle_output[i]), numpy.array(torch_output[i]), atol=self.atol, rtol=self.rtol)
-                    elif 'tolist' in self.api_config.api_name:
-                        self.np_assert_accuracy(numpy.array(paddle_output[i]), numpy.array(torch_output[i]), atol=self.atol, rtol=self.rtol)
-                    elif not isinstance(paddle_output[i], paddle.Tensor):
-                        print("[not compare] ", paddle_output[i], torch_output[i], flush=True)
-                        write_to_log("accuracy_error", self.api_config.config)
+                    if not compare_paddle_and_torch(paddle_output, torch_output):
                         return
-                    elif not isinstance(torch_output[i], torch.Tensor):
-                        print("[accuracy error]", self.api_config.config, "\n[output type diff error3], ", type(torch_output[i]), flush=True)
-                        write_to_log("accuracy_error", self.api_config.config)
-                        return
-                    else:
-                        try:
-                            if paddle_output[i].dtype == paddle.bfloat16:
-                                paddle_output[i] = paddle.cast(paddle_output[i], dtype="float32")
-                                torch_output[i] = torch_output[i].to(dtype=torch.float32)
-                            # self.np_assert_accuracy(paddle_output[i].numpy(), torch_output[i].numpy(), atol=self.atol, rtol=self.rtol)
-                            self.torch_assert_accuracy(paddle_output[i], torch_output[i], atol=self.atol, rtol=self.rtol)
-                        except Exception as err:
-                            print("[accuracy error]", self.api_config.config, "\n", str(err), flush=True)
-                            write_to_log("accuracy_error", self.api_config.config)
-                            return
 
         if torch_grad_success:
             self.is_backward = True
@@ -429,8 +369,8 @@ class APITestAccuracy(APITestBase):
                 "paddle.nn.functional.kl_div",
                 "paddle.scale",
             }:
-                paddle_out_grads = paddle_out_grads[0]
-                torch_out_grads = torch_out_grads[0]
+                paddle_out_grads = paddle_out_grads[:1]
+                torch_out_grads = torch_out_grads[:1]
             elif self.api_config.api_name in {
                 "paddle.combinations",
                 "paddle.nn.utils.parameters_to_vector",
@@ -441,53 +381,35 @@ class APITestAccuracy(APITestBase):
 
             if isinstance(paddle_out_grads, paddle.Tensor):
                 if isinstance(torch_out_grads, torch.Tensor):
-                    try:
-                        if paddle_out_grads.dtype == paddle.bfloat16:
-                            paddle_out_grads = paddle.cast(paddle_out_grads, dtype="float32")
-                            torch_out_grads = torch_out_grads.to(dtype=torch.float32)
-                        # self.np_assert_accuracy(paddle_out_grads.numpy(), torch_out_grads.numpy(), atol=self.atol, rtol=self.rtol)
-                        self.torch_assert_accuracy(paddle_out_grads, torch_out_grads, atol=self.atol, rtol=self.rtol)
-                    except Exception as err:
-                        print("[accuracy error] backward ", self.api_config.config, "\n", str(err), flush=True)
-                        write_to_log("accuracy_error", self.api_config.config)
+                    if not compare_paddle_and_torch(paddle_output, torch_output):
                         return
                 else:
-                    print("[accuracy error] backward ", self.api_config.config, "\n[output type diff error1], ", type(torch_out_grads), flush=True)
+                    print("[accuracy error] backward", self.api_config.config, "\n[output type diff error1], ", type(torch_out_grads), flush=True)
                     write_to_log("accuracy_error", self.api_config.config)
                     return
             elif isinstance(paddle_out_grads, (list, tuple)):
-                if isinstance(paddle_out_grads, tuple):
-                    paddle_out_grads = list(paddle_out_grads)
                 if not isinstance(torch_out_grads, (list, tuple)):
                     print("[output type diff error]", self.api_config.config, flush=True)
                     return
-                if isinstance(torch_out_grads, tuple):
-                    torch_out_grads = list(torch_out_grads)
+                paddle_out_grads = list(paddle_out_grads)
+                torch_out_grads = list(torch_out_grads)
                 if len(paddle_out_grads) != len(torch_out_grads):
-                    print("[accuracy error] backward ", self.api_config.config, "\n[output type diff error2], ", len(paddle_out_grads), len(torch_out_grads), flush=True)
+                    print("[accuracy error] backward", self.api_config.config, "\n[output type diff error2], ", len(paddle_out_grads), len(torch_out_grads), flush=True)
                     write_to_log("accuracy_error", self.api_config.config)
                     return
-                for i in range(len(paddle_out_grads)):
-                    if isinstance(paddle_out_grads[i], int):
-                        self.np_assert_accuracy(numpy.array(paddle_out_grads[i]), numpy.array(torch_out_grads[i]), atol=self.atol, rtol=self.rtol)
-                    elif not isinstance(paddle_out_grads[i], paddle.Tensor):
-                        print("[not compare] ", paddle_out_grads[i], torch_out_grads[i], flush=True)
+                for paddle_item, torch_item in zip(paddle_out_grads, torch_out_grads):
+                    if isinstance(paddle_item, int):
+                        self.np_assert_accuracy(numpy.array(paddle_item), numpy.array(torch_item), atol=self.atol, rtol=self.rtol)
+                    elif not isinstance(paddle_item, paddle.Tensor):
+                        print("[not compare]", paddle_item, torch_item, flush=True)
                         write_to_log("accuracy_error", self.api_config.config)
                         return
-                    elif not isinstance(torch_out_grads[i], torch.Tensor):
-                        print("[accuracy error] backward ", self.api_config.config, "\n[output type diff error3], ", type(torch_out_grads[i]), flush=True)
+                    elif not isinstance(torch_item, torch.Tensor):
+                        print("[accuracy error] backward", self.api_config.config, "\n[output type diff error3], ", type(torch_out_grads[i]), flush=True)
                         write_to_log("accuracy_error", self.api_config.config)
                         return
                     else:
-                        try:
-                            if paddle_out_grads[i].dtype == paddle.bfloat16:
-                                paddle_out_grads[i] = paddle.cast(paddle_out_grads[i], dtype="float32")
-                                torch_out_grads[i] = torch_out_grads[i].to(dtype=torch.float32)
-                            # self.np_assert_accuracy(paddle_out_grads[i].numpy(), torch_out_grads[i].numpy(), atol=self.atol, rtol=self.rtol)
-                            self.torch_assert_accuracy(paddle_out_grads[i], torch_out_grads[i], atol=self.atol, rtol=self.rtol)
-                        except Exception as err:
-                            print("[accuracy error] backward ", self.api_config.config, "\n", str(err), flush=True)
-                            write_to_log("accuracy_error", self.api_config.config)
+                        if not compare_paddle_and_torch(paddle_output, torch_output):
                             return
 
         print("[Pass]", self.api_config.config, flush=True)

--- a/tester/accuracy.py
+++ b/tester/accuracy.py
@@ -256,10 +256,10 @@ class APITestAccuracy(APITestBase):
 
 
         self.is_backward = False
-        def compare_paddle_and_torch(paddle_output, torch_output) -> bool:
+        def compare_paddle_and_torch(paddle_tensor, torch_tensor) -> bool:
             try:
-                # self.np_assert_accuracy(paddle_output.numpy(), torch_output.numpy(), atol=self.atol, rtol=self.rtol)
-                self.torch_assert_accuracy(paddle_output, torch_output, atol=self.atol, rtol=self.rtol)
+                # self.np_assert_accuracy(paddle_tensor.numpy(), torch_tensor.numpy(), atol=self.atol, rtol=self.rtol)
+                self.torch_assert_accuracy(paddle_tensor, torch_tensor, atol=self.atol, rtol=self.rtol)
             except Exception as err:
                 if self.is_backward:
                     print(f"[accuracy error] backward {self.api_config.config}\n{str(err)}", flush=True)
@@ -312,7 +312,7 @@ class APITestAccuracy(APITestBase):
                     write_to_log("accuracy_error", self.api_config.config)
                     return
                 else:
-                    if not compare_paddle_and_torch(paddle_output, torch_output):
+                    if not compare_paddle_and_torch(paddle_item, torch_item):
                         return
 
         if torch_grad_success:
@@ -381,7 +381,7 @@ class APITestAccuracy(APITestBase):
 
             if isinstance(paddle_out_grads, paddle.Tensor):
                 if isinstance(torch_out_grads, torch.Tensor):
-                    if not compare_paddle_and_torch(paddle_output, torch_output):
+                    if not compare_paddle_and_torch(paddle_out_grads, torch_out_grads):
                         return
                 else:
                     print("[accuracy error] backward", self.api_config.config, "\n[output type diff error1], ", type(torch_out_grads), flush=True)
@@ -409,7 +409,7 @@ class APITestAccuracy(APITestBase):
                         write_to_log("accuracy_error", self.api_config.config)
                         return
                     else:
-                        if not compare_paddle_and_torch(paddle_output, torch_output):
+                        if not compare_paddle_and_torch(paddle_item, torch_item):
                             return
 
         print("[Pass]", self.api_config.config, flush=True)

--- a/tester/api_config/config_analyzer.py
+++ b/tester/api_config/config_analyzer.py
@@ -1882,7 +1882,7 @@ class TensorConfig:
             )
             self.paddle_tensor.stop_gradient = False
             if self.dtype == "bfloat16":
-                self.paddle_tensor = paddle.cast(self.paddle_tensor, dtype="uint16")
+                self.paddle_tensor = paddle.cast(self.paddle_tensor, dtype="bfloat16")
         return self.paddle_tensor
 
     def get_torch_tensor(self, api_config):

--- a/tester/base.py
+++ b/tester/base.py
@@ -103,11 +103,12 @@ class APITestBase:
             return False
 
         if self.api_config.api_name == "paddle.assign":
-            has_list_arg = len(self.paddle_args) and isinstance(
-                self.paddle_args[0], list
+            has_list_arg = len(self.paddle_args_config) and isinstance(
+                self.paddle_args_config[0], list
             )
             has_second_arg = (
-                len(self.paddle_args) > 1 and self.paddle_args[1] is not None
+                len(self.paddle_args_config) > 1
+                and self.paddle_args_config[1] is not None
             )
             if has_list_arg or has_second_arg:
                 return False


### PR DESCRIPTION
## 问题定位:
1. `bf16` 类型的 `paddle_output` 在比较时（反向传播前）被 cast 至 `fp32` ，并未转回；在后续梯度生成时，生成为 `fp32` 的梯度，再进行反向传播，与期望测试逻辑不一致；
2. `bf16` 类型 `torch_output` 在反向传播前并未 cast，梯度生成同样为 `fp32` ，但是 torch 支持 `fp32` 至 `bf16` 的梯度传播；而 paddle `fp32` 至 `bf16` 的梯度传播会报错.

## 问题修复:
`torch_assert_accuracy` 支持 `bf16` 的 Tensor 比较了，因此不再需要 cast 至 `fp32` :
1.  优化 `output` 、 `out_grads` 的比较逻辑，直接删除 cast，提取复用代码，使得测试逻辑更一致
3. 修复 `get_paddle_tensor` 的 cast 类型为 `bf16`
4. 修复 `gen_paddle_output_and_output_grad` 、 `gen_torch_output_and_output_grad` ，使得生成梯度与输出类型一致
5. 修复 `need_check_grad` 中 `paddle.assign` 测试时 `self.paddle_args` 不存在的问题

## 测试:
全量测试 `tester/api_config/5_accuracy/accuracy_8.txt` ，全部通过:
<img width="740" height="312" alt="image" src="https://github.com/user-attachments/assets/bce0e0fa-94c6-4d0d-8ae7-5bf3af604995" />
