### PR TITLE
APITest 测试修复：修复非连续 Tensor 构造时的 NaN/Inf 误报

### DIFF
--- a/tester/api_config/config_analyzer.py
+++ b/tester/api_config/config_analyzer.py
@@ -240,8 +240,20 @@ class TensorConfig:
             self.dtype = "float32"
 
         if self.numpy_tensor is None:
-            # Special handling for optimizer APIs: use zeros for moment tensors
-            if (
+            if api_config.api_name in {"paddle.Tensor.view", "paddle.view"}:
+                if (
+                    self.check_arg(api_config, 0, "x")
+                    and original_dtype == "uint8"
+                    and str(self.get_arg(api_config, 1, "shape_or_dtype", "")) == "paddle.bfloat16"
+                ):
+                    bf16_numel = math.prod(self.shape) // 2
+                    finite_float32 = ((numpy.random.random(bf16_numel) - 0.5) * 1.2).astype(
+                        "float32"
+                    )
+                    self.numpy_tensor = (
+                        (finite_float32.view("uint32") >> 16).astype("uint16").view("uint8")
+                    )
+            elif (
                 api_config.api_name in optimizer_apis
                 and self.index in optimizer_apis[api_config.api_name]
             ):
@@ -2900,28 +2912,34 @@ class TensorConfig:
 
     def _create_strided_paddle_tensor(self, api_config):
         """Create a non-contiguous paddle tensor from the shared logical numpy input."""
-        intermediate_dtype = (
-            "float16" if self.dtype in ["float8_e5m2", "float8_e4m3fn"] else self.dtype
-        )
-        flat_tensor = paddle.empty(
-            [self._strided_storage_size()],
-            dtype=intermediate_dtype,
-            device=self.place,
-        )
-        tensor = paddle.as_strided(flat_tensor, self.shape, self.strides)
-        logical_tensor = self.get_numpy_tensor(api_config)
-        if logical_tensor.size > 0:
-            tensor[...] = paddle.to_tensor(
-                logical_tensor,
-                dtype=intermediate_dtype,
-                place=self.place,
+        flag_name = "FLAGS_check_nan_inf"
+        original_flag = paddle.get_flags([flag_name])
+        paddle.set_flags({flag_name: False})
+        try:
+            intermediate_dtype = (
+                "float16" if self.dtype in ["float8_e5m2", "float8_e4m3fn"] else self.dtype
             )
-        if self.dtype in ["float8_e5m2", "float8_e4m3fn"]:
-            flat_tensor = paddle.cast(flat_tensor, dtype=self.dtype)
+            flat_tensor = paddle.empty(
+                [self._strided_storage_size()],
+                dtype=intermediate_dtype,
+                device=self.place,
+            )
             tensor = paddle.as_strided(flat_tensor, self.shape, self.strides)
+            logical_tensor = self.get_numpy_tensor(api_config)
+            if logical_tensor.size > 0:
+                tensor[...] = paddle.to_tensor(
+                    logical_tensor,
+                    dtype=intermediate_dtype,
+                    place=self.place,
+                )
+            if self.dtype in ["float8_e5m2", "float8_e4m3fn"]:
+                flat_tensor = paddle.cast(flat_tensor, dtype=self.dtype)
+                tensor = paddle.as_strided(flat_tensor, self.shape, self.strides)
 
-        tensor.stop_gradient = False
-        return tensor
+            tensor.stop_gradient = False
+            return tensor
+        finally:
+            paddle.set_flags(original_flag)
 
     def get_torch_tensor(self, api_config):
         device = torch.device("cuda:0") if torch.cuda.is_available() else torch.device("cpu")


### PR DESCRIPTION
修复非连续 Tensor 构造在开启 `FLAGS_check_nan_inf=true` 时触发 NaN/Inf 误报的问题。

## 🎯 主要改进

- 在构造 strided Paddle tensor 时临时关闭并恢复 `FLAGS_check_nan_inf`，覆盖 `as_strided` 和填充 strided view 的中间过程。
- 针对 `paddle.Tensor.view(uint8 -> bfloat16)` 生成有限 bf16 bit pattern，避免随机字节重解释出 NaN/Inf。
 
## 📝 技术细节

**修改文件**：`tester/api_config/config_analyzer.py`

| 修改位置 | 内容 | 影响 |
|---------|------|------|
| `get_numpy_tensor()` | 新增 `paddle.view` bf16 分支 | 确保生成的 uint8 数据转为 bf16 时合法 |
| `_create_strided_paddle_tensor()` | 包装为 try-finally 结构，临时关闭 NaN 检查 | 消除 as_strided 操作中 NaN/Inf 误报 |

### ✅ 验证

经过测试，所有发生过 `(PreconditionNotMet) There are NAN or INF` 报错的**拥有非连续输入**配置均通过测试。