### PR TITLE
 Respect accuracy compatible kernel flag in linear conversion

### DIFF
--- a/tester/paddle_to_torch/rules.py
+++ b/tester/paddle_to_torch/rules.py
@@ -3495,7 +3495,12 @@ class LinearRule(BaseRule):
     def apply(self, paddle_api: str) -> ConvertResult:
         _, map_code = self.apply_generic()
         pre = """
-weight = weight.T.contiguous()
+import paddle
+if paddle.get_flags("FLAGS_use_accuracy_compatible_kernel")["FLAGS_use_accuracy_compatible_kernel"]:
+    weight = weight.T.contiguous()
+else:
+    # Keep transpose as a view to avoid changing the GEMM layout path.
+    weight = weight.T
 """
         core = f"result = {self.torch_api}(**_kwargs)"
         code = Code(preprocess=pre.splitlines() + map_code, core=[core])


### PR DESCRIPTION
  ### 修改内容

  根据 `FLAGS_use_accuracy_compatible_kernel` 控制 `weight` 转置后的处理方式：

  - 当 `FLAGS_use_accuracy_compatible_kernel=True` 时，使用 `weight.T.contiguous()`，走精度兼容 kernel 所需路径。
  - 当 `FLAGS_use_accuracy_compatible_kernel=False` 时，保留 `weight.T` view，避免改变默认 GEMM layout 路径。

  ### 影响范围

  该修改仅影响 `tester/paddle_to_torch/rules.py` 中 `LinearRule` 的转换逻辑，不影响其他 API 转换规则。