### PR TITLE
[Accuracy diff No.96] Fix accuracy diff for paddle.incubate.nn.functional.variable_length_memory_efficient_attention API

### DIFF
--- a/tester/api_config/config_analyzer.py
+++ b/tester/api_config/config_analyzer.py
@@ -1825,9 +1825,8 @@ class TensorConfig:
                     v_seq_len = self.get_arg(api_config, 2, "value").shape[2]
                     self.numpy_tensor = self.get_random_numpy_tensor(shape=self.shape, data_type=self.dtype, min=1, max=min(k_seq_len, v_seq_len))
                 elif self.check_arg(api_config, 5, "mask"):
-                    # mask should between -inf and 0 (0 is included)
-                    eps = numpy.finfo(self.dtype).eps
-                    self.numpy_tensor = self.get_random_numpy_tensor(shape=self.shape, data_type=self.dtype, max=0 + eps)
+                    # mask should be -inf(masked) or 0(not masked)
+                    self.numpy_tensor = numpy.random.randint(0, 2, size=self.shape).astype(self.dtype) * (numpy.finfo(self.dtype).min)
             elif api_config.api_name == "paddle.zeros":
                 self.numpy_tensor = numpy.random.randint(0, 2048, size = self.shape)
                 

--- a/tester/paddle_to_torch/rules.py
+++ b/tester/paddle_to_torch/rules.py
@@ -6343,8 +6343,8 @@ def variable_length_memory_efficient_attention(
     if key.shape[1] != num_heads:
         # Repeat key and value along the num_heads dimension
         repeat_factor = num_heads // key.shape[1]
-        key = key.repeat(1, repeat_factor, 1, 1)
-        value = value.repeat(1, repeat_factor, 1, 1)
+        key = key.unsqueeze(2).expand(-1,-1, repeat_factor, -1, -1).reshape(batch_size, num_heads, key_seq_len, head_size)
+        value = value.unsqueeze(2).expand(-1,-1, repeat_factor, -1, -1).reshape(batch_size, num_heads, key_seq_len, head_size)
     # Default scale if not provided
     if scale is None:
         scale = math.sqrt(1.0 / head_size)
@@ -6373,8 +6373,8 @@ def variable_length_memory_efficient_attention(
     qk_res = torch.matmul(query, key.transpose(-1, -2))  # [batch_size, num_heads, query_seq_len, key_seq_len]
     # Apply scale
     attention = qk_res * scale
-    attention = attention.masked_fill(~seq_mask, torch.finfo(attention.dtype).min)
     attention = attention + mask
+    attention = attention.masked_fill(~seq_mask, torch.finfo(attention.dtype).min)
     # Softmax over the last dimension
     softmax_result = torch.nn.functional.softmax(attention, dim=-1)
     softmax_result = softmax_result.masked_fill(~seq_mask, 0.0)


### PR DESCRIPTION
修复 `variable_length_memory_efficient_attention` API 的两处地方。Paddle 中该 API 的实现是调用 cutlass 的，所以认为它的实现正确，以修改 PaddleAPITest 框架为主。

1. `tester/api_config/config_analyzer.py`：`mask` 数组中的元素要么是 -inf 要么是 0，在计算时 attention 的结果加上 mask 再执行 softmax 即可完成 mask 掉某些元素的效果。
2. `tester/paddle_to_torch/rules.py`：修复了 K 和 V 扩展 head_dim 的方法；修复了 mask 和 mask_fill 顺序，前者应该在前否则它会覆盖掉 mask_fill 的结果