### PR TITLE
测试基建：✨ 新增单 API 调试 Dump 能力

### DIFF
--- a/engineV2.py
+++ b/engineV2.py
@@ -38,8 +38,9 @@ if TYPE_CHECKING:
     )
 
 from tester.api_config.dump_writer import (
-    finalize_from_parent,
+    dump_enabled,
     parse_strict_bool,
+    record_dump_terminal_status,
     resolve_dump_options,
 )
 from tester.api_config.log_writer import *
@@ -612,7 +613,10 @@ def run_test_case(api_config_str, options):
         kwargs["runtime_config"] = runtime_config
         case = test_class(api_config, **kwargs)
         try:
-            case.run()
+            if dump_enabled():
+                case.run_with_dump()
+            else:
+                case.test()
             if has_terminal_log(api_config_str):
                 write_checkpoint(api_config_str)
         except Exception as err:
@@ -647,7 +651,8 @@ def run_test_case(api_config_str, options):
             elif any(marker in err_msg for marker in cuda_markers):
                 exit_code = FATAL_CUDA_EXIT_CODE
             if exit_code is not None:
-                finalize_from_parent("engine_fatal", exit_code=exit_code, error=str(err))
+                if dump_enabled():
+                    record_dump_terminal_status("engine_fatal", exit_code=exit_code, error=str(err))
                 if has_terminal_log(api_config_str):
                     write_checkpoint(api_config_str)
                 try:
@@ -1032,7 +1037,8 @@ def main():
             api_config = APIConfig(options.api_config)
         except Exception as err:
             print(f"[config_parse] {options.api_config} {err!s}", flush=True)
-            finalize_from_parent("config_parse", error=str(err))
+            if dump_enabled():
+                record_dump_terminal_status("config_parse", error=str(err))
             return
 
         test_class = _select_test_class(options)
@@ -1069,7 +1075,10 @@ def main():
         else:
             case = test_class(api_config, test_amp=options.test_amp)
         try:
-            case.run()
+            if dump_enabled():
+                case.run_with_dump()
+            else:
+                case.test()
         except Exception as err:
             if (
                 "Tensor-likes are not equal" in str(err)

--- a/engineV2.py
+++ b/engineV2.py
@@ -37,6 +37,11 @@ if TYPE_CHECKING:
         APITestTorchGPUPerformance,
     )
 
+from tester.api_config.dump_writer import (
+    finalize_from_parent,
+    parse_strict_bool,
+    resolve_dump_options,
+)
 from tester.api_config.log_writer import *
 
 os.environ["FLAGS_use_system_allocator"] = "1"
@@ -444,6 +449,17 @@ def validate_gpu_options(options) -> tuple:
     return tuple(gpu_ids)
 
 
+def _resolve_dump_options(parser, options):
+    try:
+        options.use_dump, options.dump_dir = resolve_dump_options(
+            options.use_dump, options.dump_dir
+        )
+    except ValueError as err:
+        parser.error(str(err))
+    os.environ["USE_DUMP"] = str(options.use_dump)
+    os.environ["DUMP_DIR"] = options.dump_dir
+
+
 def parse_bool(value):
     if isinstance(value, str):
         value = value.lower()
@@ -604,13 +620,14 @@ def run_test_case(api_config_str, options):
     except Exception as err:
         print(f"[config_parse] {api_config_str} {err!s}", flush=True)
         write_terminal_log("config_parse", api_config_str)
+        finalize_from_parent("config_parse", error=str(err))
         return
 
     test_class = _select_test_class(options)
     kwargs = {k: v for k, v in vars(options).items() if k in VALID_TEST_ARGS}
     case = test_class(api_config, **kwargs)
     try:
-        case.test()
+        case.run()
         if has_terminal_log(api_config_str):
             write_checkpoint(api_config_str)
     except Exception as err:
@@ -645,6 +662,7 @@ def run_test_case(api_config_str, options):
         elif any(marker in err_msg for marker in cuda_markers):
             exit_code = FATAL_CUDA_EXIT_CODE
         if exit_code is not None:
+            finalize_from_parent("engine_fatal", exit_code=exit_code, error=str(err))
             if has_terminal_log(api_config_str):
                 write_checkpoint(api_config_str)
             try:
@@ -659,6 +677,7 @@ def run_test_case(api_config_str, options):
             return
         # if not fatal error, subprocess will be alive and report error
         print(f"[error] {api_config_str}: {err}", flush=True)
+        finalize_from_parent("engine_error", error=str(err))
         raise
     finally:
         del test_class, api_config, case
@@ -700,7 +719,7 @@ def main():
     except Exception:
         paddle_version = "unknown"
 
-    parser = argparse.ArgumentParser(description="Run Paddle API test cases")
+    parser = argparse.ArgumentParser(description="Run Paddle API test cases", allow_abbrev=False)
     parser.add_argument(
         "--api_config_file",
         default="",
@@ -900,8 +919,20 @@ def main():
         default=False,
         help="Exit the process when a paddle_error occurs.",
     )
+    parser.add_argument(
+        "--use_dump",
+        type=parse_strict_bool,
+        default=None,
+        help="Enable dump tracing (True or False). Overrides USE_DUMP.",
+    )
+    parser.add_argument(
+        "--dump_dir",
+        default=None,
+        help="Dump output directory. Overrides DUMP_DIR; empty uses the default directory.",
+    )
 
     options = parser.parse_args()
+    _resolve_dump_options(parser, options)
     options.paddle_version = paddle_version
     print(f"Options: {vars(options)}", flush=True)
     print(f"PaddlePaddle version: {paddle_version}", flush=True)
@@ -922,6 +953,15 @@ def main():
     if len([m for m in mode if m is True]) != 1:
         _print_argument(ARGUMENT_ERROR_PREFIX, TEST_MODE_ERROR)
         return
+    if options.use_dump:
+        if not options.api_config or options.api_config_file or options.api_config_file_pattern:
+            _print_argument(ARGUMENT_ERROR_PREFIX, "dump only supports single --api_config runs")
+            return
+        if not (options.accuracy or options.paddle_only):
+            _print_argument(
+                ARGUMENT_ERROR_PREFIX, "dump currently supports only --accuracy or --paddle_only"
+            )
+            return
 
     # 处理 custom_device_vs_gpu 模式的配置
     bos_config_data = None
@@ -1015,6 +1055,7 @@ def main():
             api_config = APIConfig(options.api_config)
         except Exception as err:
             print(f"[config_parse] {options.api_config} {err!s}", flush=True)
+            finalize_from_parent("config_parse", error=str(err))
             return
 
         test_class = _select_test_class(options)
@@ -1050,7 +1091,7 @@ def main():
         else:
             case = test_class(api_config, test_amp=options.test_amp)
         try:
-            case.test()
+            case.run()
         except Exception as err:
             if (
                 "Tensor-likes are not equal" in str(err)
@@ -1211,11 +1252,17 @@ def main():
                             print(f"[info] Test case succeeded for {config}", flush=True)
                     except TimeoutError as err:
                         write_terminal_log("timeout", config)
+                        finalize_from_parent("engine_timeout", error=str(err))
                         print(
                             f"[timeout] {config}: {err}",
                             flush=True,
                         )
                     except ProcessExpired as err:
+                        finalize_from_parent(
+                            "engine_fatal",
+                            exit_code=err.exitcode,
+                            error=str(err),
+                        )
                         # CUDA, OOM, and Torch fatal errors may also expire the subprocess;
                         # classify them by dedicated terminal log types instead of falling through to crash.
                         if err.exitcode == FATAL_CUDA_EXIT_CODE:

--- a/engineV4.py
+++ b/engineV4.py
@@ -42,8 +42,9 @@ if TYPE_CHECKING:
     )
 
 from tester.api_config.dump_writer import (
-    finalize_from_parent,
+    dump_enabled,
     parse_strict_bool,
+    record_dump_terminal_status,
     resolve_dump_options,
 )
 from tester.api_config.log_writer import *
