### PR TITLE
[Skip] erroneous input configs

### DIFF
--- a/tester/api_config/torch_error_skip.txt
+++ b/tester/api_config/torch_error_skip.txt
@@ -15,6 +15,7 @@ paddle.logcumsumexp(Tensor([357913942, 12],"float16"), dtype="float16", axis=Non
 paddle.logcumsumexp(Tensor([1073741824, 4],"float32"), )
 paddle.logcumsumexp(Tensor([1073741824, 4],"float32"), dtype="float32", )
 paddle.matmul(x=Tensor([4, 1073741825],"float16"), y=Tensor([1073741825],"float16"), transpose_x=False, transpose_y=True, )
+paddle.matmul(Tensor([1431655766],"float16"), Tensor([3, 1431655766],"float16"), False, True, )
 paddle.nn.functional.adaptive_avg_pool1d(Tensor([178956971, 3, 8],"float16"), 2, None, )
 paddle.nn.functional.adaptive_avg_pool1d(Tensor([2, 142606337, 8],"float32"), 2, None, )
 paddle.nn.functional.adaptive_avg_pool1d(Tensor([2, 268435457, 8],"float16"), 2, None, )
@@ -1764,3 +1765,4 @@ paddle.nn.functional.conv3d_transpose(x=Tensor([2, 3, 2, 2, 2],"float64"), weigh
 paddle.nn.functional.conv3d_transpose(x=Tensor([2, 3, 2, 2, 2],"float64"), weight=Tensor([3, 1, 3, 79536432, 3],"float64"), bias=Tensor([1],"float64"), stride=1, padding=list[1,0,1,], dilation=1, )
 paddle.nn.functional.conv3d_transpose(x=Tensor([2, 3, 2, 2, 2],"float64"), weight=Tensor([3, 1, 79536432, 3, 3],"float64"), bias=Tensor([1],"float64"), stride=1, padding=1, dilation=1, )
 paddle.nn.functional.conv3d_transpose(x=Tensor([2, 3, 2, 2, 2],"float64"), weight=Tensor([3, 1, 79536432, 3, 3],"float64"), bias=Tensor([1],"float64"), stride=1, padding=list[1,0,1,], dilation=1, )
+paddle.nn.functional.nll_loss(Tensor([95070891, 3, 2, 4],"float32"), Tensor([95070891, 2, 4],"int64"),)


### PR DESCRIPTION
1. skip掉一个概率性错误：
下图展示了nll_loss api 在 ‘mean’模式下， 3次运行中两次正确，1次错误；
具体原因为输出的结果很小，是1e-5次方量级，而最终完成的计算是一个很大的reduce， 因此累加误差容易超过期望值，造成误差报错。
但其实torch 和paddle在nll_loss上的逻辑是对齐的。且能一定概率通过说明了API的正确性，对于累计误差的不确定，可能跟很多因素有关。因此建议去掉该用例。
<img width="1146" height="683" alt="截屏2025-07-23 17 56 59" src="https://github.com/user-attachments/assets/1e494405-6892-45fe-9bf7-f5ec93b83560" />

3. skip掉一个torch cuda 700错误：
<img width="857" height="125" alt="截屏2025-07-22 15 40 38" src="https://github.com/user-attachments/assets/8a2b5d07-d582-454b-8572-5638ee83f9d7" />
