### PR TITLE
chore: replace deprecated pynvml with nvidia-ml-py

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ paddle.concat(tuple(Tensor([31376, 768],"float32"),Tensor([1, 768],"float32"),),
    ```
    - 安装第三方库：
    ```bash
-   pip install func_timeout pandas pebble pynvml pyyaml typer
+   pip install func_timeout pandas pebble nvidia-ml-py pyyaml typer
    ```
 
 4. PaddlePaddle 与 PyTorch 的部分依赖项可能发生冲突，请先安装 *paddlepaddle-gpu* 再安装 *torch*，重新安装请在 pip 后添加 `--force-reinstall` 参数，仅更新 paddle 请添加 `--no-deps` 参数；engineV2 建议使用 python>=3.10

--- a/engineV2-README.md
+++ b/engineV2-README.md
@@ -22,7 +22,7 @@
     ```bash
     pip install --pre paddlepaddle-gpu -i https://www.paddlepaddle.org.cn/packages/nightly/cu118/
     pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu118
-    pip install func_timeout pandas pebble pynvml pyyaml
+    pip install func_timeout pandas pebble nvidia-ml-py pyyaml
     ```
 2. 克隆 PaddleAPITest 仓库并进入项目目录
    ```bash

--- a/test_pipline/CINN/README_test_cinn.md
+++ b/test_pipline/CINN/README_test_cinn.md
@@ -29,7 +29,7 @@
 4. 安装第三方库
 
    ```bash
-   pip install pandas pebble pynvml pyyaml
+   pip install pandas pebble nvidia-ml-py pyyaml
    ```
 
 ### 2. 准备测试集

--- a/test_pipline/V2/cpu_0size.md
+++ b/test_pipline/V2/cpu_0size.md
@@ -23,7 +23,7 @@
 5. 安装第三方库
 
    ```bash
-   pip install func_timeout pebble pynvml
+   pip install func_timeout pebble nvidia-ml-py
    ```
 
 ### 2. 准备测试集

--- a/test_pipline/V2/cpu_accuracy.md
+++ b/test_pipline/V2/cpu_accuracy.md
@@ -23,7 +23,7 @@
 5. 安装第三方库
 
    ```bash
-   pip install func_timeout pebble pynvml
+   pip install func_timeout pebble nvidia-ml-py
    ```
 
 ### 2. 准备测试集

--- a/test_pipline/V2/gpu_0size.md
+++ b/test_pipline/V2/gpu_0size.md
@@ -23,7 +23,7 @@
 5. 安装第三方库
 
    ```bash
-   pip install func_timeout pebble pynvml
+   pip install func_timeout pebble nvidia-ml-py
    ```
 
 ### 2. 准备测试集

--- a/test_pipline/V2/gpu_accuracy.md
+++ b/test_pipline/V2/gpu_accuracy.md
@@ -23,7 +23,7 @@
 5. 安装第三方库
 
    ```bash
-   pip install func_timeout pebble pynvml
+   pip install func_timeout pebble nvidia-ml-py
    ```
 
 ### 2. 准备测试集

--- a/test_pipline/V2/gpu_accuracy_tolerance.md
+++ b/test_pipline/V2/gpu_accuracy_tolerance.md
@@ -23,7 +23,7 @@
 5. 安装第三方库
 
    ```bash
-   pip install pebble pynvml pandas
+   pip install pebble nvidia-ml-py pandas
    ```
 
 ### 2. 准备测试集

--- a/test_pipline/V2/gpu_bigtensor.md
+++ b/test_pipline/V2/gpu_bigtensor.md
@@ -23,7 +23,7 @@
 5. 安装第三方库
 
    ```bash
-   pip install func_timeout pebble pynvml
+   pip install func_timeout pebble nvidia-ml-py
    ```
 
 ### 2. 准备测试集

--- a/test_pipline/V2/monitor_script/cpu_0size.md
+++ b/test_pipline/V2/monitor_script/cpu_0size.md
@@ -23,7 +23,7 @@
 5. 安装第三方库
 
    ```bash
-   pip install func_timeout pebble pynvml
+   pip install func_timeout pebble nvidia-ml-py
    ```
 
 ### 2. 准备测试集

--- a/test_pipline/V2/monitor_script/gpu_0size.md
+++ b/test_pipline/V2/monitor_script/gpu_0size.md
@@ -23,7 +23,7 @@
 5. 安装第三方库
 
    ```bash
-   pip install func_timeout pebble pynvml
+   pip install func_timeout pebble nvidia-ml-py
    ```
 
 ### 2. 准备测试集


### PR DESCRIPTION
https://github.com/gpuopenanalytics/pynvml has been marked as deprecated by the official repository, and now relies on nvidia-ml-py. This PR replaces pynvml with nvidia-ml-py.