### PR TITLE
APITest 测试修复：🐛 修复 forward-only 用例的 autograd 冗余建图

### DIFF
--- a/tester/api_config/config_analyzer.py
+++ b/tester/api_config/config_analyzer.py
@@ -18,6 +18,11 @@ USE_GPU_CACHE_MODE = os.getenv("USE_GPU_CACHE_MODE", "False").lower() == "true"
 SKIP_GPU_CLEANUP = os.getenv("SKIP_GPU_CLEANUP", "False").lower() == "true"
 cached_numpy = {}
 cached_gpu_inputs = {}
+AUTOGRAD_DTYPES = frozenset(
+    ["float32", "float64", "float16", "complex64", "complex128", "bfloat16"]
+)
+FLOAT8_DTYPES = frozenset(["float8_e5m2", "float8_e4m3fn"])
+CAST_THROUGH_INTERMEDIATE_DTYPES = frozenset(["bfloat16"]) | FLOAT8_DTYPES
 
 
 def _load_forward_only_apis():
@@ -252,14 +257,7 @@ class TensorConfig:
 
     def _supports_autograd(self, dtype=None):
         dtype = dtype or self.dtype
-        return dtype in [
-            "float32",
-            "float64",
-            "float16",
-            "complex64",
-            "complex128",
-            "bfloat16",
-        ]
+        return dtype in AUTOGRAD_DTYPES
 
     def _requires_autograd(self, api_config, dtype=None):
         if not self._supports_autograd(dtype):
@@ -307,13 +305,14 @@ class TensorConfig:
             base = (torch.rand(shape, device=device, dtype=torch.float32) - 0.5) * 1.2
             torch_tensor = base.to(dtype=torch_dtype)
 
+        requires_autograd = self._requires_autograd(api_config, dtype)
         torch_source = torch_tensor.detach()
         paddle_tensor = paddle.utils.dlpack.from_dlpack(
             torch.utils.dlpack.to_dlpack(torch_source.clone())
         )
-        paddle_tensor.stop_gradient = not self._requires_autograd(api_config, dtype)
+        paddle_tensor.stop_gradient = not requires_autograd
         torch_tensor = torch_source.clone()
-        if self._requires_autograd(api_config, dtype):
+        if requires_autograd:
             torch_tensor = torch_tensor.detach().requires_grad_(True)
         return paddle_tensor, torch_tensor
 
@@ -3055,12 +3054,11 @@ class TensorConfig:
                     f"is_contiguous: {self.paddle_tensor.is_contiguous()}"
                 )
             else:
+                requires_autograd = self._requires_autograd(api_config)
                 intermediate_dtype = (
                     "float32"
                     if self.dtype == "bfloat16"
-                    else (
-                        "float16" if self.dtype in ["float8_e5m2", "float8_e4m3fn"] else self.dtype
-                    )
+                    else ("float16" if self.dtype in FLOAT8_DTYPES else self.dtype)
                 )
                 self.paddle_tensor = paddle.to_tensor(
                     self.get_numpy_tensor(api_config),
@@ -3068,13 +3066,11 @@ class TensorConfig:
                     place=self.place,
                 )
 
-                self.paddle_tensor.stop_gradient = not self._requires_autograd(api_config)
                 if self.dtype == "bfloat16":
                     self.paddle_tensor = paddle.cast(self.paddle_tensor, dtype="bfloat16")
-                    self.paddle_tensor.stop_gradient = not self._requires_autograd(api_config)
-                elif self.dtype in ["float8_e5m2", "float8_e4m3fn"]:
+                elif self.dtype in FLOAT8_DTYPES:
                     self.paddle_tensor = paddle.cast(self.paddle_tensor, dtype=self.dtype)
-                    self.paddle_tensor.stop_gradient = not self._requires_autograd(api_config)
+                self.paddle_tensor.stop_gradient = not requires_autograd
         if TEST_NON_CONTIGUOUS:
             if not self.shuffle_dims:
                 ndim = self.paddle_tensor.dim()
@@ -3097,9 +3093,7 @@ class TensorConfig:
         original_flag = paddle.get_flags([flag_name])
         paddle.set_flags({flag_name: False})
         try:
