### PR TITLE
[BIG tensor] Adjust tolerance for matmul and bilinear

### DIFF
--- a/tester/base_config.yaml
+++ b/tester/base_config.yaml
@@ -44,7 +44,8 @@ special_accuracy_atol_rtol:
   paddle.nn.functional.interpolate: [0.5, 1.5]
   paddle.incubate.nn.functional.fused_bias_dropout_residual_layer_norm: [1.0, 1.0]
   paddle.nn.functional.softmax: [1, 0.01]
-
+  paddle.matmul: [2.0, 0.05]
+  paddle.nn.functional.bilinear: [2.0, 0.08]
 
 # All configs that report dtype diff when not in not_check_dtype list should be
 # copied to tester/api_config/5_accuracy/accuracy_gpu_error_dtype_diff.txt


### PR DESCRIPTION
matmul 和 bilinear 的误差容忍度需要增大：
1. 正确性：均调用了封装好的cublas api，且没有其他错误。且提升精度后可以pass。而不同精度使用同一套模板函数。
2. 原因分析： matmul, bilinear 在完成矩阵乘法的时候都存在维度K的reduce， reduce过程中，cublas会根据需要采用不同配置。导致reduce过程中加法的顺序并不是相同的，比如torch , paddle可能分别采用不同长度和数目组数来做组间reduce, 这一过程会引起舍入误差。由于reduce数目巨大，绝对误差容易过大，而适当调大相对误差到0.05， 0.08 就可以避免问题。

### bilinear
1. paddle:
   paddle/phi/kernels/impl/bilinear_kernel_impl.h:25
   ->cublas.GEMM
2. torch:
   pytorch/aten/src/ATen/native/Linear.cpp:709
   ->bilinear -> _trilinear -> 自定义函数

### matmul
1. paddle:
  paddle/phi/kernels/impl/matmul_kernel_impl.h:505
   ->cublasGemmStridedBatchedEx
2. torch:
  pytorch/aten/src/ATen/cuda/CUDABlas.cpp:670
  -> cublasGemmStridedBatchedEx