### PR TITLE
APITest 测试优化：🐛 修复 paddleonly 模式对 torch 的安装依赖

### DIFF
--- a/engineV2.py
+++ b/engineV2.py
@@ -282,6 +282,85 @@ def _print_argument(prefix, message):
     print(f"{prefix} {message}", flush=True)
 
 
+def _mode_uses_torch(options):
+    return any(
+        getattr(options, opt, False)
+        for opt in (
+            "accuracy",
+            "paddle_cinn",
+            "paddle_gpu_performance",
+            "torch_gpu_performance",
+            "paddle_torch_gpu_performance",
+            "accuracy_stable",
+            "paddle_custom_device",
+            "custom_device_vs_gpu",
+        )
+    )
+
+
+def _load_test_classes(options):
+    from tester import APIConfig, APITestPaddleOnly
+
+    test_classes = {
+        "APIConfig": APIConfig,
+        "APITestPaddleOnly": APITestPaddleOnly,
+    }
+    if _mode_uses_torch(options):
+        from tester import (
+            APITestAccuracy,
+            APITestAccuracyStable,
+            APITestCINNVSDygraph,
+            APITestCustomDeviceVSCPU,
+            APITestPaddleDeviceVSGPU,
+            APITestPaddleGPUPerformance,
+            APITestPaddleTorchGPUPerformance,
+            APITestTorchGPUPerformance,
+        )
+
+        test_classes.update(
+            {
+                "APITestAccuracy": APITestAccuracy,
+                "APITestCINNVSDygraph": APITestCINNVSDygraph,
+                "APITestPaddleGPUPerformance": APITestPaddleGPUPerformance,
+                "APITestTorchGPUPerformance": APITestTorchGPUPerformance,
+                "APITestPaddleTorchGPUPerformance": APITestPaddleTorchGPUPerformance,
+                "APITestAccuracyStable": APITestAccuracyStable,
+                "APITestCustomDeviceVSCPU": APITestCustomDeviceVSCPU,
+                "APITestPaddleDeviceVSGPU": APITestPaddleDeviceVSGPU,
+            }
+        )
+    return test_classes
+
+
+def _select_test_class(options):
+    test_classes = _load_test_classes(options)
+    option_to_class_name = {
+        "paddle_only": "APITestPaddleOnly",
+        "paddle_cinn": "APITestCINNVSDygraph",
+        "accuracy": "APITestAccuracy",
+        "paddle_gpu_performance": "APITestPaddleGPUPerformance",
+        "torch_gpu_performance": "APITestTorchGPUPerformance",
+        "paddle_torch_gpu_performance": "APITestPaddleTorchGPUPerformance",
+        "accuracy_stable": "APITestAccuracyStable",
+        "paddle_custom_device": "APITestCustomDeviceVSCPU",
+        "custom_device_vs_gpu": "APITestPaddleDeviceVSGPU",
+    }
+    for opt, class_name in option_to_class_name.items():
+        if getattr(options, opt, False):
+            return test_classes[class_name]
+    return test_classes["APITestAccuracy"]
+
+
+def _clear_device_cache(options):
+    import paddle
+
+    if _mode_uses_torch(options):
+        import torch
+
+        torch.cuda.empty_cache()
+    paddle.device.cuda.empty_cache()
+
+
 def _parse_gpu_ids(gpu_ids_arg, device_count):
     gpu_ids = []
     for raw_part in gpu_ids_arg.split(","):