-            intermediate_dtype = (
-                "float16" if self.dtype in ["float8_e5m2", "float8_e4m3fn"] else self.dtype
-            )
+            intermediate_dtype = "float16" if self.dtype in FLOAT8_DTYPES else self.dtype
             storage_size = self._strided_storage_size()
             flat_tensor = paddle.zeros(
                 [storage_size],
@@ -3114,7 +3108,7 @@ class TensorConfig:
                     dtype=intermediate_dtype,
                     place=self.place,
                 )
-            if self.dtype in ["float8_e5m2", "float8_e4m3fn"]:
+            if self.dtype in FLOAT8_DTYPES:
                 flat_tensor = paddle.cast(flat_tensor, dtype=self.dtype)
                 tensor = paddle.as_strided(flat_tensor, self.shape, self.strides)
 
@@ -3132,28 +3126,25 @@ class TensorConfig:
             if not self.is_contiguous and self.strides is not None:
                 self.torch_tensor = self._create_strided_torch_tensor(api_config)
             else:
-                needs_intermediate = self.dtype in ["bfloat16", "float8_e5m2", "float8_e4m3fn"]
-                if needs_intermediate:
+                needs_cast = self.dtype in CAST_THROUGH_INTERMEDIATE_DTYPES
+                if needs_cast:
                     intermediate_torch_dtype = (
                         torch.float32 if self.dtype == "bfloat16" else torch.float16
                     )
                 else:
                     intermediate_torch_dtype = self.convert_dtype_to_torch_type(self.dtype)
                 requires_grad = self._requires_autograd(api_config)
-                needs_cast = self.dtype in ["bfloat16", "float8_e5m2", "float8_e4m3fn"]
                 self.torch_tensor = torch.tensor(
                     self.get_numpy_tensor(api_config),
                     dtype=intermediate_torch_dtype,
                     requires_grad=requires_grad and not needs_cast,
                 )
-                if self.dtype == "bfloat16":
-                    self.torch_tensor = self.torch_tensor.to(dtype=torch.bfloat16)
-                    if requires_grad:
-                        self.torch_tensor = self.torch_tensor.detach().requires_grad_(True)
-                elif self.dtype in ["float8_e5m2", "float8_e4m3fn"]:
+                if needs_cast:
                     self.torch_tensor = self.torch_tensor.to(
                         dtype=self.convert_dtype_to_torch_type(self.dtype)
                     )
+                    if requires_grad:
+                        self.torch_tensor = self.torch_tensor.detach().requires_grad_(True)
         if TEST_NON_CONTIGUOUS:
             if not self.shuffle_dims:
                 ndim = self.torch_tensor.dim()
@@ -3166,7 +3157,7 @@ class TensorConfig:
     def _create_strided_torch_tensor(self, api_config):
         """Create a non-contiguous torch tensor from the shared logical numpy input."""
         device = torch.device("cuda:0") if torch.cuda.is_available() else torch.device("cpu")
-        needs_intermediate = self.dtype in ["float8_e5m2", "float8_e4m3fn"]
+        needs_intermediate = self.dtype in FLOAT8_DTYPES
         if needs_intermediate:
             intermediate_torch_dtype = torch.float16
         else:
@@ -3187,7 +3178,7 @@ class TensorConfig:
                     device=device,
                 )
             )
-        if self.dtype in ["float8_e5m2", "float8_e4m3fn"]:
+        if self.dtype in FLOAT8_DTYPES:
             flat_tensor = flat_tensor.to(dtype=self.convert_dtype_to_torch_type(self.dtype))
             tensor = torch.as_strided(flat_tensor, self.shape, self.strides)
 

--- a/tester/api_config/config_analyzer.py
+++ b/tester/api_config/config_analyzer.py
@@ -10,6 +10,7 @@ import re
 import numpy
 import paddle
 import torch
+import yaml
 
 USE_CACHED_NUMPY = os.getenv("USE_CACHED_NUMPY", "False").lower() == "true"
 TEST_NON_CONTIGUOUS = os.getenv("TEST_NON_CONTIGUOUS", "0").lower() in ("true", "1")
@@ -17,6 +18,15 @@ USE_GPU_CACHE_MODE = os.getenv("USE_GPU_CACHE_MODE", "False").lower() == "true"
 SKIP_GPU_CLEANUP = os.getenv("SKIP_GPU_CLEANUP", "False").lower() == "true"
 cached_numpy = {}
 cached_gpu_inputs = {}