@@ -1244,7 +1245,10 @@ def run_test_case(api_config_str, options):
         kwargs["runtime_config"] = runtime_config
         case = test_class(api_config, **kwargs)
         try:
-            case.run()
+            if dump_enabled():
+                case.run_with_dump()
+            else:
+                case.test()
         except Exception as err:
             err_msg = str(err).lower()
             terminal_log_type = get_terminal_log_type(api_config_str)
@@ -1277,7 +1281,8 @@ def run_test_case(api_config_str, options):
             elif any(marker in err_msg for marker in cuda_markers):
                 exit_code = FATAL_CUDA_EXIT_CODE
             if exit_code is not None:
-                finalize_from_parent("engine_fatal", exit_code=exit_code, error=str(err))
+                if dump_enabled():
+                    record_dump_terminal_status("engine_fatal", exit_code=exit_code, error=str(err))
                 if has_terminal_log(api_config_str):
                     write_checkpoint(api_config_str)
                 try:

--- a/engineV4.py
+++ b/engineV4.py
@@ -42,6 +42,11 @@ if TYPE_CHECKING:
         APITestTorchGPUPerformance,
     )
 
+from tester.api_config.dump_writer import (
+    finalize_from_parent,
+    parse_strict_bool,
+    resolve_dump_options,
+)
 from tester.api_config.log_writer import *
 
 os.environ["FLAGS_use_system_allocator"] = "1"
@@ -1025,6 +1030,17 @@ def validate_gpu_options(options) -> tuple:
     return tuple(gpu_ids)
 
 
+def _resolve_dump_options(parser, options):
+    try:
+        options.use_dump, options.dump_dir = resolve_dump_options(
+            options.use_dump, options.dump_dir
+        )
+    except ValueError as err:
+        parser.error(str(err))
+    os.environ["USE_DUMP"] = str(options.use_dump)
+    os.environ["DUMP_DIR"] = options.dump_dir
+
+
 def parse_bool(value):
     if isinstance(value, str):
         value = value.lower()
@@ -1275,13 +1291,14 @@ def run_test_case(api_config_str, options):
     except Exception as err:
         print(f"[config_parse] {api_config_str} {err!s}", flush=True)
         write_to_log("config_parse", api_config_str)
+        finalize_from_parent("config_parse", error=str(err))
         return
 
     test_class = _select_test_class(options)
     kwargs = {k: v for k, v in vars(options).items() if k in VALID_TEST_ARGS}
     case = test_class(api_config, **kwargs)
     try:
-        case.test()
+        case.run()
     except Exception as err:
         err_msg = str(err).lower()
         terminal_log_type = get_terminal_log_type(api_config_str)
@@ -1314,6 +1331,7 @@ def run_test_case(api_config_str, options):
         elif any(marker in err_msg for marker in cuda_markers):
             exit_code = FATAL_CUDA_EXIT_CODE
         if exit_code is not None:
+            finalize_from_parent("engine_fatal", exit_code=exit_code, error=str(err))
             if has_terminal_log(api_config_str):
                 write_checkpoint(api_config_str)
             try:
@@ -1328,6 +1346,7 @@ def run_test_case(api_config_str, options):
             return
         # if not fatal error, subprocess will be alive and report error
         print(f"[test error] {api_config_str}: {err}", flush=True)
+        finalize_from_parent("engine_error", error=str(err))
         raise
     finally:
         del test_class, api_config, case
@@ -1359,7 +1378,7 @@ def main():
         except Exception:
             paddle_version = "unknown"
 
-    parser = argparse.ArgumentParser(description="Run Paddle API test cases")
+    parser = argparse.ArgumentParser(description="Run Paddle API test cases", allow_abbrev=False)
     parser.add_argument(
         "--api_config_file",
         default="",
@@ -1560,6 +1579,17 @@ def main():
         help="Exit the process when a paddle_error occurs.",
     )
     parser.add_argument(
+        "--use_dump",
+        type=parse_strict_bool,
+        default=None,
+        help="Enable dump tracing (True or False). Overrides USE_DUMP.",
+    )
+    parser.add_argument(
+        "--dump_dir",
+        default=None,
+        help="Dump output directory. Overrides DUMP_DIR; empty uses the default directory.",
+    )
+    parser.add_argument(
         "--use_compute_sanitizer",
         type=parse_bool,
         default=False,
@@ -1585,6 +1615,7 @@ def main():
     )
 
     options = parser.parse_args()
+    _resolve_dump_options(parser, options)
     options.paddle_version = paddle_version
     if not options._sanitizer_child:
         print(f"Main process id: {os.getpid()}")
@@ -1607,6 +1638,15 @@ def main():
     if len([m for m in mode if m is True]) != 1:
         _print_argument(ARGUMENT_ERROR_PREFIX, TEST_MODE_ERROR)
         return
+    if options.use_dump:
+        if not options.api_config or options.api_config_file or options.api_config_file_pattern:
+            _print_argument(ARGUMENT_ERROR_PREFIX, "dump only supports single --api_config runs")
+            return
+        if not (options.accuracy or options.paddle_only):
+            _print_argument(
+                ARGUMENT_ERROR_PREFIX, "dump currently supports only --accuracy or --paddle_only"
+            )
+            return
 
     # 处理 custom_device_vs_gpu 模式的配置
     bos_config_data = None
@@ -1719,6 +1759,7 @@ def main():
             api_config = APIConfig(options.api_config)
         except Exception as err:
             print(f"[config_parse] {options.api_config} {err!s}", flush=True)
+            finalize_from_parent("config_parse", error=str(err))
             return
 
         test_class = _select_test_class(options)
@@ -1754,7 +1795,7 @@ def main():
         else:
             case = test_class(api_config, test_amp=options.test_amp)
         try:
