### PR TITLE
 [Big tensor] Refine some configurations for topk

### DIFF
--- a/tester/accuracy.py
+++ b/tester/accuracy.py
@@ -231,6 +231,7 @@ class APITestAccuracy(APITestBase):
             "paddle.incubate.nn.functional.fused_layer_norm",
             "paddle.kthvalue",
             "paddle.Tensor.kthvalue",
+            "paddle.topk",
         }:
             paddle_output = paddle_output[0]
             torch_output = torch_output[0]

--- a/tester/api_config/config_analyzer.py
+++ b/tester/api_config/config_analyzer.py
@@ -1738,7 +1738,7 @@ class TensorConfig:
                     elif self.dtype == "float16":
                         self.numpy_tensor = generate_unique_array(x_numel, self.dtype).reshape(self.shape)
                     elif self.dtype in {"int32", "int64"}:
-                        self.numpy_tensor = numpy.random.choice(numpy.arange(-x_numel, x_numel), size=self.shape, replace=False).astype(self.dtype)
+                        self.numpy_tensor = self.get_random_numpy_tensor(self.shape, self.dtype, min=1)
                     else:
                         raise ValueError(f"Unsupported dtype {self.dtype} for paddle.topk / paddle.Tensor.topk")
                 elif self.check_arg(api_config, 1, "k"):


### PR DESCRIPTION
- 设置topk仅检测topk的结果对齐，topk算子返回会topk 的结果和结果的索引信息，结果是不稳定排序，所以与torch无需在索引上对齐
- 优化topk int类型numpy_tensor生成速度