+
+
+def _load_forward_only_apis():
+    config_path = os.path.join(os.path.dirname(__file__), "..", "base_config.yaml")
+    with open(config_path, encoding="utf-8") as f:
+        return frozenset(yaml.safe_load(f).get("forward_only_apis", []))
+
+
+FORWARD_ONLY_APIS = _load_forward_only_apis()
 
 
 def _env_bool(name, default=False):
@@ -240,6 +250,26 @@ class TensorConfig:
             return False
         return True
 
+    def _supports_autograd(self, dtype=None):
+        dtype = dtype or self.dtype
+        return dtype in [
+            "float32",
+            "float64",
+            "float16",
+            "complex64",
+            "complex128",
+            "bfloat16",
+        ]
+
+    def _requires_autograd(self, api_config, dtype=None):
+        if not self._supports_autograd(dtype):
+            return False
+        api_name = getattr(api_config, "api_name", "")
+        api = api_name[api_name.rindex(".") + 1 :] if "." in api_name else api_name
+        if api in FORWARD_ONLY_APIS:
+            return False
+        return getattr(api_config, "test_backward", True)
+
     def _gpu_cache_key(self, api_config, dtype=None):
         dtype = dtype or self.dtype
         location = (
@@ -247,9 +277,15 @@ class TensorConfig:
             getattr(self, "key", None),
             tuple(getattr(self, "list_index", [])),
         )
-        return (api_config.config, location, dtype, _shape_tuple(self.shape))
+        return (
+            api_config.config,
+            location,
+            dtype,
+            _shape_tuple(self.shape),
+            self._requires_autograd(api_config, dtype),
+        )
 
-    def _make_gpu_cache_tensors(self, dtype=None):
+    def _make_gpu_cache_tensors(self, api_config, dtype=None):
         dtype = dtype or self.dtype
         torch_dtype = self.convert_dtype_to_torch_type(dtype)
         shape = tuple(self.shape)
@@ -275,17 +311,17 @@ class TensorConfig:
         paddle_tensor = paddle.utils.dlpack.from_dlpack(
             torch.utils.dlpack.to_dlpack(torch_source.clone())
         )
-        paddle_tensor.stop_gradient = False
+        paddle_tensor.stop_gradient = not self._requires_autograd(api_config, dtype)
         torch_tensor = torch_source.clone()
-        if dtype in ["float32", "float64", "float16", "complex64", "complex128", "bfloat16"]:
-            torch_tensor = torch_tensor.requires_grad_(True)
+        if self._requires_autograd(api_config, dtype):
+            torch_tensor = torch_tensor.detach().requires_grad_(True)
         return paddle_tensor, torch_tensor
 
     def _get_gpu_cache_entry(self, api_config, dtype=None):
         dtype = dtype or self.dtype
         key = self._gpu_cache_key(api_config, dtype)
         if key not in cached_gpu_inputs:
-            paddle_tensor, torch_tensor = self._make_gpu_cache_tensors(dtype)
+            paddle_tensor, torch_tensor = self._make_gpu_cache_tensors(api_config, dtype)
             cached_gpu_inputs[key] = {
                 "paddle": paddle_tensor,
                 "torch": torch_tensor,
@@ -3032,11 +3068,13 @@ class TensorConfig:
                     place=self.place,
                 )
 
-                self.paddle_tensor.stop_gradient = False
+                self.paddle_tensor.stop_gradient = not self._requires_autograd(api_config)
                 if self.dtype == "bfloat16":
                     self.paddle_tensor = paddle.cast(self.paddle_tensor, dtype="bfloat16")
+                    self.paddle_tensor.stop_gradient = not self._requires_autograd(api_config)
                 elif self.dtype in ["float8_e5m2", "float8_e4m3fn"]:
                     self.paddle_tensor = paddle.cast(self.paddle_tensor, dtype=self.dtype)
+                    self.paddle_tensor.stop_gradient = not self._requires_autograd(api_config)
         if TEST_NON_CONTIGUOUS:
             if not self.shuffle_dims:
                 ndim = self.paddle_tensor.dim()
@@ -3080,7 +3118,7 @@ class TensorConfig:
                 flat_tensor = paddle.cast(flat_tensor, dtype=self.dtype)
                 tensor = paddle.as_strided(flat_tensor, self.shape, self.strides)
 