@@ -441,7 +520,6 @@ def init_worker_gpu(gpu_worker_list, lock, available_gpus, max_workers_per_gpu, 
         os.environ["CUDA_VISIBLE_DEVICES"] = str(assigned_gpu)
 
         import paddle
-        import torch
 
         # Load custom ops from paddlefleet to register _run_custom_op operators
         try:
@@ -453,39 +531,11 @@ def init_worker_gpu(gpu_worker_list, lock, available_gpus, max_workers_per_gpu, 
         except ImportError:
             pass
 
-        globals()["torch"] = torch
         globals()["paddle"] = paddle
-
-        from tester import (
-            APIConfig,
-            APITestAccuracy,
-            APITestAccuracyStable,
-            APITestCINNVSDygraph,
-            APITestCustomDeviceVSCPU,
-            APITestPaddleDeviceVSGPU,
-            APITestPaddleGPUPerformance,
-            APITestPaddleOnly,
-            APITestPaddleTorchGPUPerformance,
-            APITestTorchGPUPerformance,
-        )
-
-        test_classes = {
-            "APIConfig": APIConfig,
-            "APITestAccuracy": APITestAccuracy,
-            "APITestCINNVSDygraph": APITestCINNVSDygraph,
-            "APITestPaddleOnly": APITestPaddleOnly,
-            "APITestPaddleGPUPerformance": APITestPaddleGPUPerformance,
-            "APITestTorchGPUPerformance": APITestTorchGPUPerformance,
-            "APITestPaddleTorchGPUPerformance": APITestPaddleTorchGPUPerformance,
-            "APITestAccuracyStable": APITestAccuracyStable,
-            "APITestCustomDeviceVSCPU": APITestCustomDeviceVSCPU,
-            "APITestPaddleDeviceVSGPU": APITestPaddleDeviceVSGPU,
-        }
-        globals().update(test_classes)
+        globals().update(_load_test_classes(options))
 
         def signal_handler(*args):
-            torch.cuda.empty_cache()
-            paddle.device.cuda.empty_cache()
+            _clear_device_cache(options)
             restore_stdio()
             close_process_files()
             sys.exit(0)
@@ -540,22 +590,7 @@ def run_test_case(api_config_str, options):
         print(f"[config parse error] {api_config_str} {err!s}", flush=True)
         return
 
-    option_to_class = {
-        "paddle_only": APITestPaddleOnly,
-        "paddle_cinn": APITestCINNVSDygraph,
-        "accuracy": APITestAccuracy,
-        "paddle_gpu_performance": APITestPaddleGPUPerformance,
-        "torch_gpu_performance": APITestTorchGPUPerformance,
-        "paddle_torch_gpu_performance": APITestPaddleTorchGPUPerformance,
-        "accuracy_stable": APITestAccuracyStable,
-        "paddle_custom_device": APITestCustomDeviceVSCPU,
-        "custom_device_vs_gpu": APITestPaddleDeviceVSGPU,
-    }
-
-    test_class = next(
-        (cls for opt, cls in option_to_class.items() if getattr(options, opt, False)),
-        APITestAccuracy,  # default fallback
-    )
+    test_class = _select_test_class(options)
     kwargs = {k: v for k, v in vars(options).items() if k in VALID_TEST_ARGS}
     case = test_class(api_config, **kwargs)
     try:
@@ -582,8 +617,7 @@ def run_test_case(api_config_str, options):
                 "paddle_torch_gpu_performance",
             )
         ) and not getattr(options, "use_gpu_cache_mode", False):
-            torch.cuda.empty_cache()
-            paddle.device.cuda.empty_cache()
+            _clear_device_cache(options)
 
 
 def main():
@@ -903,18 +937,7 @@ def main():
         except ImportError:
             pass
 
-        from tester import (
-            APIConfig,
-            APITestAccuracy,
-            APITestAccuracyStable,
-            APITestCINNVSDygraph,
-            APITestCustomDeviceVSCPU,
-            APITestPaddleDeviceVSGPU,
-            APITestPaddleGPUPerformance,
-            APITestPaddleOnly,
-            APITestPaddleTorchGPUPerformance,
-            APITestTorchGPUPerformance,
-        )
+        globals().update(_load_test_classes(options))
 
         # set log_writer
         set_engineV2()
@@ -930,22 +953,7 @@ def main():
             print(f"[config parse error] {options.api_config} {err!s}", flush=True)
             return
 
-        option_to_class = {
-            "paddle_only": APITestPaddleOnly,
-            "paddle_cinn": APITestCINNVSDygraph,
-            "accuracy": APITestAccuracy,
-            "paddle_gpu_performance": APITestPaddleGPUPerformance,
-            "torch_gpu_performance": APITestTorchGPUPerformance,
-            "paddle_torch_gpu_performance": APITestPaddleTorchGPUPerformance,
-            "accuracy_stable": APITestAccuracyStable,
-            "paddle_custom_device": APITestCustomDeviceVSCPU,
-            "custom_device_vs_gpu": APITestPaddleDeviceVSGPU,
-        }
-
-        test_class = next(
-            (cls for opt, cls in option_to_class.items() if getattr(options, opt, False)),
-            APITestAccuracy,  # default fallback
-        )
+        test_class = _select_test_class(options)
 
         if options.test_cpu:
             import paddle

