### PR TITLE
docs: fix script and module references

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ paddle.concat(tuple(Tensor([31376, 768],"float32"),Tensor([1, 768],"float32"),),
        * to_0_size*.py 是篡改为 0-size 配置的工具
        * to_big_size\*.py 是篡改为大形状张量的配置的工具。 
 
-   * tester/paddle2torch/ 是转换能力的核心代码。介绍详见 [4. paddle2torch转换](#4-paddle2torch转换)
+   * tester/paddle_to_torch/ 是转换能力的核心代码。介绍详见 [4. paddle2torch转换](#4-paddle2torch转换)
 
 3. tools 文件夹中存放了一些实用的工具，例如 move_config.py 可以用来批量的移动配置，error_stat.py 可以一键解析错误日志等。
 

--- a/test_pipline/V2/monitor_script/cpu_0size.md
+++ b/test_pipline/V2/monitor_script/cpu_0size.md
@@ -34,7 +34,7 @@
 
 
 ### 4. 执行测试
-``` bash test_pipline/V2/monitor_script/run_gpu_0size_full.sh ```
+``` bash test_pipline/V2/monitor_script/run_cpu_0size_full.sh ```
 
 
 最终的所有测试结果会保存在测试脚本中```LOG_DIR```指定的目录下，比如 `tester/api_config/test_log_cpu_0size_full` 目录，包括：


### PR DESCRIPTION
## Summary
- Update EngineV2 docs to reference the existing `run-example.sh` script.
- Fix the Paddle-to-Torch module path in README.
- Correct the CPU 0-size monitor command to use `run_cpu_0size_full.sh`.

## Test
- `git diff --check`
- Verified referenced script and module paths exist.