### PR TITLE
fix paddle.linalg.matrix_rank

### DIFF
--- a/report/big_tensor_gpu/error_config.txt
+++ b/report/big_tensor_gpu/error_config.txt
@@ -2604,8 +2604,6 @@ paddle.linalg.matrix_norm(x=Tensor([2, 3, 715827883],"float16"), p=-math.inf, ax
 paddle.linalg.matrix_norm(x=Tensor([2, 3, 715827883],"float16"), p=-math.inf, axis=list[0,1,], keepdim=True, )
 paddle.linalg.matrix_norm(x=Tensor([2, 536870913, 4],"float16"), p=-math.inf, axis=list[0,1,], keepdim=False, )
 paddle.linalg.matrix_norm(x=Tensor([2, 536870913, 4],"float16"), p=-math.inf, axis=list[0,1,], keepdim=True, )
-paddle.linalg.matrix_rank(Tensor([3, 47721859, 5, 6],"float32"), None, False, )
-paddle.linalg.matrix_rank(x=Tensor([2, 67108865, 4, 4],"float64"), tol=None, hermitian=True, )
 paddle.linalg.matrix_rank(x=Tensor([4, 1073741824],"float32"), tol=None, hermitian=False, )
 paddle.linalg.multi_dot(list[Tensor([1073741825],"float16"),Tensor([1073741825, 4],"float16"),Tensor([4, 2],"float16"),Tensor([2],"float16"),], )
 paddle.linalg.multi_dot(list[Tensor([4],"float16"),Tensor([4, 1073741825],"float16"),Tensor([1073741825, 2],"float16"),Tensor([2],"float16"),], )

--- a/report/big_tensor_gpu/error_config_paddleonly.txt
+++ b/report/big_tensor_gpu/error_config_paddleonly.txt
@@ -657,8 +657,6 @@ paddle.kthvalue(x=Tensor([3, 2, 357913942],"float64"), k=4, axis=2, keepdim=Fals
 paddle.kthvalue(x=Tensor([3, 2, 357913942],"float64"), k=4, axis=2, keepdim=True, )
 paddle.linalg.lu(Tensor([2, 429496730, 5],"float32"), )
 paddle.linalg.lu(Tensor([2, 429496730, 5],"float32"), pivot=True, get_infos=True, )
-paddle.linalg.matrix_rank(Tensor([3, 47721859, 5, 6],"float32"), None, False, )
-paddle.linalg.matrix_rank(x=Tensor([2, 67108865, 4, 4],"float64"), tol=None, hermitian=True, )
 paddle.linalg.matrix_rank(x=Tensor([4, 1073741824],"float32"), tol=None, hermitian=False, )
 paddle.linalg.svd(Tensor([10737419, 100, 2],"float64"), full_matrices=False, )
 paddle.linalg.svdvals(Tensor([10, 429496730],"float32"), )

--- a/tester/base_config.yaml
+++ b/tester/base_config.yaml
@@ -30,6 +30,7 @@ paddle_error_dismiss:
   paddle.nn.functional.class_center_sample:
     - "(InvalidArgument) The total number of elements for 'label' should be less than"
     - "(InvalidArgument) Illegal memory allocation, total allocated space must be greater than 0"
+  paddle.linalg.matrix_rank: "(PreconditionNotMet) The element size of x should be <= INT_MAX(2147483647)"
 
 # some accuracy error can be considered tolerable
 special_accuracy_atol_rtol:


### PR DESCRIPTION
### 1. 背景
paddle.linalg.matrix_rank：用于计算输入矩阵的秩（Rank），基于NVIDIA cuSOLVER库提供的奇异值分解（SVD）实现。
例：paddle.linalg.matrix_rank(Tensor([3, 47721859, 5, 6],"float32"), None, False, )
shape`[3, 47721859, 5, 6]`中
- `[3,47721859]`是batchSize。
- `[5,6]`是单个batch。

代码核心逻辑
```
for (int i = 0; i < batchSize; ++i){
  // single batch
  dynload::cusolverDnCgesvdj(…)
}
```
### 2. 现有问题：
- 单个batch的元素数超过INT32限制时报错。[Paddle显式检查报错](https://github.com/PaddlePaddle/Paddle/pull/74406)
- 耗时与batchSize成正比，对示例`[3, 47721859, 5, 6]`耗时达10h+。
### 3. 解决方案
- INT32限制时报错添加到paddle_error_dismiss。
- 删除耗时过长config。
### 4. 其他
Torch行为：显式报错。已添加到[torch_error_skip.txt](https://github.com/PFCCLab/PaddleAPITest/pull/492)