### PR TITLE
测试基建：🐛 修复前台运行 Ctrl+C 中断流程

### DIFF
--- a/run-example.sh
+++ b/run-example.sh
@@ -33,8 +33,8 @@ LOG_DIR="tester/api_config/test_log"
 # ── GPU / worker 调度 ─────────────────────────────────────────
 # NUM_GPUS!=0 时，engineV2 不受外部 "CUDA_VISIBLE_DEVICES" 影响。
 NUM_GPUS=-1
-NUM_WORKERS_PER_GPU=-1
-GPU_IDS="4-7"
+NUM_WORKERS_PER_GPU=1
+GPU_IDS="-1"
 # REQUIRED_MEMORY=10
 TIME_OUT=600
 

--- a/run-v4.sh
+++ b/run-v4.sh
@@ -50,8 +50,8 @@ LOG_DIR="tester/api_config/test_log"
 
 # ── GPU / worker 调度 ─────────────────────────────────────────
 NUM_GPUS=-1
-NUM_WORKERS_PER_GPU=-1
-GPU_IDS="4-7"
+NUM_WORKERS_PER_GPU=1
+GPU_IDS="-1"
 # REQUIRED_MEMORY=10
 TIME_OUT=600
 
@@ -261,7 +261,10 @@ if [[ "$FOREGROUND" == "true" ]]; then
     echo -e "\n\033[36m[前台模式] Ctrl+C 终止\033[0m"
     echo "日志同时写入: $LOG_FILE"
     echo ""
+    # 忽略 shell 自身的 SIGINT，让 Ctrl+C 只作用于 python 子进程
+    trap '' INT
     python "$ENGINE.py" "${ALL_ARGS[@]}" 2>&1 | tee "$LOG_FILE"
+    trap - INT
 else
     nohup setsid python "$ENGINE.py" "${ALL_ARGS[@]}" >> "$LOG_FILE" 2>&1 &
     PYTHON_PID=$!

--- a/run.py
+++ b/run.py
@@ -546,9 +546,14 @@ def run_foreground(command: list[str], env: dict[str, str], log_file: Path) -> i
     )
     with log_file.open("a", encoding="utf-8") as log_handle:
         assert process.stdout is not None
-        for line in process.stdout:
-            print(line, end="")
-            log_handle.write(line)
+        try:
+            for line in process.stdout:
+                print(line, end="")
+                log_handle.write(line)
+        except KeyboardInterrupt:
+            for line in process.stdout:
+                print(line, end="")
+                log_handle.write(line)
     return process.wait()
 
 


### PR DESCRIPTION
## 🧭 背景

`run.py` 与 `run-v4.sh` 提供前台执行模式，方便在终端实时观察测试输出并同步写入日志。此前用户在前台模式按下 Ctrl+C 时，信号会同时影响启动脚本、Python 流程和 `tee` 管道，容易使日志读取流程被提前打断，无法稳定等待子进程退出并完成剩余输出的落盘。

## 🔧 主要变更

`run-v4.sh` 在前台执行 `python | tee` 前设置 `trap '' INT`，避免 shell 被 Ctrl+C 提前中断；命令退出后恢复默认 `SIGINT` 处理。

`run.py` 的前台日志转发增加 `KeyboardInterrupt` 处理：中断发生后继续读取并同步打印、写入子进程剩余输出，最后等待并返回子进程退出码。

## 📁 改动文件

| 类别 | 文件 | 功能说明 |
| --- | --- | --- |
| 前台启动 | `run.py` | 捕获 Ctrl+C 后继续消费子进程输出并等待退出 |
| 前台启动 | `run-v4.sh` | 隔离 shell 的 SIGINT，并调整默认 GPU/worker 配置 |
| 示例配置 | `run-example.sh` | 调整默认 GPU 自动选择与单 worker 配置 |