-            case.test()
+            case.run()
         except Exception as err:
             if (
                 "Tensor-likes are not equal" in str(err)

--- a/run.py
+++ b/run.py
@@ -73,6 +73,8 @@ ENGINE_ARG_TYPES = {
     "bitwise_alignment": bool,
     "generate_failed_tests": bool,
     "exit_on_error": bool,
+    "use_dump": bool,
+    "dump_dir": str,
     "use_compute_sanitizer": bool,
     "sanitizer_command": str,
     "sanitizer_error_exitcode": int,

--- a/test_pipeline/run_config.schema.json
+++ b/test_pipeline/run_config.schema.json
@@ -87,6 +87,8 @@
         "bitwise_alignment": {"type": "boolean", "description": "对应 --bitwise_alignment。"},
         "generate_failed_tests": {"type": "boolean", "description": "对应 --generate_failed_tests。"},
         "exit_on_error": {"type": "boolean", "description": "对应 --exit_on_error。"},
+        "use_dump": {"type": "boolean", "default": false, "description": "对应 --use_dump；CLI > USE_DUMP > 默认 false。仅支持单条 api_config，且当前仅支持 accuracy 或 paddle_only 模式。"},
+        "dump_dir": {"type": "string", "description": "对应 --dump_dir；CLI > DUMP_DIR > 默认 tester/api_config/test_log/dump_case。仅配置路径不会开启 dump；空 CLI path 使用默认路径且不回退环境变量。"},
         "use_compute_sanitizer": {"type": "boolean", "description": "engineV4 only，对应 --use_compute_sanitizer。"},
         "sanitizer_command": {"type": "string", "description": "engineV4 only，对应 --sanitizer_command。"},
         "sanitizer_error_exitcode": {"type": "integer", "description": "engineV4 only，对应 --sanitizer_error_exitcode。"},

--- a/test_pipeline/run_config.yaml
+++ b/test_pipeline/run_config.yaml
@@ -20,6 +20,9 @@
 # - output.log_dir 必填。
 # - engine_args 中未配置或注释掉的字段使用 engine 默认值。
 # - 布尔值会被 run.py 转为 --key=True/False 传给 engine。
+# - Dump 配置逐字段按显式 CLI > 环境变量 > 默认值解析：USE_DUMP 默认 false，DUMP_DIR 默认
+#   tester/api_config/test_log/dump_case。仅配置 dump_dir / DUMP_DIR 不会开启 dump。
+# - --dump_dir=（显式空路径）使用默认路径，不会回退 DUMP_DIR。
 # - 标注 engineV4 only 的字段只应在 runner.engine=engineV4 时启用。
 
 name: run_config
@@ -109,6 +112,10 @@ engine_args:
   # bitwise_alignment: true
   # generate_failed_tests: true
   # exit_on_error: true
+  # use_dump: true  # 单条 api_config 调试；当前仅支持 accuracy / paddle_only
+  # dump_dir: "tester/api_config/test_log/dump_case"
+  # 也可使用环境变量 USE_DUMP=True 和 DUMP_DIR=<dir>；USE_DUMP 大小写不敏感，
+  # 接受 true/1/yes/y 和 false/0/no/n。
 
   # ========== 精度阈值 ==========
   # atol: 0.01

--- a/tester/accuracy.py
+++ b/tester/accuracy.py
@@ -88,24 +88,31 @@ class APITestAccuracy(APITestBase):
 
     # @func_set_timeout(600)
     def test(self):
+        self.dump_event("api_analyze_start", mode="accuracy")
         if self.need_skip():
             print(f"[skip] {self.api_config.config}", flush=True)
             write_to_log("skip", self.api_config.config)
+            self.dump_finalize("skip")
             return
 
         if not self.ana_api_info():
             print("ana_api_info failed", flush=True)
             write_to_log("config_parse", self.api_config.config)
+            self.dump_finalize("config_parse")
             return
+        self.dump_event("api_analyze_done", api_name=self.api_config.api_name)
 
         try:
+            self.dump_event("config_convert_start")
             convert_result = self.converter.convert(self.api_config.api_name)
         except Exception as e:
+            self.dump_error("config_convert_error", e)
             print(
                 f"[config_convert] Conversion failed for {self.api_config.config}: {e!s}",
                 flush=True,
             )
             write_to_log("config_convert", self.api_config.config)
+            self.dump_finalize("config_convert")
             return
         if not convert_result.is_supported:
             print(
@@ -113,22 +120,31 @@ class APITestAccuracy(APITestBase):
                 flush=True,
             )
             write_to_log("config_convert", self.api_config.config)
+            self.dump_event("config_convert_error", error=convert_result.error_message)
+            self.dump_finalize("config_convert")
             return
+        self.dump_event("config_convert_done")
         if not convert_result.code or not convert_result.code.is_valid():
             print(
                 f"[config_convert] No code generated for {self.api_config.api_name}",
                 flush=True,
             )
             write_to_log("config_convert", self.api_config.config)
+            self.dump_event("config_convert_error", error="no code generated")
+            self.dump_finalize("config_convert")
             return
 
         try:
+            self.dump_event("numpy_input_start")
             if not self.gen_numpy_input():
                 print("gen_numpy_input failed")
                 write_to_log("config_input", self.api_config.config)
+                self.dump_finalize("config_input")
                 return
+            self.dump_event("numpy_input_done")
         except Exception as err:
-            log_type, fatal = self.report_runtime_error(err, "config_input", "gen_numpy_input")
+            log_type, fatal = self.report_runtime_error(err, "config_input", "numpy_input")
+            self.dump_finalize(log_type or "config_input")
             if fatal:
                 raise
             return
@@ -136,10 +152,18 @@ class APITestAccuracy(APITestBase):
         try:
             device = torch.device("cuda:0")
             torch.set_default_device(device)
+            self.dump_event("torch_input_start")
             if not self.gen_torch_input():
                 print("gen_torch_input failed", flush=True)
                 write_to_log("torch_error", self.api_config.config)
+                self.dump_finalize("torch_error")
                 return
+            self.dump_save(
+                "torch_inputs",
+                {"args": self.torch_args, "kwargs": self.torch_kwargs},
+                framework="torch",
+            )
+            self.dump_event("torch_input_done")
 
             # Reseed before executing torch, so that random APIs
             # (e.g. torch.rand / uniform / normal / dropout) produce
@@ -150,6 +174,7 @@ class APITestAccuracy(APITestBase):
             # (弃用)以下代码等价于:
             # torch_output = Paddle2TorchConverter.execute(convert_result, self.torch_args, self.torch_kwargs)
             # 准备执行环境，将参数(torch tensors)直接映射至locals()
+            self.dump_event("torch_forward_start")
             exec_globals = {"torch": torch}
             exec_locals = {
                 "args": self.torch_args,
@@ -179,6 +204,8 @@ class APITestAccuracy(APITestBase):
 
             output_var = convert_result.output_var or "result"
             torch_output = exec_locals[output_var]
+            self.dump_save("torch_forward_output", torch_output, framework="torch")
+            self.dump_event("torch_forward_done")
             del exec_globals, exec_locals, output_var, convert_result, code
 
             # if "paddle.Tensor." in self.api_config.api_name:
@@ -205,6 +232,7 @@ class APITestAccuracy(APITestBase):
         except Exception as err:
             traceback.print_exc()
             _, fatal = self.report_runtime_error(err, "torch_error", "torch_forward")
+            self.dump_finalize("torch_error")
             if fatal:
                 raise
             return
@@ -213,9 +241,19 @@ class APITestAccuracy(APITestBase):
         torch_out_grads = None
         if self.need_check_grad():
             try:
+                self.dump_event("torch_backward_start")
                 inputs_list = self.get_torch_input_list()
                 result_outputs, result_outputs_grads = self.gen_torch_output_and_output_grad(
                     torch_output
+                )
+                self.dump_save(
+                    "torch_backward",
+                    {
+                        "inputs": inputs_list,
+                        "outputs": result_outputs,
+                        "grad_outputs": result_outputs_grads,
+                    },
+                    framework="torch",
                 )
                 del self.torch_args, self.torch_kwargs
                 if inputs_list and result_outputs and result_outputs_grads:
@@ -225,9 +263,12 @@ class APITestAccuracy(APITestBase):
                         grad_outputs=result_outputs_grads,
                     )
                     torch_grad_success = True
+                    self.dump_save("torch_input_grads", torch_out_grads, framework="torch")
+                self.dump_event("torch_backward_done", grad_success=torch_grad_success)
                 del inputs_list, result_outputs, result_outputs_grads
             except Exception as err:
                 if str(err).startswith("Too large tensor to get cached numpy: "):
+                    self.dump_error("torch_backward_error", err)
                     print(f"[config_input] {self.api_config.config}\n{err!s}")
                     write_to_log("config_input", self.api_config.config)
                     return
@@ -270,15 +311,24 @@ class APITestAccuracy(APITestBase):
             torch.cuda.empty_cache()
 
         try:
+            self.dump_event("paddle_input_start")
             if not self.gen_paddle_input():
                 print("gen_paddle_input failed")
                 write_to_log("paddle_error", self.api_config.config)
+                self.dump_finalize("paddle_error")
                 return
+            self.dump_save(
+                "paddle_inputs",
+                {"args": self.paddle_args, "kwargs": self.paddle_kwargs},
+                framework="paddle",
+            )
+            self.dump_event("paddle_input_done")
 
             # Reseed before executing paddle so that random APIs
             # (paddle.uniform / normal / randn / bernoulli / dropout ...)
             # match the torch run with the same seed.
             self._reset_random_state()
+            self.dump_event("paddle_forward_start")
             if "paddle.Tensor." in self.api_config.api_name:
                 api = getattr(
                     self.paddle_args[0],
@@ -314,9 +364,12 @@ class APITestAccuracy(APITestBase):
             return
 
         try:
+            self.dump_save("paddle_forward_output", paddle_output, framework="paddle")
+            self.dump_event("paddle_forward_done")
             paddle.base.core.eager._for_test_check_cuda_error()
         except Exception as err:
-            self.report_runtime_error(err, "paddle_cuda", "paddle_forward_cuda_check")
+            self.report_runtime_error(err, "paddle_cuda", "paddle_forward")
+            self.dump_finalize("paddle_cuda")
             raise
 
         paddle_output, torch_output = process_output(self.api_config, paddle_output, torch_output)
@@ -335,7 +388,7 @@ class APITestAccuracy(APITestBase):
                 )
             except Exception as err:
                 phase = "backward" if self.is_backward else "forward"
-                self.report_compare_error(err, f"{phase} idx={idx}")
+                self.report_compare_error(err, f"compare_{phase}")
                 if self.exit_on_error:
                     raise
                 return False
@@ -358,6 +411,7 @@ class APITestAccuracy(APITestBase):
                         f"[paddle_accuracy] reason=not_compare {self.api_config.config}\n{err!s}",
                         flush=True,
                     )
+                    self.dump_finalize("paddle_accuracy")
                     write_to_log("paddle_accuracy", self.api_config.config)
                     return
             elif isinstance(torch_output, (torch.return_types.max, torch.return_types.min)):
@@ -370,6 +424,7 @@ class APITestAccuracy(APITestBase):
                     f"torch is {type(torch_output)} but paddle is {type(paddle_output)}",
                     flush=True,
                 )
