### PR TITLE
APITest 测试基建：支持 compute-sanitizer 测试，优化日志聚合效果

### DIFF
--- a/engineV2.py
+++ b/engineV2.py
@@ -923,7 +923,7 @@ def main():
             config_files = [options.api_config_file]
 
         # when engineV2 was interrupted, resume from .tmp dir
-        aggregate_logs()
+        aggregate_logs(cleanup=True)
 
         # read checkpoint
         finish_configs = read_log("checkpoint")

--- a/engineV4.py
+++ b/engineV4.py
@@ -6,13 +6,15 @@ import multiprocessing as mp
 import os
 import queue
 import re
+import shlex
 import shutil
 import signal
 import subprocess
 import sys
 import threading
 import time
-from dataclasses import dataclass, field
+from collections import deque
+from dataclasses import dataclass
 from datetime import datetime
 from multiprocessing import cpu_count, set_start_method
 from pathlib import Path
@@ -60,6 +62,33 @@ VALID_TEST_ARGS = {
     "exit_on_error",
 }
 
+SANITIZER_FORWARD_ARGS = {
+    "accuracy",
+    "paddle_only",
+    "paddle_cinn",
+    "paddle_gpu_performance",
+    "torch_gpu_performance",
+    "paddle_torch_gpu_performance",
+    "accuracy_stable",
+    "paddle_custom_device",
+    "custom_device_vs_gpu",
+    "custom_device_vs_gpu_mode",
+    "test_amp",
+    "test_cpu",
+    "use_cached_numpy",
+    "log_dir",
+    "required_memory",
+    "atol",
+    "rtol",
+    "test_tol",
+    "test_backward",
+    "show_runtime_status",
+    "random_seed",
+    "bitwise_alignment",
+    "generate_failed_tests",
+    "exit_on_error",
+}
+
 DEVICE_TYPE = None
 DEVICE_TYPE_DETECTED = False
 DEVICE_COUNT = None  # total number of devices
@@ -92,7 +121,71 @@ class WorkerSlot:
     input_queue: mp.Queue | None = None
     current_task: str | None = None
     task_start_time: float | None = None
+    child_pid: int | None = None
     state: str = "dead"  # dead, starting, idle, busy
+
+
+def _init_worker_runtime(slot_index, gpu_id, options, *, redirect_output):
+    if options.log_dir:
+        set_test_log_path(options.log_dir)
+    set_engineV2()
+
+    if gpu_id is not None:
+        os.environ["CUDA_VISIBLE_DEVICES"] = str(gpu_id)
+
+    import paddle
+    import torch
+
+    try:
+        import paddlefleet_ops  # noqa: F401
+    except ImportError:
+        pass
+    try:
+        import FusedQuantOps  # noqa: F401
+    except ImportError:
+        pass
+
+    globals()["torch"] = torch
+    globals()["paddle"] = paddle
+
+    from tester import (
+        APIConfig,
+        APITestAccuracy,
+        APITestAccuracyStable,
+        APITestCINNVSDygraph,
+        APITestCustomDeviceVSCPU,
+        APITestPaddleDeviceVSGPU,
+        APITestPaddleGPUPerformance,
+        APITestPaddleOnly,
+        APITestPaddleTorchGPUPerformance,
+        APITestTorchGPUPerformance,
+    )
+
+    test_classes = {
+        "APIConfig": APIConfig,
+        "APITestAccuracy": APITestAccuracy,
+        "APITestCINNVSDygraph": APITestCINNVSDygraph,
+        "APITestPaddleOnly": APITestPaddleOnly,
+        "APITestPaddleGPUPerformance": APITestPaddleGPUPerformance,
+        "APITestTorchGPUPerformance": APITestTorchGPUPerformance,
+        "APITestPaddleTorchGPUPerformance": APITestPaddleTorchGPUPerformance,
+        "APITestAccuracyStable": APITestAccuracyStable,
+        "APITestCustomDeviceVSCPU": APITestCustomDeviceVSCPU,
+        "APITestPaddleDeviceVSGPU": APITestPaddleDeviceVSGPU,
+    }
+    globals().update(test_classes)
+
+    if options.test_cpu:
+        paddle.device.set_device("cpu")
+
+    if redirect_output:
+        redirect_stdio()
+
+    if slot_index is not None and gpu_id is not None:
+        print(
+            f"{datetime.now()} Worker PID: {os.getpid()}, Slot: {slot_index}, GPU: {gpu_id}",
+            flush=True,
+        )
 
 
 def _worker_loop(slot_index, gpu_id, input_queue, result_queue, options):