--- a/engineV4.py
+++ b/engineV4.py
@@ -138,7 +138,6 @@ def _init_worker_runtime(slot_index, gpu_id, options, *, redirect_output):
         os.environ["CUDA_VISIBLE_DEVICES"] = str(gpu_id)
 
     import paddle
-    import torch
 
     try:
         import paddlefleet_ops  # noqa: F401
@@ -149,35 +148,8 @@ def _init_worker_runtime(slot_index, gpu_id, options, *, redirect_output):
     except ImportError:
         pass
 
-    globals()["torch"] = torch
     globals()["paddle"] = paddle
-
-    from tester import (
-        APIConfig,
-        APITestAccuracy,
-        APITestAccuracyStable,
-        APITestCINNVSDygraph,
-        APITestCustomDeviceVSCPU,
-        APITestPaddleDeviceVSGPU,
-        APITestPaddleGPUPerformance,
-        APITestPaddleOnly,
-        APITestPaddleTorchGPUPerformance,
-        APITestTorchGPUPerformance,
-    )
-
-    test_classes = {
-        "APIConfig": APIConfig,
-        "APITestAccuracy": APITestAccuracy,
-        "APITestCINNVSDygraph": APITestCINNVSDygraph,
-        "APITestPaddleOnly": APITestPaddleOnly,
-        "APITestPaddleGPUPerformance": APITestPaddleGPUPerformance,
-        "APITestTorchGPUPerformance": APITestTorchGPUPerformance,
-        "APITestPaddleTorchGPUPerformance": APITestPaddleTorchGPUPerformance,
-        "APITestAccuracyStable": APITestAccuracyStable,
-        "APITestCustomDeviceVSCPU": APITestCustomDeviceVSCPU,
-        "APITestPaddleDeviceVSGPU": APITestPaddleDeviceVSGPU,
-    }
-    globals().update(test_classes)
+    globals().update(_load_test_classes(options))
 
     if options.test_cpu:
         paddle.device.set_device("cpu")
@@ -865,6 +837,85 @@ def _print_argument(prefix, message):
     print(f"{prefix} {message}", flush=True)
 
 
+def _mode_uses_torch(options):
+    return any(
+        getattr(options, opt, False)
+        for opt in (
+            "accuracy",
+            "paddle_cinn",
+            "paddle_gpu_performance",
+            "torch_gpu_performance",
+            "paddle_torch_gpu_performance",
+            "accuracy_stable",
+            "paddle_custom_device",
+            "custom_device_vs_gpu",
+        )
+    )
+
+
+def _load_test_classes(options):
+    from tester import APIConfig, APITestPaddleOnly
+
+    test_classes = {
+        "APIConfig": APIConfig,
+        "APITestPaddleOnly": APITestPaddleOnly,
+    }
+    if _mode_uses_torch(options):
+        from tester import (
+            APITestAccuracy,
+            APITestAccuracyStable,
+            APITestCINNVSDygraph,
+            APITestCustomDeviceVSCPU,
+            APITestPaddleDeviceVSGPU,
+            APITestPaddleGPUPerformance,
+            APITestPaddleTorchGPUPerformance,
+            APITestTorchGPUPerformance,
+        )
+
+        test_classes.update(
+            {
+                "APITestAccuracy": APITestAccuracy,
+                "APITestCINNVSDygraph": APITestCINNVSDygraph,
+                "APITestPaddleGPUPerformance": APITestPaddleGPUPerformance,
+                "APITestTorchGPUPerformance": APITestTorchGPUPerformance,
+                "APITestPaddleTorchGPUPerformance": APITestPaddleTorchGPUPerformance,
+                "APITestAccuracyStable": APITestAccuracyStable,
+                "APITestCustomDeviceVSCPU": APITestCustomDeviceVSCPU,
+                "APITestPaddleDeviceVSGPU": APITestPaddleDeviceVSGPU,
+            }
+        )
+    return test_classes
+
+
+def _select_test_class(options):
+    test_classes = _load_test_classes(options)
+    option_to_class_name = {
+        "paddle_only": "APITestPaddleOnly",
+        "paddle_cinn": "APITestCINNVSDygraph",
+        "accuracy": "APITestAccuracy",
+        "paddle_gpu_performance": "APITestPaddleGPUPerformance",
+        "torch_gpu_performance": "APITestTorchGPUPerformance",
+        "paddle_torch_gpu_performance": "APITestPaddleTorchGPUPerformance",
+        "accuracy_stable": "APITestAccuracyStable",
+        "paddle_custom_device": "APITestCustomDeviceVSCPU",
+        "custom_device_vs_gpu": "APITestPaddleDeviceVSGPU",
+    }
+    for opt, class_name in option_to_class_name.items():
+        if getattr(options, opt, False):
+            return test_classes[class_name]
+    return test_classes["APITestAccuracy"]
+
+
+def _clear_device_cache(options):
+    import paddle
+
+    if _mode_uses_torch(options):
+        import torch
+
+        torch.cuda.empty_cache()
+    paddle.device.cuda.empty_cache()
+
+
 def _parse_gpu_ids(gpu_ids_arg, device_count):
     gpu_ids = []
     for raw_part in gpu_ids_arg.split(","):
