### PR TITLE
[BIG tensor]adjust tolerance of lerp op

### DIFF
--- a/tester/base_config.yaml
+++ b/tester/base_config.yaml
@@ -28,6 +28,7 @@ special_accuracy_atol_rtol:
   paddle.Tensor.logcumsumexp: [1.0, 1.0]
   paddle.incubate.nn.functional.fused_bias_act: [1, 0.01]
   paddle.incubate.nn.functional.fused_rms_norm : [3, 0.5]
+  paddle.lerp : [5, 0.05]
 
 # All configs that report dtype diff when not in not_check_dtype list should be
 # copied to tester/api_config/5_accuracy/accuracy_gpu_error_dtype_diff.txt


### PR DESCRIPTION
# 目前lerp实现是反向计算方式相同正确的:
1. 反向计算方式相同
    paddle: Paddle/paddle/phi/kernels/gpu/lerp_grad_kernel.cu:252
    torch:  pytorch/tools/autograd/derivatives.yaml:936
2. 不存在溢出情况，运算仅包含加法，乘法，也没有特殊值错误情况。
3. 测试用例有时可以通过

# 误差原因：
    测试配置都牵扯到broadcast, 计算有大元素reduce操作，不同cuda配置，reduce过程中不同加和过程会引起浮点数的截断误差不同。

因此建议提升容忍度。且因为错误用例最后需要进行大张量reduce, torch参考值本身数值很大，需要提高绝对误差的最大容忍度。相对误差略提高即可。