### PR TITLE
fix corss_entropy rules

### DIFF
--- a/tester/paddle_to_torch/rules.py
+++ b/tester/paddle_to_torch/rules.py
@@ -715,11 +715,19 @@ class CrossEntropyRule(BaseRule):
         defaults_code, map_code = self.apply_generic()
         pre = """
 shp = label.shape
-if len(input.shape) > 2:
-    perm = [0] + [len(input.shape)-1]+ [i for i in range(1,len(input.shape)-1)]
-    input = input.permute(*perm)
-axis = locals().get('axis',-1)
-label = label.squeeze(-1)
+axis = locals().get('axis', -1)
+num_classes = input.shape[axis]
+if soft_label:
+    # soft label: 维持原 channels-first permute 逻辑
+    if len(input.shape) > 2:
+        perm = [0] + [len(input.shape)-1]+ [i for i in range(1,len(input.shape)-1)]
+        input = input.permute(*perm)
+    label = label.squeeze(-1)
+else:
+    # hard label: 展平成 2D [N, C], 让 torch 与 paddle 走相同的 cross_entropy kernel,
+    # 避免 [N, C, d...] 触发 torch spatial nll_loss 路径 (与 2D 路径差 ~1 ulp, 造成假 diff)
+    input = input.movedim(axis, -1).reshape(-1, num_classes)
+    label = label.reshape(-1)
 if weight is not None:
     weight.requires_grad = False
 if label.dtype == torch.int32:


### PR DESCRIPTION
Paddle.cross_entropy，有axis参数，其处理方式为：
1. 沿 axis 那一维做 softmax；
2. 把除 axis 以外的所有维全部压平成一个大 batch 维，得到 [N_flat, C]，其中 N_flat = 所有非 axis 维的乘积；
3. 对这 N_flat 个"位置"，每个独立地取 -log_softmax[label]。

torch.cross_entropy，没有aixs参数，靠张量维数来选：
  - 输入 2 维 [N, C] → 走 2D kernel
  - 输入 ≥3 维 [N, C, d...] → 走 spatial kernel（把第 1 维当类别、后面当空间维）
  
原本PaddleAPITest内逻辑：
<img width="775" height="134" alt="image" src="https://github.com/user-attachments/assets/d886e56e-9b39-4bf7-a4c8-5f8c9ea30ab8" />
修改后：
<img width="678" height="153" alt="image" src="https://github.com/user-attachments/assets/1d381bb6-c0c1-44ee-98fe-28f75792cc6a" />