-            tensor.stop_gradient = False
+            tensor.stop_gradient = not self._requires_autograd(api_config)
             return tensor
         finally:
             paddle.set_flags(original_flag)
@@ -3101,21 +3139,17 @@ class TensorConfig:
                     )
                 else:
                     intermediate_torch_dtype = self.convert_dtype_to_torch_type(self.dtype)
+                requires_grad = self._requires_autograd(api_config)
+                needs_cast = self.dtype in ["bfloat16", "float8_e5m2", "float8_e4m3fn"]
                 self.torch_tensor = torch.tensor(
                     self.get_numpy_tensor(api_config),
                     dtype=intermediate_torch_dtype,
-                    requires_grad=self.dtype
-                    in [
-                        "float32",
-                        "float64",
-                        "float16",
-                        "complex64",
-                        "complex128",
-                        "bfloat16",
-                    ],
+                    requires_grad=requires_grad and not needs_cast,
                 )
                 if self.dtype == "bfloat16":
                     self.torch_tensor = self.torch_tensor.to(dtype=torch.bfloat16)
+                    if requires_grad:
+                        self.torch_tensor = self.torch_tensor.detach().requires_grad_(True)
                 elif self.dtype in ["float8_e5m2", "float8_e4m3fn"]:
                     self.torch_tensor = self.torch_tensor.to(
                         dtype=self.convert_dtype_to_torch_type(self.dtype)
@@ -3157,15 +3191,7 @@ class TensorConfig:
             flat_tensor = flat_tensor.to(dtype=self.convert_dtype_to_torch_type(self.dtype))
             tensor = torch.as_strided(flat_tensor, self.shape, self.strides)
 
-        requires_grad = self.dtype in [
-            "float32",
-            "float64",
-            "float16",
-            "complex64",
-            "complex128",
-            "bfloat16",
-        ]
-        if requires_grad:
+        if self._requires_autograd(api_config):
             tensor = tensor.detach().requires_grad_(True)
         return tensor
 


### PR DESCRIPTION
Title: 🐛 修复 forward-only 用例的 autograd 冗余建图

## 🧭 背景

PaddleAPITest 的 `accuracy_stable` 会同时执行 Paddle 侧实现和转换后的 Torch 参考实现，用于验证多轮前向结果稳定性。对于 `moe_permute` 而言，输入规模可能很大，例如 bf16 `hidden_states` 为 `[1048576, 1024]`，按 expert 展开后的 `hidden_states_unzipped` 可达到 `[8388608, 1024]`，单个输出 tensor 约 16GB。

在这种场景下，测试只需要前向结果比对，不需要反向图；旧逻辑可能让 Torch 浮点输入默认 `requires_grad=True`，使 `MoePermuteRule` 中的大量索引和 slice assignment 构建巨大的 `CopySlices` autograd 图。这个图不会参与 backward 校验，却会增加显存、运行和对象析构成本，造成 **测试成功但进程崩溃** 的问题。

## 🛠️ 实现方案

本 PR 将输入是否需要 autograd 的判断集中至 `TensorConfig`，通过 `_supports_autograd` / `_requires_autograd` 表达 Torch 与 Paddle 共用策略。判断使用 `tester/base_config.yaml` 中的 `forward_only_apis`：命中后 Torch 输入生成 `requires_grad=False`，Paddle 输入同步设置 `stop_gradient=True`。

## 🔧 主要变更

### 1. 对齐 Torch/Paddle forward-only autograd 行为

forward-only API 不再因为浮点 dtype 自动开启 Torch autograd；对应 Paddle 输入也同步停止梯度记录。对非 forward-only API，Torch 仍按 backward 需求设置 `requires_grad=True`，Paddle 仍保持 `stop_gradient=False`。

### 2. 修复 bf16 Torch 输入 leaf 行为

bf16 backward 场景下，Torch 输入在 dtype cast 后重新设置为 leaf requires-grad tensor，避免最终输入携带 cast 产生的 `grad_fn`。

## 📁 改动文件

```text
tester/
└── api_config/
    └── config_analyzer.py              # 统一 Torch/Paddle 输入 autograd 策略，并修复 bf16 leaf 行为
```

## ✅ 验证

修改后经测试，moe_permute 测试行为正常，不再发生进程崩溃。