+                self.dump_finalize("paddle_accuracy")
                 write_to_log("paddle_accuracy", self.api_config.config)
                 return
         elif isinstance(paddle_output, (list, tuple)):
@@ -379,6 +434,7 @@ class APITestAccuracy(APITestBase):
                     f"torch is {type(torch_output)} but paddle is {type(paddle_output)}",
                     flush=True,
                 )
+                self.dump_finalize("paddle_accuracy")
                 write_to_log("paddle_accuracy", self.api_config.config)
                 return
             paddle_output = list(paddle_output)
@@ -389,6 +445,7 @@ class APITestAccuracy(APITestBase):
                     f"torch len is {len(torch_output)} but paddle len is {len(paddle_output)}",
                     flush=True,
                 )
+                self.dump_finalize("paddle_accuracy")
                 write_to_log("paddle_accuracy", self.api_config.config)
                 return
             for i, (paddle_item, torch_item) in enumerate(
@@ -417,6 +474,7 @@ class APITestAccuracy(APITestBase):
                             f"torch is {type(torch_item)} but paddle is {type(paddle_item)}",
                             flush=True,
                         )
+                        self.dump_finalize("paddle_accuracy")
                         write_to_log("paddle_accuracy", self.api_config.config)
                         return
                 elif (
@@ -436,6 +494,7 @@ class APITestAccuracy(APITestBase):
                         f"torch is {type(torch_item)} but paddle is {type(paddle_item)}",
                         flush=True,
                     )
+                    self.dump_finalize("paddle_accuracy")
                     write_to_log("paddle_accuracy", self.api_config.config)
                     return
                 else:
@@ -497,6 +556,7 @@ class APITestAccuracy(APITestBase):
                         f"torch is {type(torch_out_grads)} but paddle is {type(paddle_out_grads)}",
                         flush=True,
                     )
+                    self.dump_finalize("paddle_accuracy")
                     write_to_log("paddle_accuracy", self.api_config.config)
                     return
             elif isinstance(paddle_out_grads, (list, tuple)):
@@ -506,6 +566,7 @@ class APITestAccuracy(APITestBase):
                         f"torch is {type(torch_out_grads)} but paddle is {type(paddle_out_grads)}",
                         flush=True,
                     )
+                    self.dump_finalize("paddle_accuracy")
                     write_to_log("paddle_accuracy", self.api_config.config)
                     return
                 paddle_out_grads = list(paddle_out_grads)
@@ -516,6 +577,7 @@ class APITestAccuracy(APITestBase):
                         f"torch len is {len(torch_out_grads)} but paddle len is {len(paddle_out_grads)}",
                         flush=True,
                     )
+                    self.dump_finalize("paddle_accuracy")
                     write_to_log("paddle_accuracy", self.api_config.config)
                     return
                 for i, (paddle_item, torch_item) in enumerate(
@@ -546,6 +608,7 @@ class APITestAccuracy(APITestBase):
                             f"torch is {type(torch_item)} but paddle is {type(paddle_item)}",
                             flush=True,
                         )
+                        self.dump_finalize("paddle_accuracy")
                         write_to_log("paddle_accuracy", self.api_config.config)
                         return
                     else:
@@ -554,6 +617,7 @@ class APITestAccuracy(APITestBase):
 
         print(f"[pass] {self.api_config.config}", flush=True)
         write_to_log("pass", self.api_config.config)
+        self.dump_finalize("pass")
 
 
 def process_output(api_config, paddle_output, torch_output):

--- a/tester/api_config/dump_writer.py
+++ b/tester/api_config/dump_writer.py
@@ -603,7 +603,7 @@ def dump_enabled() -> bool:
     return parse_strict_bool(os.environ.get("USE_DUMP", "false"))
 
 