@@ -1098,22 +1149,7 @@ def run_test_case(api_config_str, options):
         print(f"[config parse error] {api_config_str} {err!s}", flush=True)
         return
 
-    option_to_class = {
-        "paddle_only": APITestPaddleOnly,
-        "paddle_cinn": APITestCINNVSDygraph,
-        "accuracy": APITestAccuracy,
-        "paddle_gpu_performance": APITestPaddleGPUPerformance,
-        "torch_gpu_performance": APITestTorchGPUPerformance,
-        "paddle_torch_gpu_performance": APITestPaddleTorchGPUPerformance,
-        "accuracy_stable": APITestAccuracyStable,
-        "paddle_custom_device": APITestCustomDeviceVSCPU,
-        "custom_device_vs_gpu": APITestPaddleDeviceVSGPU,
-    }
-
-    test_class = next(
-        (cls for opt, cls in option_to_class.items() if getattr(options, opt, False)),
-        APITestAccuracy,  # default fallback
-    )
+    test_class = _select_test_class(options)
     kwargs = {k: v for k, v in vars(options).items() if k in VALID_TEST_ARGS}
     case = test_class(api_config, **kwargs)
     try:
@@ -1140,8 +1176,7 @@ def run_test_case(api_config_str, options):
                 "paddle_torch_gpu_performance",
             )
         ) and not getattr(options, "use_gpu_cache_mode", False):
-            torch.cuda.empty_cache()
-            paddle.device.cuda.empty_cache()
+            _clear_device_cache(options)
 
 
 def main():
@@ -1509,18 +1544,7 @@ def main():
         except ImportError:
             pass
 
-        from tester import (
-            APIConfig,
-            APITestAccuracy,
-            APITestAccuracyStable,
-            APITestCINNVSDygraph,
-            APITestCustomDeviceVSCPU,
-            APITestPaddleDeviceVSGPU,
-            APITestPaddleGPUPerformance,
-            APITestPaddleOnly,
-            APITestPaddleTorchGPUPerformance,
-            APITestTorchGPUPerformance,
-        )
+        globals().update(_load_test_classes(options))
 
         # set log_writer
         set_engineV2()
@@ -1536,22 +1560,7 @@ def main():
             print(f"[config parse error] {options.api_config} {err!s}", flush=True)
             return
 
-        option_to_class = {
-            "paddle_only": APITestPaddleOnly,
-            "paddle_cinn": APITestCINNVSDygraph,
-            "accuracy": APITestAccuracy,
-            "paddle_gpu_performance": APITestPaddleGPUPerformance,
-            "torch_gpu_performance": APITestTorchGPUPerformance,
-            "paddle_torch_gpu_performance": APITestPaddleTorchGPUPerformance,
-            "accuracy_stable": APITestAccuracyStable,
-            "paddle_custom_device": APITestCustomDeviceVSCPU,
-            "custom_device_vs_gpu": APITestPaddleDeviceVSGPU,
-        }
-
-        test_class = next(
-            (cls for opt, cls in option_to_class.items() if getattr(options, opt, False)),
-            APITestAccuracy,  # default fallback
-        )
+        test_class = _select_test_class(options)
 
         if options.test_cpu:
             import paddle

