### PR TITLE
Fix grad_outputs placement in Paddle output grad generation

### DIFF
--- a/tester/base.py
+++ b/tester/base.py
@@ -610,6 +610,7 @@ class APITestBase:
             result_output_grad = paddle.to_tensor(
                 numpy_tensor,
                 dtype=dtype if dtype != "bfloat16" else "float32",
+                place=result_outputs[i].place,
             )
             result_output_grad.stop_gradient = False
             if dtype == "bfloat16":


### PR DESCRIPTION
本 pr 意图修复的问题如下：

```
python engine.py --paddle_only=True --api_config='paddle.Tensor.__getitem__(Tensor([2],"int64"), Tensor([2],"bool"), )'
# xpu:有时pass，有时报错。报错如下
# W1214 11:52:23.806428 1370665 xpu_context.cc:187] Please NOTE: xpu device: 0
W1214 11:52:23.816443 1370665 backward.cc:685] While running Node (MaskedSelectGradNode) raises an EnforceNotMet exception
[paddle error] paddle.Tensor.__getitem__(Tensor([2],"int64"), Tensor([2],"bool"), )
(External) masked_select_grad XDNN Error <1>, XDNN_INVALID_PARAM  (at /framework/Paddle/paddle/phi/kernels/xpu/masked_select_grad_kernel.cc:50)
```

根因是 PaddleAPITest 在做 `paddle.grad(...)` 时生成的 grad_outputs 没指定 device/place，默认落到 CPU；对 XPU 的 `slice_grad(complex64)` 来说，这会触发一条隐式的 CPU→XPU 转换路径，最终把 out_grad 变成了一个只有 meta、
  没有实际内存的 `Tensor(holder_ == null)`，于是 SliceGradNode 里一旦访问 `out_grad.data()` 就报 `Tensor holds no memory`；GPU 上这条隐式拷贝路径是 OK 的所以能过。