### PR TITLE
[PHI] Using `_process_file_handlers`, add `BUFFER_SIZE`

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -8,7 +8,7 @@ from datetime import datetime
 
 from tester import (APIConfig, APITestAccuracy, APITestCINNVSDygraph,
                     APITestPaddleOnly,APITestPaddleGPUPerformance, APITestTorchGPUPerformance, APITestPaddleTorchGPUPerformance, set_cfg)
-from tester.api_config.log_writer import read_log, write_to_log
+from tester.api_config.log_writer import read_log, write_to_log, close_process_files
 import torch
 import paddle
 
@@ -184,6 +184,8 @@ def main():
         #         print(str(res.stdout.read(), encoding="utf-8"), flush=True)
         #         print(str(res.stderr.read(), encoding="utf-8"), flush=True)
         #         # res.terminate()
+
+    close_process_files()
 
 if __name__ == '__main__':
     main()

--- a/engineV2.py
+++ b/engineV2.py
@@ -220,6 +220,7 @@ def init_worker_gpu(
             torch.cuda.empty_cache()
             paddle.device.cuda.empty_cache()
             restore_stdio()
+            close_process_files()
             sys.exit(0)
 
         signal.signal(signal.SIGINT, signal_handler)

--- a/tester/api_config/log_writer.py
+++ b/tester/api_config/log_writer.py
@@ -27,8 +27,9 @@ LOG_PREFIXES = {
     "oom": "api_config_oom",
 }
 
-is_engineV2 = False
+_is_engineV2 = False
 
+_process_file_handlers = {}
 
 # Command line arguments configuration
 # Used in engine.py
@@ -55,23 +56,31 @@ def set_test_log_path(log_dir):
 
 
 def set_engineV2():
-    global is_engineV2
-    is_engineV2 = True
+    global _is_engineV2
+    _is_engineV2 = True
     TMP_LOG_PATH.mkdir(exist_ok=True)
+
+
+def close_process_files():
+    """关闭本进程持有的所有文件句柄"""
+    global _process_file_handlers
+    for handler in _process_file_handlers.values():
+        try:
+            handler.close()
+        except Exception as err:
+            print(f"Error closing cached file: {err}", flush=True)
+    _process_file_handlers = {}
 
 
 def get_log_file(log_type: str):
     """获取指定日志类型和PID对应的日志文件路径"""
     if log_type not in LOG_PREFIXES:
         raise ValueError(f"Invalid log type: {log_type}")
-
     prefix = LOG_PREFIXES[log_type]
-
-    if not is_engineV2:
+    if not _is_engineV2:
         cfg = get_cfg()
         filename = f"{prefix}{cfg.id}.txt" if cfg else f"{prefix}.txt"
         return TEST_LOG_PATH / filename
-
     pid = os.getpid()
     return TMP_LOG_PATH / f"{prefix}_{pid}.txt"
 
@@ -81,12 +90,12 @@ def write_to_log(log_type, line):
     line = line.strip()
     if not line:
         return
-
     file_path = get_log_file(log_type)
-
     try:
-        with file_path.open("a") as f:
-            f.write(line + "\n")
+        if file_path not in _process_file_handlers:
+            _process_file_handlers[file_path] = file_path.open("a", buffering=1)
+        handler = _process_file_handlers[file_path]
+        handler.write(line + "\n")
     except Exception as err:
         print(f"Error writing to {file_path}: {err}", flush=True)
 
@@ -95,12 +104,10 @@ def read_log(log_type):
     """读取文件所有行，返回集合"""
     if log_type not in LOG_PREFIXES:
         raise ValueError(f"Invalid log type: {log_type}")
-
     cfg = get_cfg()
     prefix = LOG_PREFIXES[log_type]
     filename = f"{prefix}{cfg.id}.txt" if cfg else f"{prefix}.txt"
     file_path = TEST_LOG_PATH / filename
-
     try:
         with file_path.open("r") as f:
             return set(line.strip() for line in f if line.strip())
@@ -155,19 +162,24 @@ def aggregate_logs(end=False):
     log_success = True
     log_file = TEST_LOG_PATH / f"log_inorder.log"
     tmp_log_files = sorted(TMP_LOG_PATH.glob(f"log_*.log"))
+    BUFFER_SIZE = 4 * 1024 * 1024
     try:
         with log_file.open("ab") as out_f:
             for file_path in tmp_log_files:
                 try:
                     with file_path.open("rb") as in_f:
-                        for line in in_f:
-                            if len(line) > 10000:  # 如果行长度超过10000字节，截断
-                                print(
-                                    f"Truncating long line ({len(line)} bytes) in {file_path.name}"
-                                )
-                                out_f.write(line[:10000] + b"\n")
-                            else:
-                                out_f.write(line)
+                        while True:
+                            lines = in_f.readlines(BUFFER_SIZE)
+                            if not lines:
+                                break
+                            for line in lines:
+                                if len(line) > 10000:  # 如果行长度超过10000字节，截断
+                                    print(
+                                        f"Truncating long line ({len(line)} bytes) in {file_path.name}"
+                                    )
+                                    out_f.write(line[:10000] + b"\n")
+                                else:
+                                    out_f.write(line)
                 except Exception as err:
                     print(f"Error reading {file_path}: {err}", flush=True)
                     log_success = False
@@ -394,5 +406,5 @@ def log_accuracy_tolerance(error_msg, api, config, dtype, is_backward=False):
                     ]
                 )
             writer.writerow(row)
-    except Exception as e:
-        print(f"Error writing to {output_file}: {e}", flush=True)
+    except Exception as err:
+        print(f"Error writing to {output_file}: {err}", flush=True)

--- a/tester/api_config/log_writer.py
+++ b/tester/api_config/log_writer.py
@@ -68,7 +68,7 @@ def close_process_files():
         try:
             handler.close()
         except Exception as err:
-            print(f"Error closing cached file: {err}", flush=True)
+            print(f"Error closing process file: {err}", flush=True)
     _process_file_handlers = {}
 
 


### PR DESCRIPTION
## PaddleAPITest 性能提升

### 问题分析:
主要瓶颈点位于 `log_writer.py` :
1. `write_to_log()` 频繁打开关闭文件
2. `aggregate_logs()` 逐行读取写入

因此在现有框架下做最小修改:
1. 新增 `_process_file_handlers` ，进程长期持有句柄，`buffering=1` 每行写入
2. 新增 `BUFFER_SIZE` ，进行块级读取

### 测试:
在 5k 配置下测试 `accuracy_stable` ，进程数 21，总用时提升约 44% (18min->10min)
<img width="834" height="914" alt="image" src="https://github.com/user-attachments/assets/f4c341b3-8201-40a8-82cc-edf75900aacc" />
<img width="804" height="798" alt="image" src="https://github.com/user-attachments/assets/31050932-68b3-4e28-8d83-0275c2b1d1f0" />