--- a/tester/api_config/config_analyzer.py
+++ b/tester/api_config/config_analyzer.py
@@ -9,7 +9,17 @@ import re
 
 import numpy
 import paddle
-import torch
+
+
+class _LazyTorch:
+    def __getattr__(self, name):
+        import torch
+
+        globals()["torch"] = torch
+        return getattr(torch, name)
+
+
+torch = _LazyTorch()
 
 USE_CACHED_NUMPY = os.getenv("USE_CACHED_NUMPY", "False").lower() == "true"
 TEST_NON_CONTIGUOUS = os.getenv("TEST_NON_CONTIGUOUS", "0").lower() in ("true", "1")
@@ -230,9 +240,9 @@ class TensorConfig:
         dtype = dtype or self.dtype
         if not is_gpu_cache_mode():
             return False
-        if not torch.cuda.is_available():
-            return False
         if self.place is not None and "cpu" in str(self.place).lower():
+            return False
+        if "gpu" not in paddle.device.get_device():
             return False
         if not self.is_contiguous or self.strides is not None:
             return False
@@ -248,6 +258,24 @@ class TensorConfig:
             tuple(getattr(self, "list_index", [])),
         )
         return (api_config.config, location, dtype, _shape_tuple(self.shape))
+
+    def _make_gpu_paddle_tensor(self, dtype=None):
+        dtype = dtype or self.dtype
+        shape = tuple(self.shape)
+        if dtype == "bool":
+            paddle_tensor = paddle.randint(0, 2, shape, dtype="int32").cast("bool")
+        elif "int" in dtype or dtype == "uint8":
+            paddle_tensor = paddle.randint(-65535, 65535, shape, dtype="int64").cast(dtype)
+        elif dtype.startswith("complex"):
+            real_dtype = "float32" if dtype == "complex64" else "float64"
+            real_part = (paddle.rand(shape, dtype=real_dtype) - 0.5) * 1.2
+            imag_part = (paddle.rand(shape, dtype=real_dtype) - 0.5) * 1.2
+            paddle_tensor = (real_part + 1j * imag_part).cast(dtype)
+        else:
+            base = (paddle.rand(shape, dtype="float32") - 0.5) * 1.2
+            paddle_tensor = base.cast(dtype)
+        paddle_tensor.stop_gradient = False
+        return paddle_tensor
 
     def _make_gpu_cache_tensors(self, dtype=None):
         dtype = dtype or self.dtype
@@ -293,8 +321,11 @@ class TensorConfig:
         return cached_gpu_inputs[key]
 
     def get_gpu_paddle_tensor(self, api_config, dtype=None):
-        entry = self._get_gpu_cache_entry(api_config, dtype)
-        self.paddle_tensor = entry["paddle"]
+        dtype = dtype or self.dtype
+        key = self._gpu_cache_key(api_config, dtype)
+        if key not in cached_gpu_inputs:
+            cached_gpu_inputs[key] = {"paddle": self._make_gpu_paddle_tensor(dtype)}
+        self.paddle_tensor = cached_gpu_inputs[key]["paddle"]
         return self.paddle_tensor
 
     def get_gpu_torch_tensor(self, api_config, dtype=None):
@@ -2979,7 +3010,7 @@ class TensorConfig:
                             scalar_val = (numpy.random.random() - 0.5) * 1.2
                             self.numpy_tensor = numpy.array(scalar_val, dtype=self.dtype)
                 elif self._use_gpu_cache(original_dtype):
-                    self._get_gpu_cache_entry(api_config, original_dtype)
+                    self.get_gpu_paddle_tensor(api_config, original_dtype)
                 elif USE_CACHED_NUMPY and self.dtype not in ["int64", "float64"]:
                     self.numpy_tensor = self.get_cached_numpy(self.dtype, self.shape, scale=1.2)
                 else:

--- a/tester/base.py
+++ b/tester/base.py
@@ -5,7 +5,6 @@ import inspect
 
 import numpy
 import paddle
