### PR TITLE
测试问题修复：🐛 修复 TensorConfig 嵌套 Place 解析

### DIFF
--- a/tester/api_config/config_analyzer.py
+++ b/tester/api_config/config_analyzer.py
@@ -193,10 +193,12 @@ class TensorConfig:
         return result
 
     def __str__(self):
+        if self.place is not None:
+            return f'Tensor({self.shape},"{self.dtype}",place={self.place})'
         return f'Tensor({self.shape},"{self.dtype}")'
 
     def __repr__(self):
-        return f'Tensor({self.shape},"{self.dtype}")'
+        return self.__str__()
 
     def convert_dtype_to_torch_type(self, dtype):
         if dtype in ["float32", numpy.float32]:
@@ -3568,10 +3570,67 @@ class APIConfig:
     def get_api(self, config):
         return config[0 : config.index("(")], len(config[0 : config.index("(")])
 
+    def _match_parens(self, config, start):
+        depth = 0
+        for i in range(start, len(config)):
+            if config[i] == "(":
+                depth += 1
+            elif config[i] == ")":
+                depth -= 1
+                if depth == 0:
+                    return i
+        raise ValueError(f"Unclosed parentheses starting at offset {start}")
+
     def get_tensor(self, config, offset):
-        config = config[offset:]
-        tensor_str = config[config.index("TensorConfig") : config.index(")") + 1]
-        return eval(tensor_str), offset + len(tensor_str)
+        """Parse TensorConfig(...), including nested kwargs like place=Place(cpu)."""
+        start = config.index("(", offset)
+        end = self._match_parens(config, start)
+        # Slice to the matched span so get_token cannot look past the closing ')'.
+        tensor_str = config[start : end + 1]
+        args = []
+        kwargs = collections.OrderedDict()
+        pos = 1
+
+        def skip(p):
+            while p < len(tensor_str) and tensor_str[p] in " ,\t\n":
+                p += 1
+            return p
+
+        while True:
+            pos = skip(pos)
+            if pos >= len(tensor_str) or tensor_str[pos] == ")":
+                break
+
+            # Tensor shapes use bare list syntax, not list[...].
+            if tensor_str[pos] == "[":
+                value, pos = self.get_list(tensor_str, pos)
+                args.append(value)
+                continue
+
+            key = None
+            token, pos = self.get_token(tensor_str, pos)
+            if pos is None:
+                break
+            if pos < len(tensor_str) and tensor_str[pos] == "=":
+                key = token
+                pos = skip(pos + 1)
+                if pos < len(tensor_str) and tensor_str[pos] == "[":
+                    value, pos = self.get_list(tensor_str, pos)
+                    kwargs[key] = value
+                    continue
+                token, pos = self.get_token(tensor_str, pos)
+                if pos is None:
+                    break
+
+            value, pos = self.get_one_arg(token, tensor_str, pos)
+            if pos is None:
+                break
+            if key is not None:
+                kwargs[key] = value
+            else:
+                args.append(value)
+
+        return TensorConfig(*args, **kwargs), end + 1
 
     def get_dtype(self, config, offset):
         token, offset = self.get_token(config, offset)


### PR DESCRIPTION
旧逻辑等价于 `config.index(")")`，嵌套括号场景下会得到残缺字符串再 `eval`，典型报错是括号未闭合或 `TensorConfig` 参数错位。

修改为 `TensorConfig(...)` 增加括号深度匹配，并在匹配到的子串上复用现有 `get_token` / `get_list` / `get_one_arg` 解析位置参数与 kwargs，从而保留 `place=Place(cpu)` 等嵌套值。解析窗口必须切到匹配的 `)` 为止，否则 `get_token` 会越过边界把下一个 `TensorConfig` 误读进来。