### PR TITLE
[BIG tensor] refine layer_norm tolerance and config

### DIFF
--- a/tester/api_config/torch_error_skip.txt
+++ b/tester/api_config/torch_error_skip.txt
@@ -3057,3 +3057,5 @@ paddle.nn.functional.normalize(x=Tensor([4, 25565282, 6, 7],"float16"), p=4, axi
 paddle.nn.functional.normalize(x=Tensor([4, 5, 30678338, 7],"float16"), p=4, axis=3, )
 paddle.nn.functional.normalize(x=Tensor([4, 5, 6, 35791395],"float16"), p=4, )
 paddle.dist(x=Tensor([10],"float16"), y=Tensor([429496730, 10],"float16"), p=4, )
+paddle.nn.functional.layer_norm(Tensor([20069, 209, 1024],"float32"), 1024, weight=Tensor([1024],"float32"), bias=Tensor([1024],"float32"), epsilon=1e-05, )
+paddle.nn.functional.layer_norm(Tensor([25421, 165, 1024],"float32"), 1024, weight=Tensor([1024],"float32"), bias=Tensor([1024],"float32"), epsilon=1e-05, )

--- a/tester/base_config.yaml
+++ b/tester/base_config.yaml
@@ -45,7 +45,7 @@ special_accuracy_atol_rtol:
   paddle.incubate.nn.functional.fused_rms_norm : [3, 0.5]
   paddle.incubate.nn.functional.fused_layer_norm: [1, 0.01]
   paddle.lerp : [5, 0.05]
-  paddle.nn.functional.layer_norm : [5, 0.05]
+  paddle.nn.functional.layer_norm : [0.2, 0.02]
   paddle.nn.functional.upsample: [0.5, 1.5]
   paddle.nn.functional.interpolate: [0.5, 1.5]
   paddle.incubate.nn.functional.fused_bias_dropout_residual_layer_norm: [1.0, 1.0]


### PR DESCRIPTION
1. 根据理论误差，改进了layer_norm 的tolerance
2. 跳过了两个torch出错的配置



【公式分析】
1. 以下面用例来计算理论误差：paddle.nn.functional.layer_norm(normalized_shape=tuple(2,3), x=Tensor([715827883, 2, 3],"float16"),  先计算相对误差，再计算绝对误差；
3. 预备
float32 的机器精度为 3e-8， float16的机器精度为 5e-4
数据产生为[0,1 ]的正态分布，并-0.5，故均值为0， 一阶范数为0.5
同时reduce sum的误差计算公式如下：

<img width="640" height="283" alt="截屏2025-08-05 11 43 41" src="https://github.com/user-attachments/assets/982ec96b-8e6b-4d10-ac27-4812bf1467c3" />
因此6个数字  layer_norm 计算均值操作产生的相对误差为  5e-4 * 6 = 3e-3
同理，方差操作产生的相对误差为  3 e-3
经过除法之后相对误差仍旧为  3e-3, 乘法和加法产生的误差较小，最终相对误差为6e-3。

对于反向，根据以下公式
<img width="440" height="104" alt="backward" src="https://github.com/user-attachments/assets/237f4400-d59e-42fc-a280-3c9c6c42cd9e" />
可以看出后两项的reduce误差也为6e-3
不同之处在于，第一项后面出现了减法，减法可能尝尝出现灾难误差，故最大相对误差肯定大于6e-3, 保守估计为  2e-2。
且由于大tensor 下实际运行发现反向结果最大值接近100， 因此绝对误差最大值为0.6。

【torch 错误】
发现大tensor下torch存在计算错误，以下两个配置对最后一维度进行归一化，然而torch结果中，最后一维度有连续一个batch是零的现象，这与计算公式不符。降低shape到numeric_limits<int>::max()后torch计算正确，不再出现reduce一维度连续元素为零现象。

配置1：
paddle.nn.functional.layer_norm(Tensor([20069, 209, 1024],"float32"), 1024, weight=Tensor([1024],"float32"), bias=Tensor([1024],"float32"), epsilon=1e-05, )
配置2：
paddle.nn.functional.layer_norm(Tensor([25421, 165, 1024],"float32"), 1024, weight=Tensor([1024],"float32"), bias=Tensor([1024],"float32"), epsilon=1e-05, )

这些配置的torch 结果 如下：
```
   [[[ ...,

        [[ 0.4547,  0.2267, -0.0967,  ...,  0.4445, -0.5311, -0.4847],
         [ 0.2731,  0.2462, -0.0509,  ..., -0.4345,  0.8531, -0.4088],
         [ 0.3087,  0.2616,  0.0206,  ..., -0.1682,  0.5124,  0.5244],
         ...,
         [ 0.3193,  0.2453, -0.2020,  ..., -0.3585,  0.7591,  0.5007],
         [ 0.4050,  0.2157, -0.2476,  ...,  0.0665, -0.4005,  0.7150],
         [ 0.2808,  0.2655, -0.1950,  ...,  0.2131,  0.3006, -0.3509]],

        [[ 0.3285,  0.2284, -0.4037,  ...,  0.1499,  0.5375, -0.1046],
         [ 0.2877,  0.2519, -0.2357,  ...,  0.5233, -0.3993,  0.7020],
         [ 0.4827,  0.2416, -0.2869,  ...,  0.2136,  0.9542,  0.6891],
         ...,
         [ 0.4534,  0.2387, -0.2801,  ..., -0.1281, -0.5914, -0.1426],
         [ 0.3495,  0.2588, -0.4314,  ..., -0.3876,  0.8238, -0.3501],
         [ 0.4763,  0.2296, -0.3351,  ...,  0.6186,  0.2520,  0.7515]],

        [[ 0.4093,  0.2292,  0.0306,  ..., -0.3288,  0.1918, -0.5007],
         [ 0.4820,  0.2669, -0.3738,  ..., -0.2235,  0.0285,  0.4642],
         [ 0.4677,  0.2339, -0.3509,  ..., -0.4322,  0.7380,  0.7601],
         ...,
         [ 0.0000,  0.0000,  0.0000,  ...,  0.0000,  0.0000,  0.0000],
         [ 0.0000,  0.0000,  0.0000,  ...,  0.0000,  0.0000,  0.0000],
         [ 0.0000,  0.0000,  0.0000,  ...,  0.0000,  0.0000,  0.0000]]]
```


【源码分析】
pytorch:
  layer_norm_cuda
  layer_norm_backward_cuda
  pytorch/aten/src/ATen/native/cuda/layer_norm_kernel.cu
     ->vectorized_layer_norm_kernel_impl. (line 211)

paddle:
  Paddle/paddle/phi/kernels/funcs/layer_norm_impl.cu.h