@@ -112,64 +205,8 @@ def _worker_loop(slot_index, gpu_id, input_queue, result_queue, options):
     "ready".
     """
     # ── GPU initialization (equivalent to init_worker_gpu) ──
-    if options.log_dir:
-        set_test_log_path(options.log_dir)
-    set_engineV2()
-
-    os.environ["CUDA_VISIBLE_DEVICES"] = str(gpu_id)
-
     try:
-        import paddle
-        import torch
-
-        try:
-            import paddlefleet_ops  # noqa: F401
-        except ImportError:
-            pass
-        try:
-            import FusedQuantOps  # noqa: F401
-        except ImportError:
-            pass
-
-        globals()["torch"] = torch
-        globals()["paddle"] = paddle
-
-        from tester import (
-            APIConfig,
-            APITestAccuracy,
-            APITestAccuracyStable,
-            APITestCINNVSDygraph,
-            APITestCustomDeviceVSCPU,
-            APITestPaddleDeviceVSGPU,
-            APITestPaddleGPUPerformance,
-            APITestPaddleOnly,
-            APITestPaddleTorchGPUPerformance,
-            APITestTorchGPUPerformance,
-        )
-
-        test_classes = {
-            "APIConfig": APIConfig,
-            "APITestAccuracy": APITestAccuracy,
-            "APITestCINNVSDygraph": APITestCINNVSDygraph,
-            "APITestPaddleOnly": APITestPaddleOnly,
-            "APITestPaddleGPUPerformance": APITestPaddleGPUPerformance,
-            "APITestTorchGPUPerformance": APITestTorchGPUPerformance,
-            "APITestPaddleTorchGPUPerformance": APITestPaddleTorchGPUPerformance,
-            "APITestAccuracyStable": APITestAccuracyStable,
-            "APITestCustomDeviceVSCPU": APITestCustomDeviceVSCPU,
-            "APITestPaddleDeviceVSGPU": APITestPaddleDeviceVSGPU,
-        }
-        globals().update(test_classes)
-
-        if options.test_cpu:
-            paddle.device.set_device("cpu")
-
-        redirect_stdio()
-
-        print(
-            f"{datetime.now()} Worker PID: {os.getpid()}, Slot: {slot_index}, GPU: {gpu_id}",
-            flush=True,
-        )
+        _init_worker_runtime(slot_index, gpu_id, options, redirect_output=True)
     except Exception as e:
         print(f"{datetime.now()} Worker {os.getpid()} init failed: {e}", flush=True)
         result_queue.put(("init_failed", slot_index, str(e)))
@@ -208,6 +245,132 @@ def _worker_loop(slot_index, gpu_id, input_queue, result_queue, options):
         pass
 
 
+def _format_cli_value(value):
+    if isinstance(value, bool):
+        return "True" if value else "False"
+    return str(value)
+
+
+def _build_sanitizer_case_command(api_config_str, options):
+    cmd = [
+        *shlex.split(options.sanitizer_command),
+        sys.executable,
+        str(Path(__file__).resolve()),
+        f"--api_config={api_config_str}",
+        "--_sanitizer_child=True",
+    ]
+    for key in sorted(SANITIZER_FORWARD_ARGS):
+        value = getattr(options, key, None)
+        if value is None:
+            continue
+        if isinstance(value, str) and value == "":
+            continue
+        if isinstance(value, bool) and not value:
+            continue
+        cmd.append(f"--{key}={_format_cli_value(value)}")
+    return cmd
+
+
+def _sanitizer_worker_loop(slot_index, gpu_id, input_queue, result_queue, options):
+    if options.log_dir:
+        set_test_log_path(options.log_dir)
+    set_engineV2()
+    redirect_stdio()
+
+    child_process = None
+
+    def terminate_child(*args):
+        if child_process is not None and child_process.poll() is None:
+            try:
+                os.killpg(child_process.pid, signal.SIGKILL)
+            except (ProcessLookupError, OSError):
+                child_process.kill()
+        raise SystemExit(1)
+
+    signal.signal(signal.SIGINT, terminate_child)
+    signal.signal(signal.SIGTERM, terminate_child)
+
+    try:
+        print(
+            f"{datetime.now()} Sanitizer worker PID: {os.getpid()}, Slot: {slot_index}, GPU: {gpu_id}",
+            flush=True,
+        )
+        result_queue.put(("ready", slot_index))
+
+        while True:
+            try:
+                task = input_queue.get()
+            except (EOFError, OSError):
+                break
+            if task is None:
+                break
+
+            api_config_str = task
+            result_queue.put(("ack", slot_index, api_config_str))
+            try:
+                cmd = _build_sanitizer_case_command(api_config_str, options)
+            except ValueError as err:
+                result_queue.put(("error", slot_index, api_config_str, str(err)))
+                continue
+            env = os.environ.copy()
+            env["CUDA_VISIBLE_DEVICES"] = str(gpu_id)
+
+            print(
+                f"{datetime.now()} Sanitizer slot {slot_index} launch: {' '.join(shlex.quote(part) for part in cmd)}",
+                flush=True,
+            )
+            try:
+                child_process = subprocess.Popen(
+                    cmd,
+                    env=env,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.STDOUT,
+                    text=True,
+                    encoding="utf-8",
+                    errors="replace",
+                    bufsize=1,
+                    start_new_session=True,
+                )
+            except OSError as err:
+                result_queue.put(("error", slot_index, api_config_str, str(err)))
+                continue
+            result_queue.put(("child", slot_index, child_process.pid))
+            output_lines = deque(maxlen=40)
+            try:
+                for line in child_process.stdout:
+                    output_lines.append(line)
+                    print(line, end="", flush=True)
+                returncode = child_process.wait()
+            finally:
+                if child_process.stdout is not None:
+                    child_process.stdout.close()
+
+            child_process = None
+            if returncode == 0:
+                result_queue.put(("done", slot_index, api_config_str))
+            elif returncode == 2:
+                output_tail = "".join(output_lines)
+                result_queue.put(("error", slot_index, api_config_str, output_tail))
+            else:
+                output_tail = "".join(output_lines)
+                result_queue.put(("crashed", slot_index, api_config_str, returncode, output_tail))
+    finally:
+        if child_process is not None and child_process.poll() is None:
+            try:
+                os.killpg(child_process.pid, signal.SIGKILL)
+            except (ProcessLookupError, OSError):
+                child_process.kill()
+            try:
+                child_process.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                pass
+        try:
+            close_process_files()
+            restore_stdio()
+        except Exception:
+            pass
+
+
 class WorkerPool:
     """Custom process pool with per-worker queues for fair GPU scheduling."""
 
@@ -222,6 +385,7 @@ class WorkerPool:
         self._shutdown_event = threading.Event()
         self._watchdog_thread = None
         self._lock = threading.Lock()  # protects slot state modifications
+        self._closed = False
 
         # Build worker slots: deterministic GPU assignment
         idx = 0
@@ -244,11 +408,40 @@ class WorkerPool:
         )
         self._watchdog_thread.start()
 
+    def _close_queue(self, q, *, cancel_join=False):
+        """Close a multiprocessing queue without letting cleanup errors mask test results."""
+        if q is None:
+            return
+        try:
+            if cancel_join:
+                q.cancel_join_thread()
+        except Exception:
+            pass
+        try:
+            q.close()
+        except Exception:
+            pass
+        if not cancel_join:
+            try:
+                q.join_thread()
+            except Exception:
+                pass
+
     def _spawn_worker(self, slot):
         """Spawn a new worker process for the given slot."""
+        if self._closed or self._shutdown_event.is_set():
+            return False
+        if slot.process is not None and not slot.process.is_alive():
+            self._join_process(slot.process, timeout=1)
+        self._close_queue(slot.input_queue, cancel_join=True)
         slot.input_queue = mp.Queue()
+        worker_target = (
+            _sanitizer_worker_loop
+            if getattr(self.options, "use_compute_sanitizer", False)
+            else _worker_loop
+        )
         p = mp.Process(
-            target=_worker_loop,
+            target=worker_target,
             args=(slot.index, slot.gpu_id, slot.input_queue, self.result_queue, self.options),
             daemon=True,
         )
@@ -257,6 +450,8 @@ class WorkerPool:
         slot.state = "starting"
         slot.current_task = None
         slot.task_start_time = None
+        slot.child_pid = None
+        return True
 
     def warmup(self, timeout=180):
         """Wait for all workers to report ready."""
@@ -328,15 +523,21 @@ class WorkerPool:
             slot.state = "idle"
             slot.current_task = None
             slot.task_start_time = None
+            slot.child_pid = None
 
     def _watchdog_loop(self):
         """Periodically check for timeouts and unexpectedly dead workers."""
         while not self._shutdown_event.is_set():
-            time.sleep(1.0)
+            if self._shutdown_event.wait(1.0):
+                break
             now = time.time()
 
             for slot in self.slots:
+                if self._shutdown_event.is_set():
+                    break
                 with self._lock:
+                    if self._shutdown_event.is_set():
+                        break
                     # Check timeout
                     if (
                         slot.state == "busy"
@@ -345,6 +546,9 @@ class WorkerPool:
                     ):
                         self._handle_timeout(slot)
                         continue
+
+                    if self._shutdown_event.is_set():
+                        break
 
                     # Check unexpected death
                     if (
@@ -356,26 +560,49 @@ class WorkerPool:
 
     def _handle_timeout(self, slot):
         """Kill timed-out worker and enqueue timeout result."""
+        if self._closed or self._shutdown_event.is_set():
+            return
         config = slot.current_task
         print(
             f"{datetime.now()} Watchdog: slot {slot.index} timeout, killing PID {slot.process.pid}",
             flush=True,
         )
+        self._kill_slot_child(slot)
         self._kill_process(slot.process)
+        if self._closed or self._shutdown_event.is_set():
+            return
         self.result_queue.put(("timeout", slot.index, config))
         self._spawn_worker(slot)
 
     def _handle_crash(self, slot):
         """Handle unexpectedly dead worker."""
+        if self._closed or self._shutdown_event.is_set():
+            return
         exitcode = slot.process.exitcode if slot.process else None
         config = slot.current_task
         print(
             f"{datetime.now()} Watchdog: slot {slot.index} died (exit={exitcode})",
             flush=True,
         )
+        if self._closed or self._shutdown_event.is_set():
+            return
         if config is not None:
             self.result_queue.put(("crashed", slot.index, config, exitcode))
         self._spawn_worker(slot)
+
+    def _kill_process_group(self, pid):
+        try:
+            os.killpg(pid, signal.SIGKILL)
+        except (ProcessLookupError, OSError):
+            try:
+                os.kill(pid, signal.SIGKILL)
+            except (ProcessLookupError, OSError):
+                pass
+
+    def _kill_slot_child(self, slot):
+        if slot.child_pid is not None:
+            self._kill_process_group(slot.child_pid)
+            slot.child_pid = None
 
     def _sigkill_process(self, process):
         """Send SIGKILL to a process without waiting for it to exit."""
@@ -398,34 +625,45 @@ class WorkerPool:
         self._join_process(process, timeout=5)
 
     def shutdown(self, force=False):
-        """Stop all workers."""
+        """Stop all workers and release multiprocessing queues."""
+        if self._closed:
+            return
+        self._closed = True
         self._shutdown_event.set()
-
-        if not force:
-            # Graceful: send poison pills
-            for slot in self.slots:
-                if slot.input_queue is not None:
-                    try:
-                        slot.input_queue.put(None)
-                    except (OSError, EOFError):
-                        pass
-            for slot in self.slots:
-                if slot.process is not None:
-                    slot.process.join(timeout=10)
-                    if slot.process.is_alive():
-                        self._kill_process(slot.process)
-        else:
-            # Force: send SIGKILL to all workers first, then join all.
-            # This avoids serial join latency when many CUDA-deadlocked workers exist.
-            for slot in self.slots:
-                if slot.process is not None:
-                    self._sigkill_process(slot.process)
-            for slot in self.slots:
-                if slot.process is not None:
-                    self._join_process(slot.process, timeout=3)
 
         if self._watchdog_thread and self._watchdog_thread.is_alive():
             self._watchdog_thread.join(timeout=3)
+
+        try:
+            if not force:
+                # Graceful: send poison pills
+                for slot in self.slots:
+                    if slot.input_queue is not None:
+                        try:
+                            slot.input_queue.put(None)
+                        except (OSError, EOFError, ValueError):
+                            pass
+                for slot in self.slots:
+                    if slot.process is not None:
+                        slot.process.join(timeout=10)
+                        if slot.process.is_alive():
+                            self._kill_process(slot.process)
+            else:
+                # Force: send SIGKILL to all workers first, then join all.
+                # This avoids serial join latency when many CUDA-deadlocked workers exist.
+                for slot in self.slots:
+                    self._kill_slot_child(slot)
+                    if slot.process is not None:
+                        self._sigkill_process(slot.process)
+                for slot in self.slots:
+                    if slot.process is not None:
+                        self._join_process(slot.process, timeout=3)
+
+        finally:
+            for slot in self.slots:
+                self._close_queue(slot.input_queue, cancel_join=force)
+                slot.input_queue = None
+            self._close_queue(self.result_queue, cancel_join=force)
 
 
 def detect_device_type() -> str:
@@ -950,6 +1188,30 @@ def main():
         default=False,
         help="Whether to exit the process when a paddle_error occurs.",
     )
+    parser.add_argument(
+        "--use_compute_sanitizer",
+        type=parse_bool,
+        default=False,
+        help="Run each worker case in a compute-sanitizer wrapped subprocess.",
+    )
+    parser.add_argument(
+        "--sanitizer_command",
+        type=str,
+        default="compute-sanitizer --target-processes all --error-exitcode=86",
+        help="Command prefix used when --use_compute_sanitizer=True.",
+    )
+    parser.add_argument(
+        "--sanitizer_error_exitcode",
+        type=int,
+        default=86,
+        help="Exit code used by compute-sanitizer when it reports errors.",
+    )
+    parser.add_argument(
+        "--_sanitizer_child",
+        type=parse_bool,
+        default=False,
+        help=argparse.SUPPRESS,
+    )
 
     options = parser.parse_args()
     options.paddle_version = paddle_version
@@ -1029,6 +1291,23 @@ def main():
         options.rtol = 0.0
     if options.log_dir:
         set_test_log_path(options.log_dir)
+
+    if options._sanitizer_child:
+        try:
+            _init_worker_runtime(None, None, options, redirect_output=False)
+            options.api_config = options.api_config.strip()
+            run_test_case(options.api_config, options)
+        except SystemExit:
+            raise
+        except Exception as err:
+            print(f"[test error] {options.api_config}: {err}", flush=True)
+            sys.exit(2)
+        finally:
+            try:
+                close_process_files()
+            except Exception:
+                pass
+        return
 
     if options.api_config:
         # Single config execution
@@ -1158,7 +1437,7 @@ def main():
             config_files = [options.api_config_file]
 
         # when engineV2 was interrupted, resume from .tmp dir
-        aggregate_logs()
+        aggregate_logs(cleanup=True)
 
         # read checkpoint
         finish_configs = read_log("checkpoint")
@@ -1199,6 +1478,19 @@ def main():
                 flush=True,
             )
             return
+
+        if options.use_compute_sanitizer:
+            try:
+                sanitizer_cmd = shlex.split(options.sanitizer_command)
+            except ValueError as err:
+                print(f"invalid sanitizer_command: {err}", flush=True)
+                return
+            if not sanitizer_cmd:
+                print("sanitizer_command cannot be empty", flush=True)
+                return
+            if shutil.which(sanitizer_cmd[0]) is None:
+                print(f"sanitizer command not found: {sanitizer_cmd[0]}", flush=True)
+                return
 
         total_workers = sum(max_workers_per_gpu.values())
         print(
@@ -1270,10 +1562,20 @@ def main():
                         active_tasks += 1
                     continue
 
+                if msg_type == "child":
+                    slot_idx = msg[1]
+                    child_pid = msg[2]
+                    with pool._lock:
+                        pool.slots[slot_idx].child_pid = child_pid
+                    continue
+
                 # Task completed (done/error/timeout/crashed)
                 slot_idx = msg[1]
                 config = msg[2]
-                if msg_type in ("done", "error"):
+                worker_reusable = msg_type in ("done", "error") or (
+                    msg_type == "crashed" and options.use_compute_sanitizer
+                )
+                if worker_reusable:
                     pool.mark_idle(slot_idx)
                 active_tasks -= 1
                 tested_case += 1
@@ -1305,6 +1607,15 @@ def main():
                             f"[error] CUDA out of memory for {config}",
                             flush=True,
                         )
+                    elif (
+                        options.use_compute_sanitizer
+                        and exitcode == options.sanitizer_error_exitcode
+                    ):
+                        write_to_log("cuda_error", config)
+                        print(
+                            f"[error] compute-sanitizer reported errors for {config} (exit={exitcode})",
+                            flush=True,
+                        )
                     else:
                         write_to_log("crash", config)
                         print(
@@ -1323,8 +1634,8 @@ def main():
                 if next_config is None:
                     continue
 
-                # For timeout/crashed: worker is restarting, queue for later dispatch
-                if msg_type in ("timeout", "crashed"):
+                # For timeout/non-sanitizer crashed: worker is restarting, queue for later dispatch
+                if not worker_reusable:
                     pending_dispatch.append(next_config)
                 else:
                     # Worker is alive and ready for next task
@@ -1335,7 +1646,6 @@ def main():
                 if tested_case % 1000 == 0:
                     aggregate_logs()
 
-            aggregate_logs()
             pool.shutdown()
         except Exception as e:
             print(f"Unexpected error: {e}", flush=True)
@@ -1343,6 +1653,7 @@ def main():
             total_time = time.time() - start_time
             print(f"Test time: {round(total_time / 60, 3)} minutes.", flush=True)
         finally:
+            pool.shutdown()
             print(f"{tested_case} cases have been tested.", flush=True)
             log_counts = aggregate_logs(end=True)
             print_log_info(all_case, log_counts)

--- a/run-v4.sh
+++ b/run-v4.sh
@@ -19,6 +19,12 @@ ENGINE=engineV4           # engineV2 | engineV4
 FOREGROUND=false          # true=前台运行(调试用，Ctrl+C终止)
 DRY_RUN=false             # true=只打印最终命令，不执行
 
+# ── compute-sanitizer ─────────────────────────────────────────
+# true=由 engineV4 为每个 worker slot 单独启动 compute-sanitizer 子进程，保留多 GPU/多 worker 并发
+USE_COMPUTE_SANITIZER=false
+SANITIZER_COMMAND="compute-sanitizer --target-processes all --error-exitcode=86"
+SANITIZER_ERROR_EXITCODE=86
+
 # ── Paddle Flags ──────────────────────────────────────────────
 export FLAGS_use_system_allocator=true
 export FLAGS_check_cuda_error=true
@@ -152,11 +158,18 @@ TIME_OUT_ARGS=(
     --timeout="$TIME_OUT"
 )
 
+SANITIZER_ARGS=(
+    --use_compute_sanitizer="$USE_COMPUTE_SANITIZER"
+    --sanitizer_command="$SANITIZER_COMMAND"
+    --sanitizer_error_exitcode="$SANITIZER_ERROR_EXITCODE"
+)
+
 ALL_ARGS=(
     "${TEST_MODE_ARGS[@]}"
     "${IN_OUT_ARGS[@]}"
     "${PARALLEL_ARGS[@]}"
     "${TIME_OUT_ARGS[@]}"
+    "${SANITIZER_ARGS[@]}"
 )
 
 # ── 打印有效配置 ──
@@ -167,6 +180,7 @@ echo "  日志:    $LOG_DIR"
 echo "  GPU:     ids=$GPU_IDS  workers/gpu=$NUM_WORKERS_PER_GPU"
 echo "  超时:    ${TIME_OUT}s"
 echo "  模式:    ${TEST_MODE_ARGS[*]:-<无>}"
+echo "  Sanitizer: enabled=$USE_COMPUTE_SANITIZER exitcode=$SANITIZER_ERROR_EXITCODE command='$SANITIZER_COMMAND'"
 echo "────────────────────────────────────────────"
 
 # ── Dry-run 模式 ──
@@ -192,7 +206,7 @@ if [[ "$FOREGROUND" == "true" ]]; then
     echo ""
     python "$SCRIPT_DIR/$ENGINE.py" "${ALL_ARGS[@]}" 2>&1 | tee "$LOG_FILE"
 else
-    nohup python "$SCRIPT_DIR/$ENGINE.py" "${ALL_ARGS[@]}" >> "$LOG_FILE" 2>&1 &
+    nohup setsid python "$SCRIPT_DIR/$ENGINE.py" "${ALL_ARGS[@]}" >> "$LOG_FILE" 2>&1 &
     PYTHON_PID=$!
     echo "$PYTHON_PID" > "$PID_FILE"
 

--- a/tester/api_config/log_writer.py
+++ b/tester/api_config/log_writer.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import csv
+import io
 import os
 import re
 import shutil
@@ -35,6 +36,7 @@ LOG_PREFIXES = {
 _is_engineV2 = False
 
 _process_file_handlers = {}
+_aggregated_offsets = {}
 
 # Command line arguments configuration
 # Used in engine.py
@@ -123,24 +125,58 @@ def read_log(log_type):
         return set()
 
 
-def aggregate_logs(end=False):
+def _read_pending_bytes(file_path, end=False):
+    offset = _aggregated_offsets.get(file_path, 0)
+    file_size = file_path.stat().st_size
+    if file_size < offset:
+        offset = 0
+    if file_size == offset:
+        return b"", offset, offset
+    with file_path.open("rb") as f:
+        f.seek(offset)
+        data = f.read(file_size - offset)
+    if not end and data and not data.endswith(b"\n"):
+        last_newline = data.rfind(b"\n")
+        if last_newline < 0:
+            return b"", offset, offset
+        data = data[: last_newline + 1]
+        file_size = offset + last_newline + 1
+    return data, offset, file_size
+
+
+def _commit_aggregate_offset(file_path, offset, clear=False):
+    if clear:
+        _aggregated_offsets.pop(file_path, None)
+    else:
+        _aggregated_offsets[file_path] = offset
+
+
+def aggregate_logs(end=False, cleanup=False):
     """聚合所有相同类型的日志文件"""
-    if not TMP_LOG_PATH.exists() and not end:
+    should_cleanup_tmp = end or cleanup
+    tmp_exists = TMP_LOG_PATH.exists()
+    if not tmp_exists and not should_cleanup_tmp:
         TMP_LOG_PATH.mkdir(exist_ok=True)
         return
 
     all_success = True
     for prefix in LOG_PREFIXES.values():
-        log_files = list(TMP_LOG_PATH.glob(f"{prefix}_*.txt"))
+        log_files = list(TMP_LOG_PATH.glob(f"{prefix}_*.txt")) if tmp_exists else []
         if not log_files:
             continue
 
         prefix_success = True
         all_lines = set()
+        pending_offsets = {}
         for file_path in log_files:
             try:
-                with file_path.open("r") as f:
-                    all_lines.update(line.strip() for line in f if line.strip())
+                data, start_offset, end_offset = _read_pending_bytes(
+                    file_path, end=should_cleanup_tmp
+                )
+                pending_offsets[file_path] = end_offset
+                all_lines.update(
+                    line.strip() for line in data.decode().splitlines() if line.strip()
+                )
             except Exception as err:
                 print(f"Error reading {file_path}: {err}", flush=True)
                 prefix_success = False
@@ -151,8 +187,9 @@ def aggregate_logs(end=False):
 
         aggregated_file = TEST_LOG_PATH / f"{prefix}.txt"
         try:
-            with aggregated_file.open("a") as f:
-                f.writelines(f"{line}\n" for line in sorted(all_lines))
+            if all_lines:
+                with aggregated_file.open("a") as f:
+                    f.writelines(f"{line}\n" for line in sorted(all_lines))
         except Exception as err:
             print(f"Error writing to {aggregated_file}: {err}", flush=True)
             prefix_success = False
@@ -161,33 +198,37 @@ def aggregate_logs(end=False):
             aggregated_file.unlink(missing_ok=True)
             all_success = False
         else:
-            for file_path in log_files:
-                if end:
+            for file_path, offset in pending_offsets.items():
+                _commit_aggregate_offset(file_path, offset, clear=should_cleanup_tmp)
+                if should_cleanup_tmp:
                     file_path.unlink()
-                else:
-                    file_path.write_bytes(b"")
 
     log_success = True
     log_file = TEST_LOG_PATH / "log_inorder.log"
-    tmp_log_files = sorted(TMP_LOG_PATH.glob("log_*.log"))
+    tmp_log_files = sorted(TMP_LOG_PATH.glob("log_*.log")) if tmp_exists else []
     BUFFER_SIZE = 4 * 1024 * 1024
+    pending_log_offsets = {}
     try:
         with log_file.open("ab") as out_f:
             for file_path in tmp_log_files:
                 try:
-                    with file_path.open("rb") as in_f:
-                        while True:
-                            lines = in_f.readlines(BUFFER_SIZE)
-                            if not lines:
-                                break
-                            for line in lines:
-                                if len(line) > 200000:  # 如果行长度超过200000字节,截断
-                                    # print(
-                                    #     f"Truncating long line ({len(line)} bytes) in {file_path.name}"
-                                    # )
-                                    out_f.write(line[:200000] + b"\n")
-                                else:
-                                    out_f.write(line)
+                    data, start_offset, end_offset = _read_pending_bytes(
+                        file_path, end=should_cleanup_tmp
+                    )
+                    pending_log_offsets[file_path] = end_offset
+                    in_f = io.BytesIO(data)
+                    while True:
+                        lines = in_f.readlines(BUFFER_SIZE)
+                        if not lines:
+                            break
+                        for line in lines:
+                            if len(line) > 200000:  # 如果行长度超过200000字节,截断
+                                # print(
+                                #     f"Truncating long line ({len(line)} bytes) in {file_path.name}"
+                                # )
+                                out_f.write(line[:200000] + b"\n")
+                            else:
+                                out_f.write(line)
                 except Exception as err:
                     print(f"Error reading {file_path}: {err}", flush=True)
                     log_success = False
@@ -200,20 +241,21 @@ def aggregate_logs(end=False):
         log_file.unlink(missing_ok=True)
         all_success = False
     else:
-        for file_path in tmp_log_files:
-            if end:
+        for file_path, offset in pending_log_offsets.items():
+            _commit_aggregate_offset(file_path, offset, clear=should_cleanup_tmp)
+            if should_cleanup_tmp:
                 file_path.unlink()
-            else:
-                file_path.write_bytes(b"")
 
     tol_success = True
     tol_file = TEST_LOG_PATH / "tol.csv"
-    tmp_tol_files = sorted(TMP_LOG_PATH.glob("tol_*.csv"))
+    tmp_tol_files = sorted(TMP_LOG_PATH.glob("tol_*.csv")) if tmp_exists else []
     if tmp_tol_files:
+        pending_tol_offsets = {}
         try:
+            tol_is_new = not tol_file.exists() or tol_file.stat().st_size == 0
             with tol_file.open("a", newline="") as out_f:
                 writer = csv.writer(out_f)
-                if not tol_file.exists() or tol_file.stat().st_size == 0:
+                if tol_is_new:
                     writer.writerow(
                         [
                             "API",
@@ -226,12 +268,16 @@ def aggregate_logs(end=False):
                     )
                 for file_path in tmp_tol_files:
                     try:
-                        with file_path.open("r") as in_f:
-                            reader = csv.reader(in_f)
+                        data, start_offset, end_offset = _read_pending_bytes(
+                            file_path, end=should_cleanup_tmp
+                        )
+                        pending_tol_offsets[file_path] = end_offset
+                        reader = csv.reader(io.StringIO(data.decode()))
+                        if start_offset == 0:
                             next(reader, None)
-                            for row in reader:
-                                if row:  # 确保行不为空
-                                    writer.writerow(row)
+                        for row in reader:
+                            if row:  # 确保行不为空
+                                writer.writerow(row)
                     except Exception as err:
                         print(f"Error reading {file_path}: {err}", flush=True)
                         tol_success = False
@@ -244,20 +290,21 @@ def aggregate_logs(end=False):
             tol_file.unlink(missing_ok=True)
             all_success = False
         else:
-            for file_path in tmp_tol_files:
-                if end:
+            for file_path, offset in pending_tol_offsets.items():
+                _commit_aggregate_offset(file_path, offset, clear=should_cleanup_tmp)
+                if should_cleanup_tmp:
                     file_path.unlink()
-                else:
-                    file_path.write_bytes(b"")
 
     stable_success = True
     stable_file = TEST_LOG_PATH / "stable.csv"
-    tmp_stable_files = sorted(TMP_LOG_PATH.glob("stable_*.csv"))
+    tmp_stable_files = sorted(TMP_LOG_PATH.glob("stable_*.csv")) if tmp_exists else []
     if tmp_stable_files:
+        pending_stable_offsets = {}
         try:
+            stable_is_new = not stable_file.exists() or stable_file.stat().st_size == 0
             with stable_file.open("a", newline="") as out_f:
                 writer = csv.writer(out_f)
-                if not stable_file.exists() or stable_file.stat().st_size == 0:
+                if stable_is_new:
                     writer.writerow(
                         [
                             "API",
@@ -270,34 +317,42 @@ def aggregate_logs(end=False):
                     )
                 for file_path in tmp_stable_files:
                     try:
-                        with file_path.open("r") as in_f:
-                            reader = csv.reader(in_f)
+                        data, start_offset, end_offset = _read_pending_bytes(
+                            file_path, end=should_cleanup_tmp
+                        )
+                        pending_stable_offsets[file_path] = end_offset
+                        reader = csv.reader(io.StringIO(data.decode()))
+                        if start_offset == 0:
                             next(reader, None)
-                            for row in reader:
-                                if row:  # 确保行不为空
-                                    writer.writerow(row)
+                        for row in reader:
+                            if row:  # 确保行不为空
+                                writer.writerow(row)
                     except Exception as err:
                         print(f"Error reading {file_path}: {err}", flush=True)
                         stable_success = False
                         break
         except Exception as err:
-            print(f"Error writing to {tol_file}: {err}", flush=True)
+            print(f"Error writing to {stable_file}: {err}", flush=True)
             stable_success = False
 
         if not stable_success:
             stable_file.unlink(missing_ok=True)
             all_success = False
         else:
-            for file_path in tmp_stable_files:
-                if end:
+            for file_path, offset in pending_stable_offsets.items():
+                _commit_aggregate_offset(file_path, offset, clear=should_cleanup_tmp)
+                if should_cleanup_tmp:
                     file_path.unlink()
-                else:
-                    file_path.write_bytes(b"")
+
+    if (
+        should_cleanup_tmp
+        and all_success
+        and TMP_LOG_PATH.exists()
+        and not os.listdir(TMP_LOG_PATH)
+    ):
+        shutil.rmtree(TMP_LOG_PATH)
 
     if end:
-        if all_success and TMP_LOG_PATH.exists() and not os.listdir(TMP_LOG_PATH):
-            shutil.rmtree(TMP_LOG_PATH)
-
         if tol_file.exists():
             try:
                 df = pd.read_csv(tol_file, on_bad_lines="warn")


### PR DESCRIPTION
## 🧪 COMPUTE_SANITIZER 支持                                                                                                                                                                                      
                                                                                                                                                                                                                 
  - 新增 --use_compute_sanitizer 开关，在不改动默认执行路径的前提下，为 engineV4 提供可选的 CUDA 动态检查能力
  - 将 compute-sanitizer 下沉到 worker slot 内按 case 启动，避免 sanitizer 包裹主调度进程后破坏 engineV4 的多进程并发
  - 新增 --sanitizer_command 配置，允许按需切换 memcheck、racecheck、synccheck 等 sanitizer 参数，无需修改引擎代码
  - 新增 --sanitizer_error_exitcode 配置，将 sanitizer 检出的 CUDA 问题稳定识别并归类到 cuda_error
  - 增加 sanitizer child 子进程模式，复用现有单 case 执行和日志写入逻辑，让每个 case 在独立 sanitizer 进程中运行
  - 增加 sanitizer 子进程组清理逻辑，在 timeout、crash 或主动 --stop 时清理 compute-sanitizer 及其 Python 子进程
  - 修复主动停止时 watchdog 误 respawn worker 的竞态，避免 cleanup 阶段 multiprocessing 队列/信号量已释放后，新 worker 启动时报 SemLock._rebuild FileNotFoundError
  - 保持 USE_COMPUTE_SANITIZER=false 时走原 worker 执行路径

##  📝 log writer 写入优化

  - 将日志聚合改为基于 offset 的增量读取，避免重复扫描和重复聚合 .tmp 日志内容，降低长时间运行时的 I/O 开销
  - 增加 cleanup/end 场景下的聚合处理，让框架在任务中断、主动停止或正常退出时收敛临时日志
  - 优化临时日志清理流程，减少退出阶段重复处理日志

##  📁 变动文件

  - engineV4.py：新增 compute-sanitizer worker 执行模式、子进程清理、退出竞态修复和 sanitizer 结果分类
  - run-v4.sh：新增 sanitizer 相关启动配置，并支持通过脚本开关控制是否启用
  - tester/api_config/log_writer.py：优化日志聚合写入逻辑，支持增量聚合和退出清理场景