### PR TITLE
feat: add fused_act_dequant to forward_only_apis and remove NaN check in paddle_only mode

### DIFF
--- a/tester/base_config.yaml
+++ b/tester/base_config.yaml
@@ -173,6 +173,7 @@ forward_only_apis:
   - moe_permute
   - moe_unpermute
   - fp8_quant_blockwise
+  - fused_act_dequant
   - __and__
   - __eq__
   - __floordiv__

--- a/tester/paddle_only.py
+++ b/tester/paddle_only.py
@@ -77,39 +77,6 @@ class APITestPaddleOnly(APITestBase):
             write_to_log("paddle_error", self.api_config.config)
             return
 
-        # NaN check on forward output
-        if paddle_output is not None:
-            has_nan = False
-            try:
-                if isinstance(paddle_output, paddle.Tensor):
-                    if paddle_output.dtype in (
-                        paddle.float16,
-                        paddle.float32,
-                        paddle.float64,
-                        paddle.bfloat16,
-                    ):
-                        has_nan = bool(paddle.isnan(paddle_output).any())
-                elif isinstance(paddle_output, (list, tuple)):
-                    for t in paddle_output:
-                        if isinstance(t, paddle.Tensor) and t.dtype in (
-                            paddle.float16,
-                            paddle.float32,
-                            paddle.float64,
-                            paddle.bfloat16,
-                        ):
-                            if bool(paddle.isnan(t).any()):
-                                has_nan = True
-                                break
-            except Exception:
-                pass
-            if has_nan:
-                paddle_output = None
-                result_outputs = None
-                result_outputs_grads = None
-                print(f"[nan] {self.api_config.config}", flush=True)
-                write_to_log("nan", self.api_config.config)
-                return
-
         try:
             paddle.base.core.eager._for_test_check_cuda_error()
         except Exception as err:


### PR DESCRIPTION
- 将 `fused_act_dequant` 加入 `forward_only_apis` 列表，使其仅执行前向测试
- 移除 `paddle_only.py` 中前向输出的 NaN 检查逻辑
