### PR TITLE
[BIG tensor] fix config for preventing torch error

### DIFF
--- a/report/big_tensor_gpu/error_config.txt
+++ b/report/big_tensor_gpu/error_config.txt
@@ -7234,7 +7234,7 @@ paddle.nn.functional.cross_entropy(Tensor([230, 512, 1024, 19],"float32"), Tenso
 paddle.nn.functional.cross_entropy(Tensor([252645136, 17],"float16"), Tensor([252645136],"int64"), reduction="none", )
 paddle.nn.functional.cross_entropy(Tensor([25928425, 4, 22],"float32"), Tensor([25928425, 4],"int64"), reduction="none", )
 paddle.nn.functional.cross_entropy(Tensor([286331154, 15],"float16"), Tensor([286331154],"int64"), weight=None, ignore_index=-100, reduction="none", soft_label=False, axis=-1, use_softmax=True, label_smoothing=0.0, name=None, )
-paddle.nn.functional.cross_entropy(Tensor([3, 2, 2, 357913942],"float16"), Tensor([3, 2, 2],"int64"), soft_label=True, label_smoothing=0.7336344401714625, axis=-1, weight=None, reduction="none", )
+paddle.nn.functional.cross_entropy(Tensor([3, 2, 2, 207913942],"float32"), Tensor([3, 2, 2],"int64"), soft_label=True, label_smoothing=0.7336344401714625, axis=-1, weight=None, reduction="none", )
 paddle.nn.functional.cross_entropy(Tensor([3292499, 7, 99],"float32"), Tensor([3292499, 7, 1],"int64"), weight=None, ignore_index=-100, reduction="none", soft_label=False, axis=-1, use_softmax=True, label_smoothing=0.0, name=None, )
 paddle.nn.functional.cross_entropy(Tensor([3292499, 7, 99],"float32"), Tensor([3292499, 7, 1],"int64"), weight=None, ignore_index=0, reduction="none", soft_label=False, axis=-1, use_softmax=True, label_smoothing=0.0, name=None, )
 paddle.nn.functional.cross_entropy(Tensor([39269, 125, 125, 7],"float16"), Tensor([39269, 125, 125],"int64"), weight=Tensor([7],"float16"), ignore_index=255, reduction="none", soft_label=False, axis=-1, use_softmax=True, label_smoothing=0.0, name=None, )


### PR DESCRIPTION
## torch 在f16， soft_label 模式下 cross_entropy 存在数值稳定性错误，会溢出，提升精度f32后torch不会溢出
```
[accuracy error] paddle.nn.functional.cross_entropy(Tensor([3, 2, 2, 357913942],"float16"), Tensor([3, 2, 2],"int64"), soft_label=True, label_smoothing=0.7336344401714625, axis=-1, weight=None, reduction="none", )
Not equal to tolerance rtol=0.01, atol=0.01
Tensor-likes are not close!

Mismatched elements: 12 / 12 (100.0%)
Greatest absolute difference: inf at index (0, 0, 0, 0) (up to 0.01 allowed)
Greatest relative difference: nan at index (0, 0, 0, 0) (up to 0.01 allowed)
ACTUAL: (shape=torch.Size([3, 2, 2, 1]), dtype=torch.float16)
tensor([[[[5.3867],
          [5.1484]],

        ...

         [[5.1641],
          [5.1367]]]], dtype=torch.float16)
DESIRED: (shape=torch.Size([3, 2, 2, 1]), dtype=torch.float16)
tensor([[[[inf],
          [inf]],

         ...
         [[inf],
          [inf]]]], dtype=torch.float16)
```