-import torch
 import yaml
 
 from .api_config.config_analyzer import (
@@ -34,6 +33,18 @@ with open("tester/api_config/torch_error_skip.txt") as f:
     torch_error_skip = frozenset(line.strip() for line in f if line.strip())
 
 del config
+
+
+class _LazyTorch:
+    def __getattr__(self, name):
+        import torch
+
+        globals()["torch"] = torch
+        return getattr(torch, name)
+
+
+torch = _LazyTorch()
+
 
 CUDA_ERROR = frozenset(
     [
@@ -175,11 +186,13 @@ no_signature_api_mappings.update(
 
 
 class APITestBase:
-    def __init__(self, api_config):
+    def __init__(self, api_config, use_torch=True):
         self.api_config = api_config
         self.outputs_grad_numpy = []
-        torch.set_num_threads(8)
-        torch.set_printoptions(threshold=100, linewidth=120)
+        self.outputs_grad_paddleonly = []
+        if use_torch:
+            torch.set_num_threads(8)
+            torch.set_printoptions(threshold=100, linewidth=120)
 
     def need_skip(self, paddle_only=False):
         # not support
@@ -744,11 +757,35 @@ class APITestBase:
             dtype=torch_dtype
         )
 
+    def _make_paddle_output_grad(self, shape, dtype):
+        if "int" in dtype:
+            return paddle.randint(-65535, 65535, tuple(shape), dtype="int64").cast(dtype)
+        if dtype in ["float8_e5m2", "float8_e4m3fn"]:
+            base_dtype = "float16"
+        elif dtype == "bfloat16":
+            base_dtype = "float32"
+        elif dtype.startswith("complex"):
+            real_dtype = "float32" if dtype == "complex64" else "float64"
+            real_part = paddle.rand(tuple(shape), dtype=real_dtype) - 0.5
+            imag_part = paddle.rand(tuple(shape), dtype=real_dtype) - 0.5
+            return (real_part + 1j * imag_part).cast(dtype)
+        else:
+            base_dtype = dtype
+        return (paddle.rand(tuple(shape), dtype=base_dtype) - 0.5).cast(dtype)
+
     def _use_gpu_output_grad(self, output):
-        if not is_gpu_cache_mode() or not torch.cuda.is_available():
+        if not is_gpu_cache_mode() or "gpu" not in paddle.device.get_device():
             return False
         dtype = str(output.dtype).split(".")[-1]
         return dtype in ["float32", "float64", "float16", "bfloat16", "complex64", "complex128"]
+
+    def _get_gpu_output_grad_paddleonly(self, output, index):
+        if len(self.outputs_grad_paddleonly) <= index:
+            dtype = str(output.dtype).split(".")[-1]
+            paddle_grad = self._make_paddle_output_grad(output.shape, dtype)
+            paddle_grad.stop_gradient = False
+            self.outputs_grad_paddleonly.append(paddle_grad)
+        return self.outputs_grad_paddleonly[index]
 
     def _get_gpu_output_grad_pair(self, output, index):
         if len(self.outputs_grad_numpy) <= index:
@@ -807,10 +844,10 @@ class APITestBase:
                     raise ValueError("outputs format not support")
 
         result_outputs_grads = []
-        if len(self.outputs_grad_numpy) == 0:
+        if len(self.outputs_grad_numpy) == 0 and len(self.outputs_grad_paddleonly) == 0:
             for i, output in enumerate(result_outputs):
                 if self._use_gpu_output_grad(output):
-                    self._get_gpu_output_grad_pair(output, i)
+                    self._get_gpu_output_grad_paddleonly(output, i)
                     continue
                 dtype = str(output.dtype).split(".")[-1]
                 if USE_CACHED_NUMPY:
@@ -830,6 +867,8 @@ class APITestBase:
                             numpy_dtype = dtype
                         numpy_tensor = (numpy.random.random(output.shape) - 0.5).astype(numpy_dtype)
                 self.outputs_grad_numpy.append(numpy_tensor)
+        for paddle_grad in self.outputs_grad_paddleonly:
+            result_outputs_grads.append(paddle_grad)
         for i, numpy_tensor in enumerate(self.outputs_grad_numpy):
             if isinstance(numpy_tensor, tuple):
                 result_outputs_grads.append(numpy_tensor[0])

--- a/tester/paddle_only.py
+++ b/tester/paddle_only.py
@@ -10,7 +10,7 @@ from .base import CUDA_ERROR, CUDA_OOM, APITestBase
 
 class APITestPaddleOnly(APITestBase):
     def __init__(self, api_config, **kwargs):
-        super().__init__(api_config)
+        super().__init__(api_config, use_torch=False)
         self.test_amp = kwargs.get("test_amp", False)
 
     # @func_set_timeout(600)


### PR DESCRIPTION
## 🧭 背景
PaddleAPITest 的 `paddle_only` 模式用于单独验证 Paddle API 配置能否被引擎解析并在 Paddle 侧正常执行，理论上不需要安装 PyTorch。当前测试框架里 accuracy、性能和部分 GPU cache 能力会依赖 torch，但这些依赖不应影响只跑 Paddle 的场景，安装 torch 会显著增加环境准备成本。

本次改动围绕主力入口 `engineV2.py` 和 `engineV4.py`，将 paddleonly 路径从 torch 相关类加载、cache 清理和 GPU cache 数据生成中拆出来，保证普通 paddleonly 以及 `--use_gpu_cache_mode=True` 下都不会因为缺少 torch 报错。

## 🔎 问题定位
旧逻辑中，主进程或 worker 初始化会一次性导入所有 tester 类，间接触发 accuracy / performance 等 torch 相关模块加载；同时 `tester/base.py` 和 `tester/api_config/config_analyzer.py` 顶层直接 `import torch`，导致仅导入 Paddle-only tester 也要求环境存在 torch。

进一步排查发现，`paddle_only + --use_gpu_cache_mode=True` 还会在 GPU cache 判断和数据生成阶段访问 `torch.cuda.is_available()`、Torch 随机张量和 DLPack 转换。对 paddleonly 来说，这些判断和张量生成都可以由 Paddle 完成。

## 🛠️ 实现方案
主入口侧采用按模式延迟加载：paddleonly 只加载 `APIConfig` 和 `APITestPaddleOnly`，只有 accuracy、CINN、性能、custom device 等确实需要 torch 的模式才加载 torch 相关 tester；cache 清理同样只在 torch 模式下调用 `torch.cuda.empty_cache()`。

shared tester 侧将 torch 改为 lazy 访问，避免模块 import 阶段强制加载 torch。对于 GPU cache，Paddle-only 输入和输出梯度改为 Paddle 原生生成与缓存；accuracy 路径仍保留原本的 Paddle/Torch 成对梯度逻辑，确保对比模式下 paddle grad 和 torch grad 来源一致。

## 🔧 主要变更
### 1. 主力入口延迟加载 torch 相关能力
`engineV2.py` 和 `engineV4.py` 新增按模式判断、测试类加载和 cache 清理封装。paddleonly worker 和单 case 路径不再无条件导入 torch，也不再无条件加载 accuracy/performance tester。

### 2. Paddle-only tester 去除初始化期 torch 依赖
`APITestBase` 支持 `use_torch` 开关，`APITestPaddleOnly` 显式关闭 torch 初始化。`tester/base.py` 与 `tester/api_config/config_analyzer.py` 使用 lazy torch 代理，只有真正访问 torch 功能时才加载 torch。

### 3. paddleonly GPU cache 改为 Paddle 原生路径
`config_analyzer.py` 中 GPU cache 可用性判断改为 Paddle 当前设备判断，不再使用 `torch.cuda.is_available()`。Paddle-only 的 GPU 输入 cache 使用 Paddle tensor 生成，避免为了生成 Paddle 输入而创建 torch tensor。

## 📁 改动文件
```text
PaddleAPITest/
├── engineV2.py                                # 主力 V2 引擎：模式化加载、paddleonly torch-free、GPU/cache 参数处理
├── engineV4.py                                # V4 引擎：同步 V2 的加载策略，并补充 sanitizer 单 case 支持
├── tester/
    ├── base.py                                # lazy torch、paddleonly 输出梯度 cache、Paddle/Torch pair cache 拆分
    ├── paddle_only.py                         # paddleonly 初始化关闭 torch 设置
    └── api_config/
        └── config_analyzer.py                 # lazy torch、Paddle-only GPU 输入 cache、设备判断改造

```
