### PR TITLE
[BIG tensor] remove improper api config

### DIFF
--- a/tester/api_config/torch_error_skip.txt
+++ b/tester/api_config/torch_error_skip.txt
@@ -1924,4 +1924,6 @@ paddle.nn.functional.margin_ranking_loss(Tensor([429496730, 10],"float16"), Tens
 paddle.nn.functional.margin_ranking_loss(Tensor([429496730, 10],"float16"), Tensor([429496730, 10],"float16"), Tensor([429496730, 10],"float16"), 0.2, "sum", )
 paddle.nn.functional.margin_ranking_loss(Tensor([429496730, 10],"float16"), Tensor([429496730, 10],"float16"), Tensor([429496730, 10],"float16"), 0.2, "sum", None, )
 paddle.linalg.multi_dot(list[Tensor([4],"float16"),Tensor([4, 1073741825],"float16"),Tensor([1073741825, 2],"float16"),Tensor([2],"float16"),], )
+paddle.nn.functional.margin_cross_entropy(Tensor([1073741825, 2],"float16"), label=Tensor([1073741825],"int64"), margin1=1.0, margin2=0.5, margin3=0.0, scale=64.0, group=None, return_softmax=False, reduction="mean", )
+paddle.nn.functional.margin_cross_entropy(Tensor([1073741825, 2],"float16"), label=Tensor([1073741825],"int64"), margin1=1.0, margin2=0.7, margin3=0.2, scale=32.0, group=None, return_softmax=False, reduction="mean", )
 


### PR DESCRIPTION
1. api正确性：
margin_cross_loss float16实现为全float32实现，torch拆为多个算子，计算精度采用float32,中间结果存储用float16， 误差来自大tensor reduce过程,和torch中间结果丢失的精度，提升精度后改不一致可消除。
2. 测试用例中已经有相同数据规模的测试用例，可以删除该config，该config reduce 维度过高，容易报出误差。
### 源码：
paddle:
/host_home/xiazichao/Paddle/paddle/phi/kernels/gpu/margin_cross_entropy_kernel.cu:19
采用数值稳定的计算方式。新版本对float16直接提升精度到f32
torch：
/host_home/xiazichao/PaddleAPITest/tester/paddle_to_torch/rules.py:3689
margin_cross_entropy -> 分为 log_softmax (float16->float32) +  nll_loss   （float16 -> float32）
pytorch/aten/src/ATen/native/LossNLL.cpp:695
-> pytorch/aten/src/ATen/native/cuda/Loss.cu:224