-def finalize_from_parent(status: str, **data: Any) -> None:
+def record_dump_terminal_status(status: str, **data: Any) -> None:
     if not dump_enabled():
         return
     ctx = DumpContext(

--- a/tester/api_config/dump_writer.py
+++ b/tester/api_config/dump_writer.py
@@ -1,0 +1,625 @@
+from __future__ import annotations
+
+import contextlib
+import os
+import platform
+import re
+import shutil
+import socket
+import subprocess
+import sys
+import time
+import traceback
+from importlib import metadata as importlib_metadata
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import yaml
+
+DEFAULT_DUMP_DIR = "tester/api_config/test_log/dump_case"
+
+
+def parse_strict_bool(value: bool | str) -> bool:
+    """Parse supported boolean spellings, rejecting every other value."""
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in {"true", "1", "yes", "y"}:
+            return True
+        if normalized in {"false", "0", "no", "n"}:
+            return False
+    raise ValueError(f"expected one of true/1/yes/y or false/0/no/n, got {value!r}")
+
+
+def resolve_dump_options(
+    cli_use_dump: bool | None,
+    cli_dump_dir: str | None,
+    *,
+    environ: dict[str, str] | os._Environ[str] | None = None,
+) -> tuple[bool, str]:
+    """Resolve each dump field independently with CLI > env > default precedence."""
+    env = os.environ if environ is None else environ
+    if cli_use_dump is not None:
+        use_dump = cli_use_dump
+    elif "USE_DUMP" in env:
+        try:
+            use_dump = parse_strict_bool(env["USE_DUMP"])
+        except ValueError as err:
+            raise ValueError(f"invalid USE_DUMP: {err}") from err
+    else:
+        use_dump = False
+
+    if cli_dump_dir is not None:
+        dump_dir = cli_dump_dir or DEFAULT_DUMP_DIR
+    else:
+        dump_dir = env.get("DUMP_DIR") or DEFAULT_DUMP_DIR
+    return use_dump, dump_dir
+
+
+class TeeStream:
+    def __init__(self, primary, secondary):
+        self.primary = primary
+        self.secondary = secondary
+
+    def write(self, data):
+        self.primary.write(data)
+        self.secondary.write(data)
+        self.flush()
+        return len(data)
+
+    def flush(self):
+        self.primary.flush()
+        self.secondary.flush()
+
+    def isatty(self):
+        return getattr(self.primary, "isatty", lambda: False)()
+
+    def fileno(self):
+        return self.primary.fileno()
+
+
+class DumpContext:
+    def __init__(
+        self,
+        dump_dir: str | os.PathLike[str],
+        api_config: str | None = None,
+        *,
+        auto_start: bool = True,
+    ):
+        self.root = Path(dump_dir)
+        self.tensors_dir = self.root / "tensors"
+        self.metadata_path = self.root / "dump.yaml"
+        self.api_config = api_config or ""
+        self.current_phase = "created"
+        self._data: dict[str, Any] = {}
+        self.root.mkdir(parents=True, exist_ok=True)
+        self.tensors_dir.mkdir(parents=True, exist_ok=True)
+        self._data = self._init_metadata(auto_start=auto_start)
+        self.current_phase = self._data.get("current_phase", "created")
+        if auto_start:
+            self._data["environment"] = collect_environment(self._data["run"])
+            self._append_event("engine_start")
+            self._flush_metadata()
+
+    def _init_metadata(self, *, auto_start: bool) -> dict[str, Any]:
+        if not auto_start and self.metadata_path.exists():
+            try:
+                with self.metadata_path.open(encoding="utf-8") as f:
+                    loaded = yaml.safe_load(f) or {}
+                if isinstance(loaded, dict):
+                    return loaded
+            except Exception:
+                pass
+        return {
+            "schema_version": 1,
+            "created_at": _now_text(),
+            "created_timestamp": time.time(),
+            "api_config": self.api_config,
+            "current_phase": self.current_phase,
+            "status": None,
+            "run": _collect_run_info(),
+            "environment": {},
+            "events": [],
+            "tensors": [],
+        }
+
+    def _flush_metadata(self) -> None:
+        self._data["current_phase"] = self.current_phase
+        tmp = self.metadata_path.with_suffix(".yaml.tmp")
+        with tmp.open("w", encoding="utf-8") as f:
+            yaml.safe_dump(
+                _make_yaml_safe(self._data),
+                f,
+                allow_unicode=True,
+                default_flow_style=False,
+                sort_keys=False,
+            )
+        tmp.replace(self.metadata_path)
+
+    def _append_event(self, name: str, **data: Any) -> None:
+        self.current_phase = data.pop("phase", name)
+        payload = {
+            "event": name,
+            "time": _now_text(),
+            "timestamp": time.time(),
+            "pid": os.getpid(),
+            "current_phase": self.current_phase,
+        }
+        payload.update(data)
+        self._data.setdefault("events", []).append(payload)
+
+    def event(self, name: str, **data: Any) -> None:
+        self._append_event(name, **data)
+        self._flush_metadata()
+
+    def error_event(self, name: str, err: BaseException) -> None:
+        self.event(
+            name,
+            error_type=type(err).__name__,
+            error=str(err),
+            traceback="".join(traceback.format_exception(type(err), err, err.__traceback__)),
+        )
+
+    def finalize(self, status: str, **data: Any) -> None:
+        payload = {
+            "name": status,
+            "time": _now_text(),
+            "timestamp": time.time(),
+            "pid": os.getpid(),
+            "current_phase": self.current_phase,
+        }
+        payload.update(data)
+        self._data["status"] = payload
+        self._append_event(f"final_{status}", **data)
+        self._flush_metadata()
+
+    def save_tensors(self, stem: str, obj: Any, framework: str | None = None) -> None:
+        arrays: dict[str, np.ndarray] = {}
+        items: list[dict[str, Any]] = []
+        _collect_tensor_items(obj, stem, arrays, items, framework=framework)
+        path = self.tensors_dir / f"{stem}.npz"
+        tmp = path.with_suffix(".npz.tmp")
+        with tmp.open("wb") as f:
+            np.savez_compressed(f, **arrays)
+        tmp.replace(path)
+        stat = path.stat()
+        entry = {
+            "name": stem,
+            "framework": framework,
+            "file": str(path.relative_to(self.root)),
+            "format": "npz",
+            "size_bytes": stat.st_size,
+            "saved_at": _now_text(),
+            "items": _make_yaml_safe(items),
+        }
+        tensors = self._data.setdefault("tensors", [])
+        tensors[:] = [item for item in tensors if item.get("name") != stem]
+        tensors.append(entry)
+        self._append_event(
+            f"save_{stem}_done",
+            tensor_file=entry["file"],
+            size_bytes=stat.st_size,
+        )
+        self._flush_metadata()
+
+    @contextlib.contextmanager
+    def tee_output(self):
+        log_path = self.root / "case.log"
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+        with log_path.open("a", encoding="utf-8") as f:
+            old_stdout, old_stderr = sys.stdout, sys.stderr
+            sys.stdout = TeeStream(old_stdout, f)
+            sys.stderr = TeeStream(old_stderr, f)
+            try:
+                yield
+            finally:
+                sys.stdout = old_stdout
+                sys.stderr = old_stderr
+
+
+def collect_environment(process: dict[str, Any] | None = None) -> dict[str, Any]:
+    return {
+        "captured_at": _now_text(),
+        "process": process or _collect_run_info(),
+        "system": _collect_system_info(),
+        "env": _collect_relevant_env(),
+        "gpu": _collect_gpu_info(),
+        "cuda_runtime": _collect_cuda_info(),
+        "framework_runtime": _collect_framework_runtime(),
+        "python_packages": _collect_python_packages(),
+        "pip_freeze": _run_command([sys.executable, "-m", "pip", "freeze"], timeout=30).get(
+            "stdout_lines", []
+        ),
+    }
+
+
+def _collect_run_info() -> dict[str, Any]:
+    return {
+        "python": sys.version,
+        "executable": sys.executable,
+        "argv": sys.argv,
+        "hostname": socket.gethostname(),
+        "cwd": os.getcwd(),
+        "pid": os.getpid(),
+        "ppid": os.getppid(),
+    }
+
+
+def _collect_system_info() -> dict[str, Any]:
+    info = {
+        "platform": platform.platform(),
+        "system": platform.system(),
+        "release": platform.release(),
+        "version": platform.version(),
+        "machine": platform.machine(),
+        "processor": platform.processor(),
+        "python_build": platform.python_build(),
+        "python_compiler": platform.python_compiler(),
+        "libc": platform.libc_ver(),
+        "uname": platform.uname()._asdict(),
+    }
+    os_release = Path("/etc/os-release")
+    if os_release.exists():
+        info["os_release"] = os_release.read_text(encoding="utf-8", errors="replace")
+    return info
+
+
+def _collect_relevant_env() -> dict[str, str]:
+    prefixes = (
+        "CUDA",
+        "CUDNN",
+        "CUBLAS",
+        "CUPTI",
+        "NCCL",
+        "NVIDIA",
+        "NV",
+        "FLAGS_",
+        "PADDLE",
+        "TORCH",
+        "PYTORCH",
+        "PYTHON",
+        "OMP",
+        "MKL",
+        "OPENBLAS",
+        "BLAS",
+        "LAPACK",
+        "LD_",
+    )
+    names = {
+        "PATH",
+        "PYTHONPATH",
+        "LIBRARY_PATH",
+        "CPATH",
+        "USE_GPU_MODE",
+        "USE_CACHED_NUMPY",
+        "USE_DUMP",
+        "DUMP_DIR",
+        "SKIP_GPU_CLEANUP",
+    }
+    redacted = ("KEY", "SECRET", "TOKEN", "PASSWORD", "PASSWD", "AK", "SK")
+    env = {}
+    for key, value in sorted(os.environ.items()):
+        if key in names or key.startswith(prefixes):
+            if any(part in key.upper() for part in redacted):
+                env[key] = "<redacted>"
+            else:
+                env[key] = value
+    return env
+
+
+def _collect_gpu_info() -> dict[str, Any]:
+    queries = [
+        "index",
+        "name",
+        "uuid",
+        "driver_version",
+        "vbios_version",
+        "compute_cap",
+        "memory.total",
+        "memory.free",
+        "memory.used",
+        "clocks.current.graphics",
+        "clocks.current.memory",
+        "power.limit",
+        "power.draw",
+        "temperature.gpu",
+    ]
+    result = _run_command(
+        [
+            "nvidia-smi",
+            f"--query-gpu={','.join(queries)}",
+            "--format=csv,noheader,nounits",
+        ],
+        timeout=15,
+    )
+    info: dict[str, Any] = {"nvidia_smi_query": result}
+    if result.get("returncode") == 0:
+        gpus = []
+        for line in result.get("stdout_lines", []):
+            values = [part.strip() for part in line.split(",")]
+            gpus.append(dict(zip(queries, values)))
+        info["gpus"] = gpus
+    info["nvidia_smi"] = _run_command(["nvidia-smi"], timeout=15)
+    return info
+
+
+def _collect_cuda_info() -> dict[str, Any]:
+    info: dict[str, Any] = {
+        "nvcc": _run_command(["nvcc", "--version"], timeout=15),
+        "ldconfig_cuda_libraries": _collect_cuda_libraries(),
+    }
+    cuda_home = os.environ.get("CUDA_HOME") or os.environ.get("CUDA_PATH")
+    if cuda_home:
+        info["cuda_home"] = cuda_home
+        info["cuda_version_file"] = _read_optional(
+            Path(cuda_home) / "version.json"
+        ) or _read_optional(Path(cuda_home) / "version.txt")
+    return info
+
+
+def _collect_cuda_libraries() -> list[str] | dict[str, str]:
+    if not shutil.which("ldconfig"):
+        return {"error": "ldconfig not found"}
+    result = _run_command(["ldconfig", "-p"], timeout=15)
+    if result.get("returncode") != 0:
+        return result
+    patterns = (
+        "cuda",
+        "cudart",
+        "cublas",
+        "cudnn",
+        "cufft",
+        "curand",
+        "cusolver",
+        "cusparse",
+        "cutensor",
+        "nccl",
+        "nvrtc",
+    )
+    return [
+        line
+        for line in result.get("stdout_lines", [])
+        if any(name in line.lower() for name in patterns)
+    ]
+
+
+def _collect_framework_runtime() -> dict[str, Any]:
+    info: dict[str, Any] = {}
+
+    def collect_paddle():
+        import paddle
+
+        version = getattr(paddle, "version", None)
+        return {
+            "version": getattr(version, "full_version", getattr(paddle, "__version__", None)),
+            "cuda": version.cuda() if version and hasattr(version, "cuda") else None,
+            "cudnn": version.cudnn() if version and hasattr(version, "cudnn") else None,
+            "nccl": version.nccl() if version and hasattr(version, "nccl") else None,
+            "mkl": version.mkl() if version and hasattr(version, "mkl") else None,
+            "compiled_with_cuda": paddle.device.is_compiled_with_cuda(),
+        }
+
+    def collect_torch():
+        import torch
+
+        return {
+            "version": str(torch.__version__),
+            "cuda": torch.version.cuda,
+            "cudnn": torch.backends.cudnn.version()
+            if torch.backends.cudnn.is_available()
+            else None,
+            "nccl": torch.cuda.nccl.version()
+            if torch.cuda.is_available()
+            and hasattr(torch.cuda, "nccl")
+            and hasattr(torch.cuda.nccl, "version")
+            else None,
+            "hip": torch.version.hip,
+            "cuda_available": torch.cuda.is_available(),
+        }
+
+    info["paddle"] = _safe_call(collect_paddle)
+    info["torch"] = _safe_call(collect_torch)
+    info["numpy"] = {"version": np.__version__}
+    return info
+
+
+def _collect_python_packages() -> dict[str, str]:
+    packages = {}
+    for dist in importlib_metadata.distributions():
+        name = dist.metadata.get("Name")
+        if name:
+            packages[name] = dist.version
+    return dict(sorted(packages.items(), key=lambda item: item[0].lower()))
+
+
+def _safe_call(fn):
+    try:
+        return fn()
+    except Exception as err:
+        return {"error": str(err)}
+
+
+def _run_command(command: list[str], timeout: int = 10) -> dict[str, Any]:
+    if not command or not shutil.which(command[0]):
+        return {"command": command, "error": f"{command[0] if command else ''} not found"}
+    try:
+        completed = subprocess.run(
+            command,
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+        return {
+            "command": command,
+            "returncode": completed.returncode,
+            "stdout": completed.stdout,
+            "stderr": completed.stderr,
+            "stdout_lines": completed.stdout.splitlines(),
+            "stderr_lines": completed.stderr.splitlines(),
+        }
+    except Exception as err:
+        return {"command": command, "error": str(err)}
+
+
+def _read_optional(path: Path) -> str | None:
+    try:
+        if path.exists():
+            return path.read_text(encoding="utf-8", errors="replace")
+    except Exception:
+        return None
+    return None
+
+
+def _collect_tensor_items(
+    obj: Any,
+    path: str,
+    arrays: dict[str, np.ndarray],
+    items: list[dict[str, Any]],
+    *,
+    framework: str | None,
+) -> None:
+    if obj is None:
+        items.append({"path": path, "kind": "none"})
+        return
+    if isinstance(obj, dict):
+        items.append({"path": path, "kind": "dict", "keys": list(obj.keys())})
+        for key, value in obj.items():
+            _collect_tensor_items(value, f"{path}/{key}", arrays, items, framework=framework)
+        return
+    if isinstance(obj, (list, tuple)):
+        items.append({"path": path, "kind": type(obj).__name__, "length": len(obj)})
+        for index, value in enumerate(obj):
+            _collect_tensor_items(value, f"{path}/{index}", arrays, items, framework=framework)
+        return
+
+    meta: dict[str, Any] = {"path": path}
+    array = tensor_to_numpy(obj, meta)
+    if array is None:
+        items.append(_make_yaml_safe(meta))
+        return
+    key = _unique_key(_safe_key(path), arrays)
+    arrays[key] = array
+    meta.update(
+        {
+            "key": key,
+            "saved_dtype": str(arrays[key].dtype),
+            "saved_shape": list(arrays[key].shape),
+            "nbytes": int(arrays[key].nbytes),
+        }
+    )
+    if framework and "framework" not in meta:
+        meta["framework"] = framework
+    items.append(_make_yaml_safe(meta))
+
+
+def tensor_to_numpy(obj: Any, meta: dict[str, Any]) -> np.ndarray | None:
+    module = type(obj).__module__
+    type_name = type(obj).__name__
+    if module.startswith("paddle") and type_name == "Tensor":
+        meta.update(
+            {
+                "kind": "tensor",
+                "framework": "paddle",
+                "type": "Tensor",
+                "dtype": str(getattr(obj, "dtype", "")),
+                "shape": list(getattr(obj, "shape", [])),
+                "place": str(getattr(obj, "place", "")),
+                "stop_gradient": getattr(obj, "stop_gradient", None),
+            }
+        )
+        return obj.numpy()
+    if module.startswith("torch") and type_name == "Tensor":
+        meta.update(
+            {
+                "kind": "tensor",
+                "framework": "torch",
+                "type": "Tensor",
+                "dtype": str(getattr(obj, "dtype", "")),
+                "shape": list(getattr(obj, "shape", [])),
+                "device": str(getattr(obj, "device", "")),
+                "requires_grad": getattr(obj, "requires_grad", None),
+            }
+        )
+        tensor = obj.detach().cpu().contiguous()
+        try:
+            return tensor.numpy()
+        except Exception:
+            meta["stored_as"] = "raw_uint8"
+            return np.frombuffer(tensor.numpy(force=True).tobytes(), dtype=np.uint8)
+    if isinstance(obj, np.ndarray):
+        meta.update({"kind": "ndarray", "dtype": str(obj.dtype), "shape": list(obj.shape)})
+        return obj
+    if isinstance(obj, (bool, int, float, str, np.generic)):
+        array = np.asarray(obj)
+        meta.update(
+            {
+                "kind": type(obj).__name__,
+                "dtype": str(array.dtype),
+                "shape": list(array.shape),
+                "value": obj.item() if isinstance(obj, np.generic) else obj,
+            }
+        )
+        return array
+    meta.update({"kind": "repr", "type": f"{module}.{type_name}", "repr": repr(obj)})
+    return None
+
+
+def _safe_key(path: str) -> str:
+    key = re.sub(r"[^0-9A-Za-z_]+", "_", path).strip("_")
+    return key or "value"
+
+
+def _unique_key(key: str, arrays: dict[str, np.ndarray]) -> str:
+    if key not in arrays:
+        return key
+    index = 1
+    while f"{key}_{index}" in arrays:
+        index += 1
+    return f"{key}_{index}"
+
+
+def _make_yaml_safe(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {str(k): _make_yaml_safe(v) for k, v in value.items()}
+    if isinstance(value, (list, tuple, set)):
+        return [_make_yaml_safe(item) for item in value]
+    if isinstance(value, np.generic):
+        return value.item()
+    if isinstance(value, np.ndarray):
+        return value.tolist()
+    if isinstance(value, (str, int, float, bool)) or value is None:
+        return value
+    return str(value)
+
+
+def _now_text() -> str:
+    return time.strftime("%Y-%m-%dT%H:%M:%S%z")
+
+
+def dump_enabled() -> bool:
+    return parse_strict_bool(os.environ.get("USE_DUMP", "false"))
+
+
+def finalize_from_parent(status: str, **data: Any) -> None:
+    if not dump_enabled():
+        return
+    ctx = DumpContext(
+        os.environ.get("DUMP_DIR") or DEFAULT_DUMP_DIR,
+        auto_start=False,
+    )
+    if not ctx._data.get("environment"):
+        ctx._data["environment"] = collect_environment()
+    ctx._append_event(status, **data)
+    ctx._data["status"] = {
+        "name": status,
+        "time": _now_text(),
+        "timestamp": time.time(),
+        "pid": os.getpid(),
+        "current_phase": ctx.current_phase,
+        **data,
+    }
+    ctx._append_event(f"final_{status}", **data)
+    ctx._flush_metadata()

--- a/tester/base.py
+++ b/tester/base.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import collections
+import contextlib
 import inspect
 import os
 
@@ -15,6 +16,7 @@ from .api_config.config_analyzer import (
     is_gpu_mode,
     should_skip_gpu_cleanup,
 )
+from .api_config.dump_writer import DEFAULT_DUMP_DIR, DumpContext, dump_enabled
 from .api_config.log_writer import log_accuracy_tolerance, write_to_log
 
 with open("tester/base_config.yaml", encoding="utf-8") as f:
@@ -235,14 +237,52 @@ class APITestBase:
     def __init__(self, api_config, use_torch=True):
         self.api_config = api_config
         self.api_config.use_torch = use_torch
+        self.dump_context = (
+            DumpContext(
+                os.environ.get("DUMP_DIR") or DEFAULT_DUMP_DIR,
+                api_config=api_config.config,
+            )
+            if dump_enabled()
+            else None
+        )
         self.outputs_grad_numpy = []
         self.outputs_grad_paddleonly = []
         if use_torch:
             torch.set_num_threads(8)
             torch.set_printoptions(threshold=100, linewidth=120)
 
+    def run(self):
+        output_context = (
+            self.dump_context.tee_output() if self.dump_context else contextlib.nullcontext()
+        )
+        with output_context:
+            try:
+                return self.test()
+            except Exception as err:
+                if self.dump_context and self.dump_context._data.get("status") is None:
+                    self.dump_finalize("engine_error", error=str(err))
+                raise
+
+    def dump_event(self, name, **data):
+        if self.dump_context:
+            self.dump_context.event(name, **data)
+
+    def dump_error(self, name, err):
+        if self.dump_context:
+            self.dump_context.error_event(name, err)
+
+    def dump_save(self, stem, obj, framework=None):
+        if self.dump_context:
+            self.dump_context.save_tensors(stem, obj, framework=framework)
+
+    def dump_finalize(self, status, **data):
+        if self.dump_context:
+            self.dump_context.finalize(status, **data)
+
     def report_runtime_error(self, err, default_log_type, phase="", allow_ignore_paddle=False):
         err_msg = str(err)
+        if phase:
+            self.dump_error(f"{phase}_error", err)
         log_type, fatal = classify_runtime_error(err_msg)
         if log_type is None and allow_ignore_paddle and self.should_ignore_paddle_error(err_msg):
             print(f"[pass] {self.api_config.config}", flush=True)

--- a/tester/base.py
+++ b/tester/base.py
@@ -300,15 +300,15 @@ class APITestBase:
             torch.set_num_threads(8)
             torch.set_printoptions(threshold=100, linewidth=120)
 
-    def run(self):
-        output_context = (
-            self.dump_context.tee_output() if self.dump_context else contextlib.nullcontext()
-        )
-        with output_context:
+    def run_with_dump(self):
+        """Execute the test with dump output capture and lifecycle reporting."""
+        if self.dump_context is None:
+            raise RuntimeError("run_with_dump() requires dump mode to be enabled")
+        with self.dump_context.tee_output():
             try:
                 return self.test()
             except Exception as err:
-                if self.dump_context and self.dump_context._data.get("status") is None:
+                if self.dump_context._data.get("status") is None:
                     self.dump_finalize("engine_error", error=str(err))
                 raise
 

--- a/tester/paddle_only.py
+++ b/tester/paddle_only.py
@@ -15,60 +15,93 @@ class APITestPaddleOnly(APITestBase):
 
     # @func_set_timeout(600)
     def test(self):
+        self.dump_event("api_analyze_start", mode="paddle_only")
         if self.need_skip(paddle_only=True):
             print(f"[skip] {self.api_config.config}", flush=True)
             write_to_log("skip", self.api_config.config)
+            self.dump_finalize("skip")
             return
 
         if not self.ana_paddle_api_info():
             print("ana_paddle_api_info failed", flush=True)
             write_to_log("config_parse", self.api_config.config)
+            self.dump_finalize("config_parse")
             return
+        self.dump_event("api_analyze_done", api_name=self.api_config.api_name)
 
         try:
+            self.dump_event("numpy_input_start")
             if not self.gen_numpy_input():
                 print("gen_numpy_input failed", flush=True)
                 write_to_log("config_input", self.api_config.config)
+                self.dump_finalize("config_input")
                 return
+            self.dump_event("numpy_input_done")
         except Exception as err:
-            log_type, fatal = self.report_runtime_error(err, "config_input", "gen_numpy_input")
+            log_type, fatal = self.report_runtime_error(err, "config_input", "numpy_input")
+            self.dump_finalize(log_type or "config_input")
             if fatal:
                 raise
             return
 
         try:
+            self.dump_event("paddle_input_start")
             if not self.gen_paddle_input():
                 print("gen_paddle_input failed", flush=True)
                 write_to_log("paddle_error", self.api_config.config)
+                self.dump_finalize("paddle_error")
                 return
+            self.dump_save(
+                "paddle_inputs",
+                {"args": self.paddle_args, "kwargs": self.paddle_kwargs},
+                framework="paddle",
+            )
+            self.dump_event("paddle_input_done")
+
+            self.dump_event("paddle_forward_start")
             if self.test_amp:
                 with paddle.amp.auto_cast():
                     paddle_output = self.paddle_api(*tuple(self.paddle_args), **self.paddle_kwargs)
             else:
                 paddle_output = self.paddle_api(*tuple(self.paddle_args), **self.paddle_kwargs)
+            self.dump_save("paddle_forward_output", paddle_output, framework="paddle")
+            self.dump_event("paddle_forward_done")
+
             if self.need_check_grad():
+                self.dump_event("paddle_backward_start")
                 inputs_list = self.get_paddle_input_list()
                 result_outputs, result_outputs_grads = self.gen_paddle_output_and_output_grad(
                     paddle_output
+                )
+                self.dump_save(
+                    "paddle_backward",
+                    {
+                        "inputs": inputs_list,
+                        "outputs": result_outputs,
+                        "grad_outputs": result_outputs_grads,
+                    },
+                    framework="paddle",
                 )
                 if (
                     len(inputs_list) != 0
                     and len(result_outputs) != 0
                     and len(result_outputs_grads) != 0
                 ):
-                    paddle.grad(
+                    input_grads = paddle.grad(
                         result_outputs,
                         inputs_list,
                         grad_outputs=result_outputs_grads,
                         allow_unused=True,
                     )
+                    self.dump_save("paddle_input_grads", input_grads, framework="paddle")
+                self.dump_event("paddle_backward_done")
+            else:
+                self.dump_event("paddle_backward_skipped")
         except Exception as err:
-            paddle_output = None
-            result_outputs = None
-            result_outputs_grads = None
             _, fatal = self.report_runtime_error(
                 err, "paddle_error", "paddle_only", allow_ignore_paddle=True
             )
+            self.dump_finalize("paddle_error")
             if fatal:
                 raise
             return
@@ -76,14 +109,10 @@ class APITestPaddleOnly(APITestBase):
         try:
             paddle.base.core.eager._for_test_check_cuda_error()
         except Exception as err:
-            paddle_output = None
-            result_outputs = None
-            result_outputs_grads = None
             self.report_runtime_error(err, "paddle_cuda", "paddle_only_cuda_check")
+            self.dump_finalize("paddle_cuda")
             raise
 
-        paddle_output = None
-        result_outputs = None
-        result_outputs_grads = None
         print(f"[pass] {self.api_config.config}", flush=True)
         write_to_log("pass", self.api_config.config)
+        self.dump_finalize("pass")


### PR DESCRIPTION
## 🧭 背景
现有 API 测试在出现精度差异、运行时异常或进程级故障时，主要依赖终端输出和分类日志定位，缺少对运行环境、执行阶段、中间张量及完整输出的统一留存，部分问题因此难以复现和回溯。

本 PR 为单条 `api_config` 调试新增可选 Dump 能力，当前支持 `accuracy` 和 `paddle_only` 模式，将运行元数据、阶段事件、关键张量、完整日志及可能影响精度的环境信息集中保存。

## 🛠️ 实现方案
新增统一的 `DumpContext` 管理 Dump 生命周期。开启后，测试基类通过 `run()` 包装原有测试调用，统一处理日志转存和未处理异常收尾；具体测试流程通过事件、张量保存和最终状态接口记录各执行阶段。父进程在配置解析失败、超时、子进程退出及引擎级错误场景补写终态，保留故障发生前已落盘的阶段产物。

Dump 配置按字段独立遵循“显式 CLI > 环境变量 > 默认值”的优先级：

- `--use_dump` / `USE_DUMP` 控制是否开启，默认关闭
- `--dump_dir` / `DUMP_DIR` 指定目录，默认 `tester/api_config/test_log/dump_case`
- 仅设置目录不会开启 Dump；显式空 `--dump_dir` 使用默认目录且不回退环境变量
- 开启时仅允许单条 `--api_config`，且当前仅支持 `accuracy` 或 `paddle_only`

Dump 产物由 `dump.yaml`、`case.log` 和 `tensors/*.npz` 组成。元数据持续记录阶段时间线、最终状态、进程与系统、GPU/CUDA、框架版本、Python 包及脱敏后的关键环境变量；张量通过压缩 NPZ 保存，并在 YAML 中记录容器路径、类型、形状、设备和梯度属性等恢复信息。

## 🔧 主要变更
### 1. 新增统一 Dump 基础能力
实现配置解析、上下文管理、环境采集、事件记录、异常记录、状态收尾和原子化元数据更新。支持递归提取 Paddle Tensor、Torch Tensor、NumPy 数组及嵌套容器中的数据。

### 2. 接入测试执行生命周期
为测试基类新增统一 `run()` 入口，在 Dump 开启时捕获标准输出和错误输出，并统一处理未捕获异常。Engine V2、Engine V4 改为通过该入口执行测试，同时规范化 `USE_DUMP` 和 `DUMP_DIR` 供测试进程及 sanitizer 子进程继承。

### 3. 覆盖关键执行阶段和终态
在 API 解析、输入生成、Paddle/Torch 前向与反向、结果比较等阶段即时写入事件和张量产物。成功、跳过、配置错误、运行时错误及精度失败均写入最终状态；父进程异常路径也会补充终态信息。

### 4. 补充配置入口和使用说明
Engine V2、Engine V4 新增 `--use_dump` 和 `--dump_dir`，并关闭 argparse 参数缩写以避免旧 `--dump` 被误识别。Pipeline Runner、配置 Schema 和示例 YAML 同步支持新参数及优先级说明。

## 📁 改动文件
| 类别 | 文件 | 功能说明 |
| --- | --- | --- |
| Engine 接入 | `engineV2.py`、`engineV4.py` | 接入参数、模式约束、统一运行入口及父进程异常收尾 |
| Pipeline 配置 | `run.py`、`test_pipeline/run_config.schema.json`、`test_pipeline/run_config.yaml` | 注册参数并补充 Schema 与配置示例 |
| Dump 核心 | `tester/api_config/dump_writer.py` | 实现环境采集、日志转存、阶段事件和张量持久化 |
| 测试基类 | `tester/base.py` | 提供统一执行包装和 Dump 操作接口 |
| 测试模式 | `tester/accuracy.py`、`tester/paddle_only.py` | 记录关键阶段、张量产物和最终状态 |
