### PR TITLE
测试基建：♻️ 收敛测试日志写入链路

### DIFF
--- a/engineV2.py
+++ b/engineV2.py
@@ -551,10 +551,6 @@ def init_worker_gpu(gpu_worker_list, lock, available_gpus, max_workers_per_gpu, 
 
         redirect_stdio()
 
-        print(
-            f"{datetime.now()} Worker PID: {my_pid}, Assigned GPU ID: {assigned_gpu}",
-            flush=True,
-        )
     except Exception as e:
         print(f"{datetime.now()} Worker {my_pid} initialization failed: {e}", flush=True)
         raise
@@ -562,14 +558,19 @@ def init_worker_gpu(gpu_worker_list, lock, available_gpus, max_workers_per_gpu, 
 
 def run_test_case(api_config_str, options):
     """Run a single test case for the given API configuration."""
-    case_id = write_case_begin(api_config_str)
+    completion = [os.getpid(), None]
+    started_at = time.monotonic()
+    gpu_id = int(os.environ.get("CUDA_VISIBLE_DEVICES", "0").split(",")[0])
+    case_id = write_case_begin(
+        api_config_str,
+        worker_pid=os.getpid(),
+        gpu=gpu_id,
+        paddle_version=options.paddle_version,
+    )
     case_status = "done"
     try:
-        cuda_visible = os.environ.get("CUDA_VISIBLE_DEVICES", "0")
-        gpu_id = int(cuda_visible.split(",")[0])
-
         print(
-            f"{datetime.now()} GPU {gpu_id} {os.getpid()} [paddle {options.paddle_version}] test begin: {api_config_str}",
+            f"test begin: {api_config_str}",
             flush=True,
         )
 
@@ -608,7 +609,7 @@ def run_test_case(api_config_str, options):
             print(f"[config_parse] {api_config_str} {err!s}", flush=True)
             write_terminal_log("config_parse", api_config_str)
             case_status = "error"
-            return os.getpid()
+            return completion
 
         test_class = _select_test_class(options)
         kwargs = {k: v for k, v in vars(options).items() if k in VALID_TEST_ARGS}
@@ -660,7 +661,7 @@ def run_test_case(api_config_str, options):
                         os._exit(exit_code)
             if has_terminal_log(api_config_str):
                 write_checkpoint(api_config_str)
-                return os.getpid()
+                return completion
             # if not fatal error, subprocess will be alive and report error
             print(f"[error] {api_config_str}: {err}", flush=True)
             raise
@@ -690,12 +691,17 @@ def run_test_case(api_config_str, options):
                         flush=True,
                     )
 
-        return os.getpid()
+        return completion
     except BaseException:
         case_status = "error"
         raise
     finally:
-        write_case_end(case_status, case_id=case_id)
+        completion[1] = write_case_end(
+            case_status,
+            case_id=case_id,
+            api_config_str=api_config_str,
+            duration_ms=round((time.monotonic() - started_at) * 1000),
+        )
 
 
 def main():
@@ -1217,18 +1223,18 @@ def main():
                     config = futures[future]
                     checkpoint_ready = True
                     try:
-                        worker_pid = future.result()
-                        mark_inorder_case_complete(worker_pid)
+                        worker_pid, completed_offset = future.result()
+                        mark_inorder_case_complete(worker_pid, completed_offset)
                         if options.show_runtime_status or tested_case % 10000 == 0:
                             print(f"[info] Test case succeeded for {config}", flush=True)
                     except TimeoutError as err:
                         write_terminal_log("timeout", config)
                         worker_pid = getattr(err, "pid", None)
                         if worker_pid is not None:
-                            append_case_end_to_worker_log(
+                            completed_offset = append_case_end_to_worker_log(
                                 worker_pid, "timeout", api_config_str=config
                             )
-                            mark_inorder_case_complete(worker_pid, flush=True)
+                            mark_inorder_case_complete(worker_pid, completed_offset)
                         print(
                             f"[timeout] {config}: {err}",
                             flush=True,
@@ -1281,10 +1287,10 @@ def main():
                         )
                         checkpoint_ready = False  # checkpoint already written by write_terminal_log
                         if worker_pid is not None:
-                            append_case_end_to_worker_log(
+                            completed_offset = append_case_end_to_worker_log(
                                 worker_pid, expired_status, api_config_str=config
                             )
-                            mark_inorder_case_complete(worker_pid, flush=True)
+                            mark_inorder_case_complete(worker_pid, completed_offset)
                     if checkpoint_ready:
                         tested_case += 1
                         if options.show_runtime_status or tested_case % 10000 == 0:

--- a/engineV2.py
+++ b/engineV2.py
@@ -607,6 +607,7 @@ def run_test_case(api_config_str, options):
         except Exception as err:
             print(f"[config_parse] {api_config_str} {err!s}", flush=True)
             write_terminal_log("config_parse", api_config_str)
+            case_status = "error"
             return os.getpid()
 
         test_class = _select_test_class(options)

--- a/engineV2.py
+++ b/engineV2.py
@@ -562,129 +562,139 @@ def init_worker_gpu(gpu_worker_list, lock, available_gpus, max_workers_per_gpu, 
 
 def run_test_case(api_config_str, options):
     """Run a single test case for the given API configuration."""
-    cuda_visible = os.environ.get("CUDA_VISIBLE_DEVICES", "0")
-    gpu_id = int(cuda_visible.split(",")[0])
+    case_id = write_case_begin(api_config_str)
+    case_status = "done"
+    try:
+        cuda_visible = os.environ.get("CUDA_VISIBLE_DEVICES", "0")
+        gpu_id = int(cuda_visible.split(",")[0])
 
-    print(
-        f"{datetime.now()} GPU {gpu_id} {os.getpid()} [paddle {options.paddle_version}] test begin: {api_config_str}",
-        flush=True,
-    )
-
-    last_memory_log_time = 0
-    while True:
-        total_memory, used_memory = get_memory_info(gpu_id)
-        free_memory = total_memory - used_memory
-
-        if free_memory >= options.required_memory:
-            break
-
-        now = time.time()
-        if now - last_memory_log_time >= MEMORY_WAIT_LOG_INTERVAL:
-            print(
-                f"{datetime.now()} device {gpu_id} Free: {free_memory:.1f} GB, "
-                f"Required: {options.required_memory:.1f} GB. ",
-                "Waiting for available memory...",
-                flush=True,
-            )
-            last_memory_log_time = now
-        time.sleep(MEMORY_WAIT_SECONDS)
-
-    if options.show_runtime_status:
-        total_memory, used_memory_before = get_memory_info(gpu_id)
         print(
-            f"{datetime.now()} GPU {gpu_id} memory before: used={used_memory_before:.1f} GB, "
-            f"free={total_memory - used_memory_before:.1f} GB",
+            f"{datetime.now()} GPU {gpu_id} {os.getpid()} [paddle {options.paddle_version}] test begin: {api_config_str}",
             flush=True,
         )
 
-    api_config = None
-    case = None
-    try:
-        api_config = APIConfig(api_config_str)
-    except Exception as err:
-        print(f"[config_parse] {api_config_str} {err!s}", flush=True)
-        write_terminal_log("config_parse", api_config_str)
-        return
+        last_memory_log_time = 0
+        while True:
+            total_memory, used_memory = get_memory_info(gpu_id)
+            free_memory = total_memory - used_memory
 
-    test_class = _select_test_class(options)
-    kwargs = {k: v for k, v in vars(options).items() if k in VALID_TEST_ARGS}
-    case = test_class(api_config, **kwargs)
-    try:
-        case.test()
-        if has_terminal_log(api_config_str):
-            write_checkpoint(api_config_str)
-    except Exception as err:
-        err_msg = str(err).lower()
-        terminal_log_type = get_terminal_log_type(api_config_str)
-        oom_markers = (
-            "cuda out of memory",
-            "out of memory error",
-            "resourceexhaustederror",
-            "out of memory",
-            "outofmemoryerror",
-            "cannot allocate memory",
-            "std::bad_alloc",
-            "bad allocation",
-            "memoryerror",
-            "cublas_status_alloc_failed",
-        )
-        cuda_markers = (
-            "cuda error",
-            "memory corruption",
-            "illegal memory access",
-            "invalid configuration argument",
-            "invalid resource handle",
-        )
-        exit_code = None
-        if any(marker in err_msg for marker in oom_markers):
-            exit_code = FATAL_OOM_EXIT_CODE
-        elif terminal_log_type == "torch_error" and any(
-            marker in err_msg for marker in cuda_markers
-        ):
-            exit_code = FATAL_TORCH_EXIT_CODE
-        elif any(marker in err_msg for marker in cuda_markers):
-            exit_code = FATAL_CUDA_EXIT_CODE
-        if exit_code is not None:
+            if free_memory >= options.required_memory:
+                break
+
+            now = time.time()
+            if now - last_memory_log_time >= MEMORY_WAIT_LOG_INTERVAL:
+                print(
+                    f"{datetime.now()} device {gpu_id} Free: {free_memory:.1f} GB, "
+                    f"Required: {options.required_memory:.1f} GB. ",
+                    "Waiting for available memory...",
+                    flush=True,
+                )
+                last_memory_log_time = now
+            time.sleep(MEMORY_WAIT_SECONDS)
+
+        if options.show_runtime_status:
+            total_memory, used_memory_before = get_memory_info(gpu_id)
+            print(
+                f"{datetime.now()} GPU {gpu_id} memory before: used={used_memory_before:.1f} GB, "
+                f"free={total_memory - used_memory_before:.1f} GB",
+                flush=True,
+            )
+
+        api_config = None
+        case = None
+        try:
+            api_config = APIConfig(api_config_str)
+        except Exception as err:
+            print(f"[config_parse] {api_config_str} {err!s}", flush=True)
+            write_terminal_log("config_parse", api_config_str)
+            return os.getpid()
+
+        test_class = _select_test_class(options)
+        kwargs = {k: v for k, v in vars(options).items() if k in VALID_TEST_ARGS}
+        case = test_class(api_config, **kwargs)
+        try:
+            case.test()
             if has_terminal_log(api_config_str):
                 write_checkpoint(api_config_str)
-            try:
-                close_process_files()
-            finally:
+        except Exception as err:
+            err_msg = str(err).lower()
+            terminal_log_type = get_terminal_log_type(api_config_str)
+            oom_markers = (
+                "cuda out of memory",
+                "out of memory error",
+                "resourceexhaustederror",
+                "out of memory",
+                "outofmemoryerror",
+                "cannot allocate memory",
+                "std::bad_alloc",
+                "bad allocation",
+                "memoryerror",
+                "cublas_status_alloc_failed",
+            )
+            cuda_markers = (
+                "cuda error",
+                "memory corruption",
+                "illegal memory access",
+                "invalid configuration argument",
+                "invalid resource handle",
+            )
+            exit_code = None
+            if any(marker in err_msg for marker in oom_markers):
+                exit_code = FATAL_OOM_EXIT_CODE
+            elif terminal_log_type == "torch_error" and any(
+                marker in err_msg for marker in cuda_markers
+            ):
+                exit_code = FATAL_TORCH_EXIT_CODE
+            elif any(marker in err_msg for marker in cuda_markers):
+                exit_code = FATAL_CUDA_EXIT_CODE
+            if exit_code is not None:
+                if has_terminal_log(api_config_str):
+                    write_checkpoint(api_config_str)
                 try:
-                    restore_stdio()
+                    close_process_files()
                 finally:
-                    os._exit(exit_code)
-        if has_terminal_log(api_config_str):
-            write_checkpoint(api_config_str)
-            return
-        # if not fatal error, subprocess will be alive and report error
-        print(f"[error] {api_config_str}: {err}", flush=True)
+                    try:
+                        restore_stdio()
+                    finally:
+                        os._exit(exit_code)
+            if has_terminal_log(api_config_str):
+                write_checkpoint(api_config_str)
+                return os.getpid()
+            # if not fatal error, subprocess will be alive and report error
+            print(f"[error] {api_config_str}: {err}", flush=True)
+            raise
+        finally:
+            del test_class, api_config, case
+            gc.collect()
+            if not any(
+                getattr(options, opt)
+                for opt in (
+                    "paddle_gpu_performance",
+                    "torch_gpu_performance",
+                    "paddle_torch_gpu_performance",
+                )
+            ) and not getattr(options, "use_gpu_mode", False):
+                _clear_device_cache(options)
+            if options.show_runtime_status:
+                try:
+                    total_memory, used_memory_after = get_memory_info(gpu_id)
+                    print(
+                        f"{datetime.now()} GPU {gpu_id} memory after cleanup: used={used_memory_after:.1f} GB, "
+                        f"free={total_memory - used_memory_after:.1f} GB",
+                        flush=True,
+                    )
+                except Exception as err:
+                    print(
+                        f"{datetime.now()} Failed to read GPU {gpu_id} memory after cleanup: {err}",
+                        flush=True,
+                    )
+
+        return os.getpid()
+    except BaseException:
+        case_status = "error"
         raise
     finally:
-        del test_class, api_config, case
-        gc.collect()
-        if not any(
-            getattr(options, opt)
-            for opt in (
-                "paddle_gpu_performance",
-                "torch_gpu_performance",
-                "paddle_torch_gpu_performance",
-            )
-        ) and not getattr(options, "use_gpu_mode", False):
-            _clear_device_cache(options)
-        if options.show_runtime_status:
-            try:
-                total_memory, used_memory_after = get_memory_info(gpu_id)
-                print(
-                    f"{datetime.now()} GPU {gpu_id} memory after cleanup: used={used_memory_after:.1f} GB, "
-                    f"free={total_memory - used_memory_after:.1f} GB",
-                    flush=True,
-                )
-            except Exception as err:
-                print(
-                    f"{datetime.now()} Failed to read GPU {gpu_id} memory after cleanup: {err}",
-                    flush=True,
-                )
+        write_case_end(case_status, case_id=case_id)
 
 
 def main():
@@ -1206,37 +1216,50 @@ def main():
                     config = futures[future]
                     checkpoint_ready = True
                     try:
-                        future.result()
+                        worker_pid = future.result()
+                        mark_inorder_case_complete(worker_pid)
                         if options.show_runtime_status or tested_case % 10000 == 0:
                             print(f"[info] Test case succeeded for {config}", flush=True)
                     except TimeoutError as err:
                         write_terminal_log("timeout", config)
+                        worker_pid = getattr(err, "pid", None)
+                        if worker_pid is not None:
+                            append_case_end_to_worker_log(
+                                worker_pid, "timeout", api_config_str=config
+                            )
+                            mark_inorder_case_complete(worker_pid, flush=True)
                         print(
                             f"[timeout] {config}: {err}",
                             flush=True,
                         )
                     except ProcessExpired as err:
+                        worker_pid = getattr(err, "pid", None)
+                        expired_status = "paddle_crash"
                         # CUDA, OOM, and Torch fatal errors may also expire the subprocess;
                         # classify them by dedicated terminal log types instead of falling through to crash.
                         if err.exitcode == FATAL_CUDA_EXIT_CODE:
+                            expired_status = "paddle_cuda"
                             write_terminal_log("paddle_cuda", config)
                             print(
                                 f"[paddle_cuda] {config}: {err}",
                                 flush=True,
                             )
                         elif err.exitcode == FATAL_OOM_EXIT_CODE:
+                            expired_status = "oom"
                             write_terminal_log("oom", config)
                             print(
                                 f"[oom] {config}: {err}",
                                 flush=True,
                             )
                         elif err.exitcode == FATAL_TORCH_EXIT_CODE:
+                            expired_status = "torch_error"
                             write_terminal_log("torch_error", config)
                             print(
                                 f"[torch_error] {config}: {err}",
                                 flush=True,
                             )
                         elif err.exitcode in (-signal.SIGKILL, -signal.SIGTERM):
+                            expired_status = "timeout"
                             checkpoint_ready = False
                             print(
                                 f"[warn] Worker was externally killed for {config} "
@@ -1256,6 +1279,11 @@ def main():
                             flush=True,
                         )
                         checkpoint_ready = False  # checkpoint already written by write_terminal_log
+                        if worker_pid is not None:
+                            append_case_end_to_worker_log(
+                                worker_pid, expired_status, api_config_str=config
+                            )
+                            mark_inorder_case_complete(worker_pid, flush=True)
                     if checkpoint_ready:
                         tested_case += 1
                         if options.show_runtime_status or tested_case % 10000 == 0:

--- a/engineV4.py
+++ b/engineV4.py
@@ -208,13 +208,13 @@ def _worker_loop(slot_index, gpu_id, input_queue, result_queue, options):
 
         try:
             run_test_case(api_config_str, options)
-            result_queue.put(("done", slot_index, api_config_str))
+            result_queue.put(("done", slot_index, api_config_str, os.getpid()))
         except SystemExit:
             # run_test_case calls os._exit for CUDA errors, this shouldn't reach here
             # but if it does via sys.exit, let it propagate
             raise
         except Exception as e:
-            result_queue.put(("error", slot_index, api_config_str, str(e)))
+            result_queue.put(("error", slot_index, api_config_str, str(e), os.getpid()))
 
     # Graceful exit
     try:
@@ -292,6 +292,7 @@ def _sanitizer_worker_loop(slot_index, gpu_id, input_queue, result_queue, option
 
             api_config_str = task
             result_queue.put(("ack", slot_index, api_config_str))
+            case_id = write_case_begin(api_config_str)
             case_log_dir = get_sanitizer_case_log_dir(slot_index, os.getpid())
             if case_log_dir.exists():
                 shutil.rmtree(case_log_dir)
@@ -302,7 +303,8 @@ def _sanitizer_worker_loop(slot_index, gpu_id, input_queue, result_queue, option
                 )
             except ValueError as err:
                 shutil.rmtree(case_log_dir, ignore_errors=True)
-                result_queue.put(("error", slot_index, api_config_str, str(err)))
+                write_case_end("error", case_id=case_id)
+                result_queue.put(("error", slot_index, api_config_str, str(err), os.getpid()))
                 continue
 
             print(
@@ -323,7 +325,8 @@ def _sanitizer_worker_loop(slot_index, gpu_id, input_queue, result_queue, option
                 )
             except OSError as err:
                 shutil.rmtree(case_log_dir, ignore_errors=True)
-                result_queue.put(("error", slot_index, api_config_str, str(err)))
+                write_case_end("error", case_id=case_id)
+                result_queue.put(("error", slot_index, api_config_str, str(err), os.getpid()))
                 continue
             result_queue.put(("child", slot_index, child_process.pid))
             output_tail = deque(maxlen=40)
@@ -361,14 +364,17 @@ def _sanitizer_worker_loop(slot_index, gpu_id, input_queue, result_queue, option
                 shutil.rmtree(case_log_dir, ignore_errors=True)
 
                 if returncode == 0 or analysis.ignore_error_exitcode:
-                    result_queue.put(("done", slot_index, api_config_str))
+                    write_case_end("done", case_id=case_id)
+                    result_queue.put(("done", slot_index, api_config_str, os.getpid()))
                 elif returncode == 2:
+                    write_case_end("error", case_id=case_id)
                     result_queue.put(
                         (
                             "error",
                             slot_index,
                             api_config_str,
                             f"child exited with {returncode}",
+                            os.getpid(),
                         )
                     )
                 else:
@@ -591,15 +597,19 @@ class WorkerPool:
         if self._closed or self._shutdown_event.is_set():
             return
         config = slot.current_task
+        old_pid = slot.process.pid if slot.process else None
         print(
             f"{datetime.now()} Watchdog: slot {slot.index} timeout, killing PID {slot.process.pid}",
             flush=True,
         )
         self._kill_slot_child(slot)
         self._kill_process(slot.process)
+        if old_pid is not None and config is not None:
+            append_case_end_to_worker_log(old_pid, "timeout", api_config_str=config)
+            mark_inorder_case_complete(old_pid, flush=True)
         if self._closed or self._shutdown_event.is_set():
             return
-        self.result_queue.put(("timeout", slot.index, config))
+        self.result_queue.put(("timeout", slot.index, config, old_pid))
         self._spawn_worker(slot)
 
     def _handle_crash(self, slot):
@@ -1239,108 +1249,117 @@ def check_gpu_memory(gpu_ids, num_workers_per_gpu, required_memory):  # required
 
 def run_test_case(api_config_str, options):
     """Run a single test case for the given API configuration."""
-    cuda_visible = os.environ.get("CUDA_VISIBLE_DEVICES", "0")
-    gpu_id = int(cuda_visible.split(",")[0])
+    case_id = write_case_begin(api_config_str)
+    case_status = "done"
+    try:
+        cuda_visible = os.environ.get("CUDA_VISIBLE_DEVICES", "0")
+        gpu_id = int(cuda_visible.split(",")[0])
 
-    print(
-        f"{datetime.now()} GPU {gpu_id} {os.getpid()} [paddle {options.paddle_version}] test begin: {api_config_str}",
-        flush=True,
-    )
-
-    max_memory_wait = 30  # max 30 iterations × 10s = 5 minutes
-    for wait_iter in range(max_memory_wait):
-        total_memory, used_memory = get_memory_info(gpu_id)
-        free_memory = total_memory - used_memory
-
-        if free_memory >= options.required_memory:
-            break
-
-        if wait_iter % 6 == 0:  # log every ~60s (every 6th iteration)
-            print(
-                f"{datetime.now()} device {gpu_id} Free: {free_memory:.1f} GB, "
-                f"Required: {options.required_memory:.1f} GB. "
-                f"Waiting for available memory... (attempt {wait_iter + 1}/{max_memory_wait})",
-                flush=True,
-            )
-        time.sleep(10)
-    else:
         print(
-            f"{datetime.now()} device {gpu_id} Memory wait timeout after {max_memory_wait * 10}s. "
-            f"Proceeding anyway (free={free_memory:.1f} GB, required={options.required_memory:.1f} GB).",
+            f"{datetime.now()} GPU {gpu_id} {os.getpid()} [paddle {options.paddle_version}] test begin: {api_config_str}",
             flush=True,
         )
 
-    try:
-        api_config = APIConfig(api_config_str)
-    except Exception as err:
-        print(f"[config_parse] {api_config_str} {err!s}", flush=True)
-        write_to_log("config_parse", api_config_str)
-        return
+        max_memory_wait = 30  # max 30 iterations × 10s = 5 minutes
+        for wait_iter in range(max_memory_wait):
+            total_memory, used_memory = get_memory_info(gpu_id)
+            free_memory = total_memory - used_memory
 
-    test_class = _select_test_class(options)
-    kwargs = {k: v for k, v in vars(options).items() if k in VALID_TEST_ARGS}
-    case = test_class(api_config, **kwargs)
-    try:
-        case.test()
-    except Exception as err:
-        err_msg = str(err).lower()
-        terminal_log_type = get_terminal_log_type(api_config_str)
-        oom_markers = (
-            "cuda out of memory",
-            "out of memory error",
-            "resourceexhaustederror",
-            "out of memory",
-            "outofmemoryerror",
-            "cannot allocate memory",
-            "std::bad_alloc",
-            "bad allocation",
-            "memoryerror",
-            "cublas_status_alloc_failed",
-        )
-        cuda_markers = (
-            "cuda error",
-            "memory corruption",
-            "illegal memory access",
-            "invalid configuration argument",
-            "invalid resource handle",
-        )
-        exit_code = None
-        if any(marker in err_msg for marker in oom_markers):
-            exit_code = FATAL_OOM_EXIT_CODE
-        elif terminal_log_type == "torch_error" and any(
-            marker in err_msg for marker in cuda_markers
-        ):
-            exit_code = FATAL_TORCH_EXIT_CODE
-        elif any(marker in err_msg for marker in cuda_markers):
-            exit_code = FATAL_CUDA_EXIT_CODE
-        if exit_code is not None:
+            if free_memory >= options.required_memory:
+                break
+
+            if wait_iter % 6 == 0:  # log every ~60s (every 6th iteration)
+                print(
+                    f"{datetime.now()} device {gpu_id} Free: {free_memory:.1f} GB, "
+                    f"Required: {options.required_memory:.1f} GB. "
+                    f"Waiting for available memory... (attempt {wait_iter + 1}/{max_memory_wait})",
+                    flush=True,
+                )
+            time.sleep(10)
+        else:
+            print(
+                f"{datetime.now()} device {gpu_id} Memory wait timeout after {max_memory_wait * 10}s. "
+                f"Proceeding anyway (free={free_memory:.1f} GB, required={options.required_memory:.1f} GB).",
+                flush=True,
+            )
+
+        try:
+            api_config = APIConfig(api_config_str)
+        except Exception as err:
+            print(f"[config_parse] {api_config_str} {err!s}", flush=True)
+            write_to_log("config_parse", api_config_str)
+            return
+
+        test_class = _select_test_class(options)
+        kwargs = {k: v for k, v in vars(options).items() if k in VALID_TEST_ARGS}
+        case = test_class(api_config, **kwargs)
+        try:
+            case.test()
+        except Exception as err:
+            err_msg = str(err).lower()
+            terminal_log_type = get_terminal_log_type(api_config_str)
+            oom_markers = (
+                "cuda out of memory",
+                "out of memory error",
+                "resourceexhaustederror",
+                "out of memory",
+                "outofmemoryerror",
+                "cannot allocate memory",
+                "std::bad_alloc",
+                "bad allocation",
+                "memoryerror",
+                "cublas_status_alloc_failed",
+            )
+            cuda_markers = (
+                "cuda error",
+                "memory corruption",
+                "illegal memory access",
+                "invalid configuration argument",
+                "invalid resource handle",
+            )
+            exit_code = None
+            if any(marker in err_msg for marker in oom_markers):
+                exit_code = FATAL_OOM_EXIT_CODE
+            elif terminal_log_type == "torch_error" and any(
+                marker in err_msg for marker in cuda_markers
+            ):
+                exit_code = FATAL_TORCH_EXIT_CODE
+            elif any(marker in err_msg for marker in cuda_markers):
+                exit_code = FATAL_CUDA_EXIT_CODE
+            if exit_code is not None:
+                if has_terminal_log(api_config_str):
+                    write_checkpoint(api_config_str)
+                try:
+                    close_process_files()
+                finally:
+                    try:
+                        restore_stdio()
+                    finally:
+                        os._exit(exit_code)
             if has_terminal_log(api_config_str):
                 write_checkpoint(api_config_str)
-            try:
-                close_process_files()
-            finally:
-                try:
-                    restore_stdio()
-                finally:
-                    os._exit(exit_code)
-        if has_terminal_log(api_config_str):
-            write_checkpoint(api_config_str)
-            return
-        # if not fatal error, subprocess will be alive and report error
-        print(f"[test error] {api_config_str}: {err}", flush=True)
+                return
+            # if not fatal error, subprocess will be alive and report error
+            print(f"[test error] {api_config_str}: {err}", flush=True)
+            raise
+        finally:
+            del test_class, api_config, case
+            gc.collect()
+            if not any(
+                getattr(options, opt)
+                for opt in (
+                    "paddle_gpu_performance",
+                    "torch_gpu_performance",
+                    "paddle_torch_gpu_performance",
+                )
+            ) and not getattr(options, "use_gpu_mode", False):
+                _clear_device_cache(options)
+
+    except BaseException:
+        case_status = "error"
         raise
     finally:
-        del test_class, api_config, case
-        gc.collect()
-        if not any(
-            getattr(options, opt)
-            for opt in (
-                "paddle_gpu_performance",
-                "torch_gpu_performance",
-                "paddle_torch_gpu_performance",
-            )
-        ) and not getattr(options, "use_gpu_mode", False):
-            _clear_device_cache(options)
+        write_case_end(case_status, case_id=case_id)
 
 
 def main():
@@ -1940,7 +1959,22 @@ def main():
                 slot_idx = msg[1]
                 config = msg[2]
                 exitcode = msg[3] if msg_type == "crashed" and len(msg) > 3 else None
-                crash_source = msg[5] if msg_type == "crashed" and len(msg) > 5 else "worker"
+                crash_source = "worker"
+                worker_pid = None
+                if msg_type == "done":
+                    worker_pid = msg[3] if len(msg) > 3 else None
+                elif msg_type == "error":
+                    worker_pid = msg[4] if len(msg) > 4 else None
+                elif msg_type == "timeout":
+                    worker_pid = msg[3] if len(msg) > 3 else None
+                elif msg_type == "crashed":
+                    if len(msg) > 5 and msg[5] == "child":
+                        crash_source = "child"
+                        worker_pid = msg[6] if len(msg) > 6 else None
+                    else:
+                        worker_pid = msg[4] if len(msg) > 4 else None
+                if worker_pid is not None:
+                    mark_inorder_case_complete(worker_pid, flush=msg_type in ("timeout", "crashed"))
                 worker_reusable = msg_type in ("done", "error") or (
                     msg_type == "crashed"
                     and options.use_compute_sanitizer

--- a/engineV4.py
+++ b/engineV4.py
@@ -293,7 +293,7 @@ def _sanitizer_worker_loop(slot_index, gpu_id, input_queue, result_queue, option
             api_config_str = task
             result_queue.put(("ack", slot_index, api_config_str))
             case_id = write_case_begin(api_config_str)
-            case_log_dir = get_sanitizer_case_log_dir(slot_index, os.getpid())
+            case_log_dir = get_case_log_dir(slot_index, os.getpid())
             if case_log_dir.exists():
                 shutil.rmtree(case_log_dir)
             case_log_dir.mkdir(parents=True, exist_ok=True)
@@ -360,7 +360,7 @@ def _sanitizer_worker_loop(slot_index, gpu_id, input_queue, result_queue, option
                     sys.stdout.flush()
 
                 if returncode in (0, 2) or analysis.ignore_error_exitcode:
-                    merge_sanitizer_case_logs(case_log_dir)
+                    merge_case_logs(case_log_dir)
                 shutil.rmtree(case_log_dir, ignore_errors=True)
 
                 if returncode == 0 or analysis.ignore_error_exitcode:
@@ -378,6 +378,7 @@ def _sanitizer_worker_loop(slot_index, gpu_id, input_queue, result_queue, option
                         )
                     )
                 else:
+                    write_case_end("crashed", case_id=case_id)
                     result_queue.put(
                         (
                             "crashed",
@@ -625,6 +626,8 @@ class WorkerPool:
         if self._closed or self._shutdown_event.is_set():
             return
         if config is not None:
+            append_case_end_to_worker_log(slot.process.pid, "crashed", api_config_str=config)
+            mark_inorder_case_complete(slot.process.pid, flush=True)
             self.result_queue.put(("crashed", slot.index, config, exitcode))
         self._spawn_worker(slot)
 
@@ -1821,7 +1824,7 @@ def main():
         # when engineV2 was interrupted, resume from .tmp dir
         aggregate_logs(cleanup=True)
         if options.use_compute_sanitizer:
-            cleanup_sanitizer_tmp_dir()
+            clean_case_logs()
         removed_stale_logs = cleanup_uncheckpointed_result_logs()
         if removed_stale_logs:
             print(
@@ -2093,7 +2096,7 @@ def main():
         finally:
             pool.shutdown()
             if options.use_compute_sanitizer:
-                cleanup_sanitizer_tmp_dir()
+                clean_case_logs()
             print(f"{tested_case} cases have been tested.", flush=True)
             log_counts = aggregate_logs(end=True)
             print_log_info(max(all_case - tested_case, 0), log_counts)

--- a/engineV4.py
+++ b/engineV4.py
@@ -1288,6 +1288,7 @@ def run_test_case(api_config_str, options):
         except Exception as err:
             print(f"[config_parse] {api_config_str} {err!s}", flush=True)
             write_to_log("config_parse", api_config_str)
+            case_status = "error"
             return
 
         test_class = _select_test_class(options)

--- a/engineV4.py
+++ b/engineV4.py
@@ -161,10 +161,7 @@ def _init_worker_runtime(slot_index, gpu_id, options, *, redirect_output):
         redirect_stdio()
 
     if slot_index is not None and gpu_id is not None:
-        print(
-            f"{datetime.now()} Worker PID: {os.getpid()}, Slot: {slot_index}, GPU: {gpu_id}",
-            flush=True,
-        )
+        os.environ["PADDLEAPITEST_WORKER_SLOT"] = str(slot_index)
 
 
 def _worker_loop(slot_index, gpu_id, input_queue, result_queue, options):
@@ -208,13 +205,24 @@ def _worker_loop(slot_index, gpu_id, input_queue, result_queue, options):
 
         try:
             run_test_case(api_config_str, options)
-            result_queue.put(("done", slot_index, api_config_str, os.getpid()))
+            result_queue.put(
+                ("done", slot_index, api_config_str, os.getpid(), get_worker_log_offset())
+            )
         except SystemExit:
             # run_test_case calls os._exit for CUDA errors, this shouldn't reach here
             # but if it does via sys.exit, let it propagate
             raise
         except Exception as e:
-            result_queue.put(("error", slot_index, api_config_str, str(e), os.getpid()))
+            result_queue.put(
+                (
+                    "error",
+                    slot_index,
+                    api_config_str,
+                    str(e),
+                    os.getpid(),
+                    get_worker_log_offset(),
+                )
+            )
 
     # Graceful exit
     try:
@@ -263,6 +271,7 @@ def _sanitizer_worker_loop(slot_index, gpu_id, input_queue, result_queue, option
     sanitizer_cmd = shlex.split(options.sanitizer_command)
     child_env = os.environ.copy()
     child_env["CUDA_VISIBLE_DEVICES"] = str(gpu_id)
+    child_env["PADDLEAPITEST_SUPPRESS_CASE_TAGS"] = "1"
 
     def terminate_child(*args):
         if child_process is not None and child_process.poll() is None:
@@ -276,10 +285,6 @@ def _sanitizer_worker_loop(slot_index, gpu_id, input_queue, result_queue, option
     signal.signal(signal.SIGTERM, terminate_child)
 
     try:
-        print(
-            f"{datetime.now()} Sanitizer worker PID: {os.getpid()}, Slot: {slot_index}, GPU: {gpu_id}",
-            flush=True,
-        )
         result_queue.put(("ready", slot_index))
 
         while True:
@@ -292,8 +297,13 @@ def _sanitizer_worker_loop(slot_index, gpu_id, input_queue, result_queue, option
 
             api_config_str = task
             result_queue.put(("ack", slot_index, api_config_str))
-            case_id = write_case_begin(api_config_str)
-            case_log_dir = get_case_log_dir(slot_index, os.getpid())
+            case_id = write_case_begin(
+                api_config_str,
+                worker_pid=os.getpid(),
+                slot=slot_index,
+                gpu=gpu_id,
+            )
+            case_log_dir = get_sanitizer_case_log_dir(slot_index, os.getpid())
             if case_log_dir.exists():
                 shutil.rmtree(case_log_dir)
             case_log_dir.mkdir(parents=True, exist_ok=True)
@@ -303,14 +313,12 @@ def _sanitizer_worker_loop(slot_index, gpu_id, input_queue, result_queue, option
                 )
             except ValueError as err:
                 shutil.rmtree(case_log_dir, ignore_errors=True)
-                write_case_end("error", case_id=case_id)
-                result_queue.put(("error", slot_index, api_config_str, str(err), os.getpid()))
+                completed_offset = write_case_end("error", case_id=case_id)
+                result_queue.put(
+                    ("error", slot_index, api_config_str, str(err), os.getpid(), completed_offset)
+                )
                 continue
 
-            print(
-                f"{datetime.now()} Sanitizer slot {slot_index} launch: {' '.join(shlex.quote(part) for part in cmd)}",
-                flush=True,
-            )
             try:
                 child_process = subprocess.Popen(
                     cmd,
@@ -325,8 +333,10 @@ def _sanitizer_worker_loop(slot_index, gpu_id, input_queue, result_queue, option
                 )
             except OSError as err:
                 shutil.rmtree(case_log_dir, ignore_errors=True)
-                write_case_end("error", case_id=case_id)
-                result_queue.put(("error", slot_index, api_config_str, str(err), os.getpid()))
+                completed_offset = write_case_end("error", case_id=case_id)
+                result_queue.put(
+                    ("error", slot_index, api_config_str, str(err), os.getpid(), completed_offset)
+                )
                 continue
             result_queue.put(("child", slot_index, child_process.pid))
             output_tail = deque(maxlen=40)
@@ -360,14 +370,16 @@ def _sanitizer_worker_loop(slot_index, gpu_id, input_queue, result_queue, option
                     sys.stdout.flush()
 
                 if returncode in (0, 2) or analysis.ignore_error_exitcode:
-                    merge_case_logs(case_log_dir)
+                    merge_sanitizer_case_logs(case_log_dir)
                 shutil.rmtree(case_log_dir, ignore_errors=True)
 
                 if returncode == 0 or analysis.ignore_error_exitcode:
-                    write_case_end("done", case_id=case_id)
-                    result_queue.put(("done", slot_index, api_config_str, os.getpid()))
+                    completed_offset = write_case_end("completed", case_id=case_id)
+                    result_queue.put(
+                        ("done", slot_index, api_config_str, os.getpid(), completed_offset)
+                    )
                 elif returncode == 2:
-                    write_case_end("error", case_id=case_id)
+                    completed_offset = write_case_end("error", case_id=case_id)
                     result_queue.put(
                         (
                             "error",
@@ -375,10 +387,11 @@ def _sanitizer_worker_loop(slot_index, gpu_id, input_queue, result_queue, option
                             api_config_str,
                             f"child exited with {returncode}",
                             os.getpid(),
+                            completed_offset,
                         )
                     )
                 else:
-                    write_case_end("crashed", case_id=case_id)
+                    completed_offset = write_case_end("crashed", case_id=case_id)
                     result_queue.put(
                         (
                             "crashed",
@@ -387,6 +400,8 @@ def _sanitizer_worker_loop(slot_index, gpu_id, input_queue, result_queue, option
                             returncode,
                             "".join(output_tail),
                             "child",
+                            os.getpid(),
+                            completed_offset,
                         )
                     )
     finally:
@@ -606,8 +621,10 @@ class WorkerPool:
         self._kill_slot_child(slot)
         self._kill_process(slot.process)
         if old_pid is not None and config is not None:
-            append_case_end_to_worker_log(old_pid, "timeout", api_config_str=config)
-            mark_inorder_case_complete(old_pid, flush=True)
+            completed_offset = append_case_end_to_worker_log(
+                old_pid, "timeout", api_config_str=config
+            )
+            mark_inorder_case_complete(old_pid, completed_offset)
         if self._closed or self._shutdown_event.is_set():
             return
         self.result_queue.put(("timeout", slot.index, config, old_pid))
@@ -626,8 +643,10 @@ class WorkerPool:
         if self._closed or self._shutdown_event.is_set():
             return
         if config is not None:
-            append_case_end_to_worker_log(slot.process.pid, "crashed", api_config_str=config)
-            mark_inorder_case_complete(slot.process.pid, flush=True)
+            completed_offset = append_case_end_to_worker_log(
+                slot.process.pid, "crashed", api_config_str=config
+            )
+            mark_inorder_case_complete(slot.process.pid, completed_offset)
             self.result_queue.put(("crashed", slot.index, config, exitcode))
         self._spawn_worker(slot)
 
@@ -1252,16 +1271,21 @@ def check_gpu_memory(gpu_ids, num_workers_per_gpu, required_memory):  # required
 
 def run_test_case(api_config_str, options):
     """Run a single test case for the given API configuration."""
-    case_id = write_case_begin(api_config_str)
+    started_at = time.monotonic()
+    gpu_id = int(os.environ.get("CUDA_VISIBLE_DEVICES", "0").split(",")[0])
+    suppress_case_tags = os.environ.get("PADDLEAPITEST_SUPPRESS_CASE_TAGS") == "1"
+    case_id = None
+    if not suppress_case_tags:
+        case_id = write_case_begin(
+            api_config_str,
+            worker_pid=os.getpid(),
+            slot=os.environ.get("PADDLEAPITEST_WORKER_SLOT"),
+            gpu=gpu_id,
+            paddle_version=options.paddle_version,
+        )
     case_status = "done"
     try:
-        cuda_visible = os.environ.get("CUDA_VISIBLE_DEVICES", "0")
-        gpu_id = int(cuda_visible.split(",")[0])
-
-        print(
-            f"{datetime.now()} GPU {gpu_id} {os.getpid()} [paddle {options.paddle_version}] test begin: {api_config_str}",
-            flush=True,
-        )
+        print(f"test begin: {api_config_str}", flush=True)
 
         max_memory_wait = 30  # max 30 iterations × 10s = 5 minutes
         for wait_iter in range(max_memory_wait):
@@ -1363,7 +1387,13 @@ def run_test_case(api_config_str, options):
         case_status = "error"
         raise
     finally:
-        write_case_end(case_status, case_id=case_id)
+        if not suppress_case_tags:
+            write_case_end(
+                case_status,
+                case_id=case_id,
+                api_config_str=api_config_str,
+                duration_ms=round((time.monotonic() - started_at) * 1000),
+            )
 
 
 def main():
@@ -1824,7 +1854,7 @@ def main():
         # when engineV2 was interrupted, resume from .tmp dir
         aggregate_logs(cleanup=True)
         if options.use_compute_sanitizer:
-            clean_case_logs()
+            clean_sanitizer_case_logs()
         removed_stale_logs = cleanup_uncheckpointed_result_logs()
         if removed_stale_logs:
             print(
@@ -1965,20 +1995,24 @@ def main():
                 exitcode = msg[3] if msg_type == "crashed" and len(msg) > 3 else None
                 crash_source = "worker"
                 worker_pid = None
+                completed_offset = None
                 if msg_type == "done":
                     worker_pid = msg[3] if len(msg) > 3 else None
+                    completed_offset = msg[4] if len(msg) > 4 else None
                 elif msg_type == "error":
                     worker_pid = msg[4] if len(msg) > 4 else None
+                    completed_offset = msg[5] if len(msg) > 5 else None
                 elif msg_type == "timeout":
                     worker_pid = msg[3] if len(msg) > 3 else None
                 elif msg_type == "crashed":
                     if len(msg) > 5 and msg[5] == "child":
                         crash_source = "child"
                         worker_pid = msg[6] if len(msg) > 6 else None
+                        completed_offset = msg[7] if len(msg) > 7 else None
                     else:
                         worker_pid = msg[4] if len(msg) > 4 else None
                 if worker_pid is not None:
-                    mark_inorder_case_complete(worker_pid, flush=msg_type in ("timeout", "crashed"))
+                    mark_inorder_case_complete(worker_pid, completed_offset)
                 worker_reusable = msg_type in ("done", "error") or (
                     msg_type == "crashed"
                     and options.use_compute_sanitizer
@@ -2070,18 +2104,16 @@ def main():
 
                 write_to_log("checkpoint", config)
 
-                # Get next config to dispatch
+                # 先派发下一项，再做周期日志聚合，避免空闲 worker 等待共享存储 I/O。
                 next_config = next(config_iter, None)
-                if next_config is None:
-                    continue
-
-                # For timeout/non-sanitizer crashed: worker is restarting, queue for later dispatch
-                if not worker_reusable:
-                    pending_dispatch.append(next_config)
-                else:
-                    # Worker is alive and ready for next task
-                    pool.dispatch(slot_idx, next_config)
-                    active_tasks += 1
+                if next_config is not None:
+                    # For timeout/non-sanitizer crashed: worker is restarting, queue for later dispatch
+                    if not worker_reusable:
+                        pending_dispatch.append(next_config)
+                    else:
+                        # Worker is alive and ready for next task
+                        pool.dispatch(slot_idx, next_config)
+                        active_tasks += 1
 
                 # Periodic log aggregation
                 if tested_case % 1000 == 0:
@@ -2096,7 +2128,7 @@ def main():
         finally:
             pool.shutdown()
             if options.use_compute_sanitizer:
-                clean_case_logs()
+                clean_sanitizer_case_logs()
             print(f"{tested_case} cases have been tested.", flush=True)
             log_counts = aggregate_logs(end=True)
             print_log_info(max(all_case - tested_case, 0), log_counts)

--- a/tester/api_config/log_writer.py
+++ b/tester/api_config/log_writer.py
@@ -6,6 +6,7 @@ import io
 import os
 import re
 import shutil
+from collections import deque
 from pathlib import Path
 from typing import Literal
 
@@ -80,24 +81,27 @@ CASE_END_TAG = "[CASE_END]"
 _use_worker_tmp_logs = False
 
 _process_file_handlers = {}
-_aggregated_offsets = {}
+# 普通结果日志和 inorder stdout 使用不同的 offset 命名空间。
+_result_offsets = {}
+_inorder_offsets = {}
+# 配置 -> 全局终态类型；comp 日志写入后也同步到这里，供 checkpoint 逻辑使用。
 _process_terminal_configs = {}
-_inorder_case_starts = {}
-_pending_inorder_blocks = []
-# 每维度的 terminal configs 追踪: dimension -> {config_line -> log_type}
+# 已完成但尚未刷入 log_inorder.log 的 block，保持 case 完成顺序。
+_pending_inorder_blocks = deque()
+# dimension -> {config_line -> log_type}，只负责 comp 维度内去重。
 _comp_terminal_configs: dict[str, dict[str, str]] = {}
 
-# Command line arguments configuration
-# Used in engine.py
+# 命令行参数配置，由 engine.py 使用
 CMD_CONFIG = None
 
 
 def get_cfg():
-    global CMD_CONFIG
+    """返回当前命令行配置。"""
     return CMD_CONFIG
 
 
 def set_cfg(cfg):
+    """保存命令行配置，并规范化其文件名后缀。"""
     global CMD_CONFIG
     if cfg.id != "":
         cfg.id = "_" + cfg.id
@@ -105,15 +109,17 @@ def set_cfg(cfg):
 
 
 def _reset_runtime():
+    """清理进程内文件句柄和聚合状态。"""
     close_process_files()
-    _aggregated_offsets.clear()
+    _result_offsets.clear()
+    _inorder_offsets.clear()
     _process_terminal_configs.clear()
-    _inorder_case_starts.clear()
     _pending_inorder_blocks.clear()
     _comp_terminal_configs.clear()
 
 
 def init_log(log_dir=None, *, worker_tmp_logs=False):
+    """初始化日志路径并重置进程内状态。"""
     global TEST_LOG_PATH, TMP_LOG_PATH, _use_worker_tmp_logs
     _reset_runtime()
     if log_dir:
@@ -128,31 +134,12 @@ def init_log(log_dir=None, *, worker_tmp_logs=False):
 
 
 def get_tmp_log_path():
+    """返回当前临时日志目录。"""
     return TMP_LOG_PATH
 
 
-def get_sanitizer_case_log_dir(slot_index, pid):
-    return TMP_LOG_PATH / "sanitizer" / f"slot_{slot_index}_{pid}"
-
-
-def merge_sanitizer_case_logs(case_log_dir):
-    case_tmp_dir = case_log_dir / ".tmp"
-    if not case_tmp_dir.exists():
-        return
-    for child_log in case_tmp_dir.iterdir():
-        if not child_log.is_file():
-            continue
-        target_log = TMP_LOG_PATH / child_log.name
-        with child_log.open("rb") as in_f, target_log.open("ab") as out_f:
-            shutil.copyfileobj(in_f, out_f)
-
-
-def cleanup_sanitizer_tmp_dir():
-    shutil.rmtree(TMP_LOG_PATH / "sanitizer", ignore_errors=True)
-
-
 def close_process_files():
-    """关闭本进程持有的所有文件句柄"""
+    """关闭当前进程缓存的结果日志句柄。"""
     global _process_file_handlers
     for handler in _process_file_handlers.values():
         try:
@@ -163,43 +150,36 @@ def close_process_files():
 
 
 def has_terminal_log(line):
+    """判断当前进程是否已分类该配置。"""
     return line.strip() in _process_terminal_configs
 
 
 def get_terminal_log_type(line):
+    """返回当前进程对配置的终态分类。"""
     return _process_terminal_configs.get(line.strip())
 
 
 def write_checkpoint(line):
+    """写入已完成配置并清理进程内分类状态。"""
     line = line.strip()
     write_to_log("checkpoint", line)
     _process_terminal_configs.pop(line, None)
 
 
 def write_terminal_log(log_type: LogType, line):
+    """写入终态分类并随后写入 checkpoint。"""
     write_to_log(log_type, line)
     write_checkpoint(line)
 
 
-def _get_log_file(log_type: LogType):
-    prefix = LOG_PREFIXES[log_type]
-    if not _use_worker_tmp_logs:
-        cfg = get_cfg()
-        filename = f"{prefix}{cfg.id}.txt" if cfg else f"{prefix}.txt"
-        return TEST_LOG_PATH / filename
-    pid = os.getpid()
-    return TMP_LOG_PATH / f"{prefix}_{pid}.txt"
-
-
-def _open_handler(file_path):
-    if file_path not in _process_file_handlers:
-        _process_file_handlers[file_path] = file_path.open("a", buffering=1)
-    return _process_file_handlers[file_path]
-
-
 def _write_line(file_path, line):
+    """通过缓存的行缓冲文件句柄写入一行。"""
     try:
-        _open_handler(file_path).write(line + "\n")
+        handler = _process_file_handlers.get(file_path)
+        if handler is None:
+            handler = file_path.open("a", buffering=1)
+            _process_file_handlers[file_path] = handler
+        handler.write(line + "\n")
         return True
     except Exception as err:
         print(f"Error writing to {file_path}: {err}", flush=True)
@@ -207,24 +187,26 @@ def _write_line(file_path, line):
 
 
 def write_to_log(log_type: LogType, line):
-    """添加单条日志到当前进程的日志文件"""
+    """向主结果日志或 worker 临时结果日志追加一个配置。"""
     line = line.strip()
     if not line:
         return
     terminal_log_type = _process_terminal_configs.get(line)
     if _use_worker_tmp_logs and log_type == "pass" and terminal_log_type not in (None, "pass"):
         return
-    try:
-        file_path = _get_log_file(log_type)
-    except Exception as err:
-        print(f"Error resolving log file for {log_type}: {err}", flush=True)
-        return
+    prefix = LOG_PREFIXES[log_type]
+    if _use_worker_tmp_logs:
+        file_path = TMP_LOG_PATH / f"{prefix}_{os.getpid()}.txt"
+    else:
+        cfg = get_cfg()
+        filename = f"{prefix}{cfg.id}.txt" if cfg else f"{prefix}.txt"
+        file_path = TEST_LOG_PATH / filename
     if _write_line(file_path, line) and log_type in TERMINAL_LOG_TYPES and _use_worker_tmp_logs:
         _process_terminal_configs[line] = log_type
 
 
 def has_comp_terminal_log(dimension, line):
-    """检查某个 comp 维度下是否已有终态分类"""
+    """判断 comp 维度是否已分类该配置。"""
     line = line.strip()
     dim_configs = _comp_terminal_configs.get(dimension)
     if dim_configs is None:
@@ -232,28 +214,18 @@ def has_comp_terminal_log(dimension, line):
     return line in dim_configs
 
 
-def _get_comp_file(dimension, log_type: LogType):
-    prefix = LOG_PREFIXES[log_type]
-    if _use_worker_tmp_logs:
-        comp_dir = TMP_LOG_PATH / "comp" / dimension
-        comp_dir.mkdir(parents=True, exist_ok=True)
-        return comp_dir / f"{prefix}_{os.getpid()}.txt"
-    comp_dir = TEST_LOG_PATH / "comp" / dimension
-    comp_dir.mkdir(parents=True, exist_ok=True)
-    cfg = get_cfg()
-    filename = f"{prefix}{cfg.id}.txt" if cfg else f"{prefix}.txt"
-    return comp_dir / filename
-
-
 def write_to_comp_log(comp, log_type: LogType, line):
-    """写入 comp 维度的日志文件，同时更新主 _process_terminal_configs"""
-    try:
-        dimension = COMP_TO_DIMENSION[comp]
-        file_path = _get_comp_file(dimension, log_type)
-    except Exception as err:
-        print(f"Error resolving comp log file for {comp}/{log_type}: {err}", flush=True)
-        return
-
+    """向一个 comp 维度写入配置并更新分类状态。"""
+    dimension = COMP_TO_DIMENSION[comp]
+    prefix = LOG_PREFIXES[log_type]
+    root = TMP_LOG_PATH if _use_worker_tmp_logs else TEST_LOG_PATH
+    comp_dir = root / "comp" / dimension
+    comp_dir.mkdir(parents=True, exist_ok=True)
+    if _use_worker_tmp_logs:
+        file_path = comp_dir / f"{prefix}_{os.getpid()}.txt"
+    else:
+        cfg = get_cfg()
+        file_path = comp_dir / (f"{prefix}{cfg.id}.txt" if cfg else f"{prefix}.txt")
     line = line.strip()
     if not line:
         return
@@ -273,9 +245,7 @@ def write_to_comp_log(comp, log_type: LogType, line):
 
 
 def read_log(log_type: LogType):
-    """读取文件所有行，返回集合"""
-    if log_type not in LOG_PREFIXES:
-        raise ValueError(f"Invalid log type: {log_type}")
+    """读取一个聚合结果日志中的所有非空配置。"""
     cfg = get_cfg()
     prefix = LOG_PREFIXES[log_type]
     filename = f"{prefix}{cfg.id}.txt" if cfg else f"{prefix}.txt"
@@ -291,7 +261,7 @@ def read_log(log_type: LogType):
 
 
 def cleanup_uncheckpointed_result_logs():
-    """Remove result rows that were written before checkpoint during an interrupted run."""
+    """删除中断运行中先于 checkpoint 写入的结果记录。"""
     checkpoint_file = TEST_LOG_PATH / "checkpoint.txt"
     try:
         with checkpoint_file.open("r") as f:
@@ -322,8 +292,9 @@ def cleanup_uncheckpointed_result_logs():
     return removed
 
 
-def _read_pending_bytes(file_path, end=False):
-    offset = _aggregated_offsets.get(file_path, 0)
+def _read_pending_result_bytes(file_path, end=False):
+    """读取上次聚合后的新增字节，非 cleanup 模式只读完整行。"""
+    offset = _result_offsets.get(file_path, 0)
     file_size = file_path.stat().st_size
     if file_size < offset:
         offset = 0
@@ -341,52 +312,63 @@ def _read_pending_bytes(file_path, end=False):
     return data, offset, file_size
 
 
-def _save_offset(file_path, offset, clear=False):
-    if clear:
-        _aggregated_offsets.pop(file_path, None)
-    else:
-        _aggregated_offsets[file_path] = offset
-
-
-def _save_offsets(pending_offsets, cleanup):
+def _save_result_offsets(pending_offsets, cleanup):
+    """保存读取偏移，并按需删除已消费的临时文件。"""
     for file_path, offset in pending_offsets.items():
-        _save_offset(file_path, offset, clear=cleanup)
         if cleanup:
+            _result_offsets.pop(file_path, None)
             file_path.unlink()
+        else:
+            _result_offsets[file_path] = offset
 
 
-def _get_worker_log_file(pid=None):
-    worker_pid = os.getpid() if pid is None else pid
-    return TMP_LOG_PATH / f"log_{worker_pid}.log"
+def get_case_log_dir(slot_index, pid):
+    """返回一个 sanitizer worker slot 的隔离输出目录。"""
+    return TMP_LOG_PATH / "sanitizer" / f"slot_{slot_index}_{pid}"
+
+
+def merge_case_logs(case_log_dir):
+    """将一个 sanitizer case 的结果文件追加到 worker 临时日志。"""
+    case_tmp_dir = case_log_dir / ".tmp"
+    if not case_tmp_dir.exists():
+        return
+    for child_log in case_tmp_dir.iterdir():
+        if not child_log.is_file():
+            continue
+        target_log = TMP_LOG_PATH / child_log.name
+        with child_log.open("rb") as in_f, target_log.open("ab") as out_f:
+            shutil.copyfileobj(in_f, out_f)
+
+
+def clean_case_logs():
+    """删除所有隔离的 sanitizer case 目录。"""
+    shutil.rmtree(TMP_LOG_PATH / "sanitizer", ignore_errors=True)
 
 
 def get_case_id(api_config_str):
+    """生成 case 边界 tag 使用的稳定短 ID。"""
     return hashlib.sha1(api_config_str.encode("utf-8", errors="replace")).hexdigest()[:12]
 
 
 def write_case_begin(api_config_str):
+    """写入 case 开始 tag 并返回其 ID。"""
     case_id = get_case_id(api_config_str)
     print(f"{CASE_BEGIN_TAG} case_id={case_id}", flush=True)
     return case_id
 
 
-def _format_case_end(status, case_id=None, api_config_str=None):
-    if case_id is None and api_config_str is not None:
-        case_id = get_case_id(api_config_str)
-    case_part = f" case_id={case_id}" if case_id else ""
-    return f"{CASE_END_TAG}{case_part} status={status}"
-
-
 def write_case_end(status, case_id=None, api_config_str=None):
-    print(_format_case_end(status, case_id, api_config_str), flush=True)
+    """为指定 ID 或配置写入 case 结束 tag。"""
+    if api_config_str is not None:
+        case_id = get_case_id(api_config_str)
+    print(f"{CASE_END_TAG} case_id={case_id} status={status}", flush=True)
 
 
 def append_case_end_to_worker_log(pid, status, case_id=None, api_config_str=None):
-    if pid is None:
-        return False
-    end_line = _format_case_end(status, case_id, api_config_str)
+    """worker 停止后补写 synthetic case 结束 tag。"""
+    end_line = f"{CASE_END_TAG} case_id={case_id or get_case_id(api_config_str)} status={status}"
     try:
-        log_file = _get_worker_log_file(pid)
+        log_file = TMP_LOG_PATH / f"log_{pid}.log"
         log_file.parent.mkdir(parents=True, exist_ok=True)
         with log_file.open("a", encoding="utf-8") as f:
             f.write(f"{end_line}\n")
@@ -396,37 +378,36 @@ def append_case_end_to_worker_log(pid, status, case_id=None, api_config_str=None
         return False
 
 
-def _copy_log_range(file_path, out_f, start_offset, end_offset):
-    with file_path.open("rb") as in_f:
-        in_f.seek(start_offset)
-        remaining = max(0, end_offset - start_offset)
-        while remaining > 0:
-            data = in_f.read(min(4 * 1024 * 1024, remaining))
-            if not data:
-                break
-            remaining -= len(data)
-            in_buf = io.BytesIO(data)
-            while True:
-                lines = in_buf.readlines(4 * 1024 * 1024)
-                if not lines:
-                    break
-                for line in lines:
-                    out_f.write(line[:200000] + b"\n" if len(line) > 200000 else line)
-
-
-def _copy_and_mark_inorder_range(file_path, out_f, start_offset, end_offset, *, clear=False):
-    if end_offset < start_offset:
-        start_offset = 0
+def _copy_inorder_range(file_path, out_f, start_offset, end_offset, *, clear=False):
+    """复制已完成字节区间，并限制每个物理行最多 200000 字节。"""
     if end_offset > start_offset:
-        _copy_log_range(file_path, out_f, start_offset, end_offset)
-    _save_offset(file_path, end_offset, clear=clear)
-    _inorder_case_starts[file_path] = end_offset
+        with file_path.open("rb") as in_f:
+            in_f.seek(start_offset)
+            remaining = end_offset - start_offset
+            while remaining:
+                line = in_f.readline(min(200001, remaining))
+                if not line:
+                    break
+                remaining -= len(line)
+                if len(line) <= 200000:
+                    out_f.write(line)
+                    continue
+                out_f.write(line[:200000] + b"\n")
+                while remaining and not line.endswith(b"\n"):
+                    line = in_f.readline(min(4 * 1024 * 1024, remaining))
+                    remaining -= len(line)
+    if clear:
+        _inorder_offsets.pop(file_path, None)
+    else:
+        _inorder_offsets[file_path] = end_offset
 
 
 def mark_inorder_case_complete(pid=None, *, flush=False):
+    """将 worker 新完成的 case block 加入有序聚合队列。"""
     if not _use_worker_tmp_logs:
         return True
-    file_path = _get_worker_log_file(pid)
+    worker_pid = os.getpid() if pid is None else pid
+    file_path = TMP_LOG_PATH / f"log_{worker_pid}.log"
     if not file_path.exists():
         return True
     try:
@@ -434,18 +415,22 @@ def mark_inorder_case_complete(pid=None, *, flush=False):
     except Exception as err:
         print(f"Error reading worker log size {file_path}: {err}", flush=True)
         return False
-    start_offset = _inorder_case_starts.get(file_path, _aggregated_offsets.get(file_path, 0))
+    start_offset = _inorder_offsets.get(file_path, 0)
+    for pending_path, _, pending_end in reversed(_pending_inorder_blocks):
+        if pending_path == file_path:
+            start_offset = pending_end
+            break
     if end_offset < start_offset:
         start_offset = 0
     if end_offset > start_offset:
         _pending_inorder_blocks.append((file_path, start_offset, end_offset))
-    _inorder_case_starts[file_path] = end_offset
     if flush or len(_pending_inorder_blocks) >= INORDER_FLUSH_CASE_BLOCKS:
         return flush_inorder_case_blocks(force=True)
     return True
 
 
 def flush_inorder_case_blocks(force=False):
+    """强制或达到批量阈值时刷出已完成的 case block。"""
     if not _pending_inorder_blocks:
         return True
     if not force and len(_pending_inorder_blocks) < INORDER_FLUSH_CASE_BLOCKS:
@@ -454,8 +439,9 @@ def flush_inorder_case_blocks(force=False):
     try:
         with out_file.open("ab") as out_f:
             while _pending_inorder_blocks:
-                file_path, start_offset, end_offset = _pending_inorder_blocks.pop(0)
-                _copy_and_mark_inorder_range(file_path, out_f, start_offset, end_offset)
+                file_path, start_offset, end_offset = _pending_inorder_blocks[0]
+                _copy_inorder_range(file_path, out_f, start_offset, end_offset)
+                _pending_inorder_blocks.popleft()
         return True
     except Exception as err:
         print(f"Error flushing case blocks to {out_file}: {err}", flush=True)
@@ -463,27 +449,17 @@ def flush_inorder_case_blocks(force=False):
         return False
 
 
-def _read_lines(log_files, cleanup):
-    all_lines = set()
-    pending_offsets = {}
-    for file_path in log_files:
-        try:
-            data, _, end_offset = _read_pending_bytes(file_path, end=cleanup)
-            pending_offsets[file_path] = end_offset
-            all_lines.update(line.strip() for line in data.decode().splitlines() if line.strip())
-        except Exception as err:
-            print(f"Error reading {file_path}: {err}", flush=True)
-            return set(), {}, False
-    return all_lines, pending_offsets, True
-
-
-def _agg_text(log_files, out_file, cleanup):
+def _aggregate_text_logs(log_files, out_file, cleanup):
+    """合并、去重并排序 worker 文本日志。"""
     if not log_files:
         return True
-    all_lines, pending_offsets, success = _read_lines(log_files, cleanup)
-    if not success:
-        return False
+    all_lines = set()
+    pending_offsets = {}
     try:
+        for file_path in log_files:
+            data, _, end_offset = _read_pending_result_bytes(file_path, end=cleanup)
+            pending_offsets[file_path] = end_offset
+            all_lines.update(line.strip() for line in data.decode().splitlines() if line.strip())
         if all_lines:
             with out_file.open("a") as f:
                 f.writelines(f"{line}\n" for line in sorted(all_lines))
@@ -491,20 +467,22 @@ def _agg_text(log_files, out_file, cleanup):
         print(f"Error writing to {out_file}: {err}", flush=True)
         out_file.unlink(missing_ok=True)
         return False
-    _save_offsets(pending_offsets, cleanup)
+    _save_result_offsets(pending_offsets, cleanup)
     return True
 
 
-def _agg_results(cleanup, tmp_exists):
+def _aggregate_result_logs(cleanup, tmp_exists):
+    """聚合所有主结果日志类型。"""
     success = True
     for prefix in LOG_PREFIXES.values():
         log_files = list(TMP_LOG_PATH.glob(f"{prefix}_*.txt")) if tmp_exists else []
         out_file = TEST_LOG_PATH / f"{prefix}.txt"
-        success = _agg_text(log_files, out_file, cleanup) and success
+        success = _aggregate_text_logs(log_files, out_file, cleanup) and success
     return success
 
 
-def _agg_inorder(cleanup, tmp_exists):
+def _aggregate_inorder_logs(cleanup, tmp_exists):
+    """刷出安全 block，并聚合已停止 worker 的剩余输出。"""
     if not tmp_exists:
         return True
     if not flush_inorder_case_blocks(force=True):
@@ -518,11 +496,11 @@ def _agg_inorder(cleanup, tmp_exists):
         with out_file.open("ab") as out_f:
             for file_path in log_files:
                 try:
-                    start_offset = _aggregated_offsets.get(file_path, 0)
+                    start_offset = _inorder_offsets.get(file_path, 0)
                     end_offset = file_path.stat().st_size
-                    _copy_and_mark_inorder_range(
-                        file_path, out_f, start_offset, end_offset, clear=cleanup
-                    )
+                    if end_offset < start_offset:
+                        start_offset = 0
+                    _copy_inorder_range(file_path, out_f, start_offset, end_offset, clear=cleanup)
                     if cleanup:
                         file_path.unlink()
                 except Exception as err:
@@ -536,7 +514,8 @@ def _agg_inorder(cleanup, tmp_exists):
     return True
 
 
-def _agg_csv(log_files, out_file, header, cleanup):
+def _aggregate_csv_logs(log_files, out_file, header, cleanup):
+    """将 worker CSV 分片中的完整行聚合到一个文件。"""
     if not log_files:
         return True
 
@@ -549,7 +528,9 @@ def _agg_csv(log_files, out_file, header, cleanup):
                 writer.writerow(header)
             for file_path in log_files:
                 try:
-                    data, start_offset, end_offset = _read_pending_bytes(file_path, end=cleanup)
+                    data, start_offset, end_offset = _read_pending_result_bytes(
+                        file_path, end=cleanup
+                    )
                     pending_offsets[file_path] = end_offset
                     reader = csv.reader(io.StringIO(data.decode()))
                     if start_offset == 0:
@@ -566,11 +547,12 @@ def _agg_csv(log_files, out_file, header, cleanup):
         out_file.unlink(missing_ok=True)
         return False
 
-    _save_offsets(pending_offsets, cleanup)
+    _save_result_offsets(pending_offsets, cleanup)
     return True
 
 
 def _sort_csv(file_path, columns):
+    """按稳定的报告字段排序聚合 CSV。"""
     if not file_path.exists():
         return
     try:
@@ -581,7 +563,8 @@ def _sort_csv(file_path, columns):
         print(f"Error arranging {file_path}: {err}", flush=True)
 
 
-def _count_logs():
+def _count_result_logs():
+    """统计结果分类并写出未完成配置列表。"""
     log_counts = {}
     checkpoint_file = TEST_LOG_PATH / "checkpoint.txt"
     api_configs = set()
@@ -619,7 +602,8 @@ def _count_logs():
     return log_counts
 
 
-def _agg_comp(cleanup, tmp_exists):
+def _aggregate_comp_logs(cleanup, tmp_exists):
+    """分别聚合每个 comp 维度的结果日志。"""
     comp_tmp_dir = TMP_LOG_PATH / "comp" if tmp_exists else None
     comp_out_dir = TEST_LOG_PATH / "comp"
     has_comp = (comp_tmp_dir and comp_tmp_dir.exists()) or comp_out_dir.exists()
@@ -633,7 +617,7 @@ def _agg_comp(cleanup, tmp_exists):
         out_dim_dir.mkdir(parents=True, exist_ok=True)
         for prefix in LOG_PREFIXES.values():
             log_files = list(dim_dir.glob(f"{prefix}_*.txt"))
-            _agg_text(log_files, out_dim_dir / f"{prefix}.txt", cleanup)
+            _aggregate_text_logs(log_files, out_dim_dir / f"{prefix}.txt", cleanup)
         if cleanup and dim_dir.exists() and not any(dim_dir.iterdir()):
             dim_dir.rmdir()
     if cleanup and comp_tmp_dir.exists() and not any(comp_tmp_dir.iterdir()):
@@ -641,7 +625,8 @@ def _agg_comp(cleanup, tmp_exists):
     return has_comp
 
 
-def _scan_dups(log_dir):
+def _find_duplicate_classifications(log_dir):
+    """查找同一目录中被多个结果类型分类的配置。"""
     config_to_types: dict[str, list[str]] = {}
     for log_type, prefix in LOG_PREFIXES.items():
         if log_type == "checkpoint":
@@ -660,14 +645,8 @@ def _scan_dups(log_dir):
     return {config: types for config, types in config_to_types.items() if len(types) > 1}
 
 
-def _add_dups(log_counts, scope, duplicates):
-    if duplicates:
-        log_counts.setdefault("_integrity_errors", []).append(
-            {"scope": scope, "duplicates": duplicates}
-        )
-
-
 def _read_log_lines(log_file):
+    """将结果文件读取为集合，文件不存在时返回空集合。"""
     if not log_file.exists():
         return set()
     try:
@@ -679,6 +658,7 @@ def _read_log_lines(log_file):
 
 
 def _sync_comp_main_summary():
+    """将各 comp 维度分类合并到主结果摘要。"""
     comp_out_dir = TEST_LOG_PATH / "comp"
     if not comp_out_dir.exists():
         return
@@ -708,31 +688,31 @@ def _sync_comp_main_summary():
             print(f"Error writing to {log_file}: {err}", flush=True)
 
 
-def _check_logs(log_counts, has_comp):
+def _check_log_integrity(log_counts, has_comp):
+    """检查重复分类并将诊断信息附加到统计结果。"""
     comp_out_dir = TEST_LOG_PATH / "comp"
     if has_comp:
         log_counts["_multi_classification"] = True
-        if _scan_dups(TEST_LOG_PATH):
+        if _find_duplicate_classifications(TEST_LOG_PATH):
             log_counts["_has_multi_result_overlap"] = True
         for dim_dir in sorted(comp_out_dir.iterdir()) if comp_out_dir.exists() else []:
             if not dim_dir.is_dir():
                 continue
-            duplicates = _scan_dups(dim_dir)
+            duplicates = _find_duplicate_classifications(dim_dir)
             if duplicates:
                 log_counts.setdefault("_comp_integrity_errors", []).append(
                     {"scope": f"comp/{dim_dir.name}", "duplicates": duplicates}
                 )
         return
-    _add_dups(log_counts, "main log directory", _scan_dups(TEST_LOG_PATH))
-
-
-def _clean_tmp(cleanup, all_success):
-    if cleanup and all_success and TMP_LOG_PATH.exists() and not any(TMP_LOG_PATH.iterdir()):
-        shutil.rmtree(TMP_LOG_PATH)
+    duplicates = _find_duplicate_classifications(TEST_LOG_PATH)
+    if duplicates:
+        log_counts["_integrity_errors"] = [
+            {"scope": "main log directory", "duplicates": duplicates}
+        ]
 
 
 def aggregate_logs(end=False, cleanup=False):
-    """聚合所有相同类型的日志文件"""
+    """聚合 worker 日志，并按需完成统计和完整性检查。"""
     cleanup_tmp = end or cleanup
     tmp_exists = TMP_LOG_PATH.exists()
     if not tmp_exists and not cleanup_tmp:
@@ -741,13 +721,13 @@ def aggregate_logs(end=False, cleanup=False):
 
     tol_file = TEST_LOG_PATH / "tol.csv"
     stable_file = TEST_LOG_PATH / "stable.csv"
-    all_success = _agg_results(cleanup_tmp, tmp_exists)
+    all_success = _aggregate_result_logs(cleanup_tmp, tmp_exists)
     if cleanup_tmp:
-        all_success = _agg_inorder(cleanup_tmp, tmp_exists) and all_success
+        all_success = _aggregate_inorder_logs(cleanup_tmp, tmp_exists) and all_success
     else:
         all_success = flush_inorder_case_blocks() and all_success
     all_success = (
-        _agg_csv(
+        _aggregate_csv_logs(
             sorted(TMP_LOG_PATH.glob("tol_*.csv")) if tmp_exists else [],
             tol_file,
             TOL_HEADER,
@@ -756,7 +736,7 @@ def aggregate_logs(end=False, cleanup=False):
         and all_success
     )
     all_success = (
-        _agg_csv(
+        _aggregate_csv_logs(
             sorted(TMP_LOG_PATH.glob("stable_*.csv")) if tmp_exists else [],
             stable_file,
             STABLE_HEADER,
@@ -766,29 +746,29 @@ def aggregate_logs(end=False, cleanup=False):
     )
 
     if not end:
-        _clean_tmp(cleanup_tmp, all_success)
+        if (
+            cleanup_tmp
+            and all_success
+            and TMP_LOG_PATH.exists()
+            and not any(TMP_LOG_PATH.iterdir())
+        ):
+            shutil.rmtree(TMP_LOG_PATH)
         return
 
     _sort_csv(tol_file, ["API", "dtype", "config", "mode"])
     _sort_csv(stable_file, ["API", "dtype", "config", "comp"])
-    has_comp = _agg_comp(cleanup_tmp, tmp_exists)
-    _clean_tmp(cleanup_tmp, all_success)
+    has_comp = _aggregate_comp_logs(cleanup_tmp, tmp_exists)
+    if cleanup_tmp and all_success and TMP_LOG_PATH.exists() and not any(TMP_LOG_PATH.iterdir()):
+        shutil.rmtree(TMP_LOG_PATH)
     if has_comp:
         _sync_comp_main_summary()
-    log_counts = _count_logs()
-    _check_logs(log_counts, has_comp)
+    log_counts = _count_result_logs()
+    _check_log_integrity(log_counts, has_comp)
     return log_counts
 
 
-def _visible_counts(log_counts):
-    return {key: value for key, value in log_counts.items() if not key.startswith("_")}
-
-
-def _sum_counts(log_counts, log_types):
-    return sum(log_counts.get(log_type, 0) for log_type in log_types)
-
-
-def _print_dups(integrity_errors):
+def _print_duplicate_classifications(integrity_errors):
+    """打印主结果目录中的重复分类。"""
     for issue in integrity_errors:
         scope = issue["scope"]
         duplicates = issue["duplicates"]
@@ -806,7 +786,8 @@ def _print_dups(integrity_errors):
         print("!" * 50 + "\n")
 
 
-def _print_comp_dups(comp_integrity_errors):
+def _print_comp_duplicate_classifications(comp_integrity_errors):
+    """按 comp 维度打印重复分类。"""
     for issue in comp_integrity_errors:
         scope = issue["scope"]
         duplicates = issue["duplicates"]
@@ -825,14 +806,14 @@ def _print_comp_dups(comp_integrity_errors):
 
 
 def print_log_info(remaining_case, log_counts=None):
-    """打印日志统计信息"""
+    """打印最终 case 统计和分类完整性告警。"""
     if log_counts is None:
         log_counts = {}
     integrity_errors = log_counts.get("_integrity_errors", [])
     comp_integrity_errors = log_counts.get("_comp_integrity_errors", [])
     is_multi_classification = log_counts.get("_multi_classification")
     has_multi_result_overlap = log_counts.get("_has_multi_result_overlap")
-    counts = _visible_counts(log_counts)
+    counts = {key: value for key, value in log_counts.items() if not key.startswith("_")}
     paddle_types = [
         "paddle_error",
         "paddle_accuracy",
@@ -849,9 +830,9 @@ def print_log_info(remaining_case, log_counts=None):
     print(f"{'Tested cases':<30}: {counts.get('checkpoint', 0):>8}")
     print(f"{'Pass cases':<30}: {counts.get('pass', 0):>8}")
     print(f"{'Skip cases':<30}: {counts.get('skip', 0):>8}")
-    print(f"{'Paddle issue cases':<30}: {_sum_counts(counts, paddle_types):>8}")
-    print(f"{'Test issue cases':<30}: {_sum_counts(counts, test_types):>8}")
-    print(f"{'Retest cases':<30}: {_sum_counts(counts, ['oom', 'timeout']):>8}")
+    print(f"{'Paddle issue cases':<30}: {sum(counts.get(key, 0) for key in paddle_types):>8}")
+    print(f"{'Test issue cases':<30}: {sum(counts.get(key, 0) for key in test_types):>8}")
+    print(f"{'Retest cases':<30}: {sum(counts.get(key, 0) for key in ('oom', 'timeout')):>8}")
     if counts:
         print("-" * 50)
         print("Log Type Breakdown:")
@@ -861,9 +842,9 @@ def print_log_info(remaining_case, log_counts=None):
             print(f"  {log_type:<28}: {count:>8}")
     print("=" * 50 + "\n")
     if is_multi_classification:
-        _print_comp_dups(comp_integrity_errors)
+        _print_comp_duplicate_classifications(comp_integrity_errors)
     else:
-        _print_dups(integrity_errors)
+        _print_duplicate_classifications(integrity_errors)
 
 
 stdout_fd = None
@@ -874,7 +855,7 @@ log_file = None
 
 
 def redirect_stdio():
-    """执行 stdout 和 stderr 的重定向"""
+    """将 worker 的 stdout 和 stderr 重定向到临时日志。"""
     global stdout_fd, stderr_fd, orig_stdout_fd, orig_stderr_fd, log_file
 
     log_path = TMP_LOG_PATH / f"log_{os.getpid()}.log"
@@ -899,7 +880,7 @@ def redirect_stdio():
 
 
 def restore_stdio():
-    """恢复 stdout 和 stderr 的重定向"""
+    """恢复 redirect_stdio 保存的 stdout 和 stderr 文件描述符。"""
     global stdout_fd, stderr_fd, orig_stdout_fd, orig_stderr_fd, log_file
     if log_file is not None:
         log_file.close()
@@ -917,6 +898,7 @@ def restore_stdio():
 
 
 def _get_diff(error_msg, abs_pattern, rel_pattern):
+    """从断言消息中提取绝对误差和相对误差。"""
     if error_msg == "Identical":
         return 0.0, 0.0
 
@@ -931,6 +913,7 @@ def _get_diff(error_msg, abs_pattern, rel_pattern):
 
 
 def _append_csv(output_file, header, row):
+    """追加一行 CSV，并在需要时创建表头。"""
     try:
         is_new = not output_file.exists() or output_file.stat().st_size == 0
         with output_file.open("a", newline="") as f:
@@ -943,9 +926,7 @@ def _append_csv(output_file, header, row):
 
 
 def log_accuracy_tolerance(error_msg, api, config, dtype, is_backward=False):
-    """从 torch.testing.assert_close 的异常消息中提取最大绝对误差和相对误差
-    将误差数据记录到 CSV 文件
-    """
+    """记录从 assert-close 失败消息中解析出的容差。"""
     mode = "backward" if is_backward else "forward"
     print(f"mode={mode} {config}\n{error_msg}", flush=True)
     abs_pattern = (
@@ -962,6 +943,7 @@ def log_accuracy_tolerance(error_msg, api, config, dtype, is_backward=False):
 
 
 def log_accuracy_stable(error_msg, api, config, dtype, comp):
+    """记录一个比较模式下的稳定性误差。"""
     print(f"comp={comp} {config}\n{error_msg}", flush=True)
     abs_pattern = (
         r"(?:Absolute|Greatest absolute|Max absolute) difference(?: among violations)?: "

--- a/tester/api_config/log_writer.py
+++ b/tester/api_config/log_writer.py
@@ -1,3 +1,69 @@
+"""Paddle API 测试日志的写入、结构化边界和聚合。
+
+函数索引：
+- get_cfg：返回当前命令行配置。
+- set_cfg：保存命令行配置并规范化日志文件 ID 后缀。
+- _reset_runtime：关闭缓存句柄并清空进程内日志状态。
+- init_log：设置输出目录并初始化主进程或 worker 日志环境。
+- get_tmp_log_path：返回 worker 临时日志目录。
+- close_process_files：关闭当前进程缓存的所有结果日志句柄。
+- has_terminal_log：判断配置是否已有主终态分类。
+- get_terminal_log_type：返回配置当前的主终态类型。
+- write_checkpoint：记录配置完成并清理其主终态状态。
+- write_terminal_log：依次写入终态分类和 checkpoint。
+- _write_line：复用缓存句柄向指定结果文件追加一行。
+- write_to_log：写入主结果或 worker 结果分片并更新分类状态。
+- has_comp_terminal_log：判断配置在指定 comp 维度是否已有分类。
+- write_to_comp_log：写入 accuracy-stable comp 维度结果并更新状态。
+- read_log：读取一个聚合结果文件中的全部配置。
+- cleanup_uncheckpointed_result_logs：删除没有对应 checkpoint 的残留结果。
+- _read_pending_result_bytes：按结果 offset 读取新增完整行。
+- _save_result_offsets：提交结果 offset，并在 cleanup 时删除已消费分片。
+- get_sanitizer_case_log_dir：返回 sanitizer case 的隔离日志目录。
+- merge_sanitizer_case_logs：将 sanitizer child 结果分片合并回 worker 临时目录。
+- clean_sanitizer_case_logs：清理 sanitizer case 隔离目录。
+- get_case_id：从配置生成稳定的短 case ID。
+- write_case_begin：输出包含运行元数据的结构化 CASE_BEGIN。
+- _case_results：读取配置在当前进程产生的全部结果类型。
+- write_case_end：输出 CASE_END，flush 后返回 worker 安全 offset。
+- get_worker_log_offset：获取当前或指定 worker stdout 文件末尾。
+- append_case_end_to_worker_log：为已停止 worker 补写 synthetic CASE_END。
+- _copy_inorder_range：复制 worker stdout 的安全字节区间并截断超长行。
+- mark_inorder_case_complete：登记 worker 最后完成 case 的安全读取上界。
+- flush_completed_inorder_logs：批量追加所有 worker 已完成区间并提交 offset。
+- _aggregate_text_logs：合并、去重并排序 worker 文本结果分片。
+- _aggregate_result_logs：聚合所有主结果日志类型。
+- _aggregate_inorder_logs：结束或 cleanup 时聚合 worker stdout 剩余内容。
+- _aggregate_csv_logs：按 offset 合并 worker CSV 分片。
+- _sort_csv：按报告字段稳定排序最终 CSV。
+- _count_result_logs：统计分类数量并生成未完成配置文件。
+- _aggregate_comp_logs：按 accuracy-stable comp 维度聚合结果。
+- _find_duplicate_classifications：查找同一目录中的重复分类。
+- _read_log_lines：将单个结果文件读取为配置集合。
+- _sync_comp_main_summary：将 comp 维度分类合并到主结果摘要。
+- _check_log_integrity：检查主目录或 comp 维度的分类完整性。
+- aggregate_logs：编排结果、stdout、CSV 和 comp 聚合及最终统计。
+- _print_duplicate_classifications：打印主结果重复分类。
+- _print_comp_duplicate_classifications：打印 comp 维度重复分类。
+- print_log_info：打印最终测试统计和完整性告警。
+- redirect_stdio：将 worker stdout/stderr 行缓冲重定向到临时日志。
+- restore_stdio：恢复 worker 原始 stdout/stderr。
+- _get_diff：从精度错误消息提取最大绝对和相对误差。
+- _append_csv：向 worker CSV 分片追加表头和数据行。
+- log_accuracy_tolerance：记录 accuracy tolerance 比较结果。
+- log_accuracy_stable：记录 accuracy-stable comp 比较结果。
+
+关键状态：
+- _process_file_handlers：当前进程按路径缓存的结果日志句柄，避免每条结果重复
+  open/close；_write_line 统一复用句柄并处理写入错误。
+- _result_offsets：各 worker 结果文本/CSV 已聚合到的位置。
+- _inorder_offsets：各 worker stdout 已写入 log_inorder.log 的位置。
+- _inorder_completed_offsets：各 worker 最后一个完整 case 的安全读取上界。
+- _process_terminal_configs/_case_result_types：当前 case 的分类和结构化结果。
+- _comp_terminal_configs：各 accuracy-stable comp 维度内的分类状态。
+- stdout_fd/stderr_fd/orig_*：worker 标准流重定向和恢复所需描述符。
+"""
+
 from __future__ import annotations
 
 import csv
@@ -6,7 +72,7 @@ import io
 import os
 import re
 import shutil
-from collections import deque
+from datetime import datetime
 from pathlib import Path
 from typing import Literal
 
@@ -74,7 +140,6 @@ COMP_TO_DIMENSION = {
 ALL_DIMENSIONS = sorted(set(COMP_TO_DIMENSION.values()))
 TOL_HEADER = ["API", "config", "dtype", "mode", "max_abs_diff", "max_rel_diff"]
 STABLE_HEADER = ["API", "config", "dtype", "comp", "max_abs_diff", "max_rel_diff"]
-INORDER_FLUSH_CASE_BLOCKS = 1000
 CASE_BEGIN_TAG = "[CASE_BEGIN]"
 CASE_END_TAG = "[CASE_END]"
 
@@ -84,10 +149,10 @@ _process_file_handlers = {}
 # 普通结果日志和 inorder stdout 使用不同的 offset 命名空间。
 _result_offsets = {}
 _inorder_offsets = {}
+_inorder_completed_offsets = {}
 # 配置 -> 全局终态类型；comp 日志写入后也同步到这里，供 checkpoint 逻辑使用。
 _process_terminal_configs = {}
-# 已完成但尚未刷入 log_inorder.log 的 block，保持 case 完成顺序。
-_pending_inorder_blocks = deque()
+_case_result_types: dict[str, set[str]] = {}
 # dimension -> {config_line -> log_type}，只负责 comp 维度内去重。
 _comp_terminal_configs: dict[str, dict[str, str]] = {}
 
@@ -113,8 +178,9 @@ def _reset_runtime():
     close_process_files()
     _result_offsets.clear()
     _inorder_offsets.clear()
+    _inorder_completed_offsets.clear()
     _process_terminal_configs.clear()
-    _pending_inorder_blocks.clear()
+    _case_result_types.clear()
     _comp_terminal_configs.clear()
 
 
@@ -173,7 +239,7 @@ def write_terminal_log(log_type: LogType, line):
 
 
 def _write_line(file_path, line):
-    """通过缓存的行缓冲文件句柄写入一行。"""
+    """复用进程文件句柄写一行，集中处理句柄创建、缓存和写入错误。"""
     try:
         handler = _process_file_handlers.get(file_path)
         if handler is None:
@@ -201,8 +267,10 @@ def write_to_log(log_type: LogType, line):
         cfg = get_cfg()
         filename = f"{prefix}{cfg.id}.txt" if cfg else f"{prefix}.txt"
         file_path = TEST_LOG_PATH / filename
-    if _write_line(file_path, line) and log_type in TERMINAL_LOG_TYPES and _use_worker_tmp_logs:
-        _process_terminal_configs[line] = log_type
+    if _write_line(file_path, line) and log_type in TERMINAL_LOG_TYPES:
+        _case_result_types.setdefault(line, set()).add(log_type)
+        if _use_worker_tmp_logs:
+            _process_terminal_configs[line] = log_type
 
 
 def has_comp_terminal_log(dimension, line):
@@ -240,6 +308,7 @@ def write_to_comp_log(comp, log_type: LogType, line):
 
     if log_type in TERMINAL_LOG_TYPES:
         dim_configs[line] = log_type
+    _case_result_types.setdefault(line, set()).add(log_type)
     if log_type in TERMINAL_LOG_TYPES and _use_worker_tmp_logs:
         _process_terminal_configs[line] = log_type
 
@@ -322,12 +391,12 @@ def _save_result_offsets(pending_offsets, cleanup):
             _result_offsets[file_path] = offset
 
 
-def get_case_log_dir(slot_index, pid):
+def get_sanitizer_case_log_dir(slot_index, pid):
     """返回一个 sanitizer worker slot 的隔离输出目录。"""
     return TMP_LOG_PATH / "sanitizer" / f"slot_{slot_index}_{pid}"
 
 
-def merge_case_logs(case_log_dir):
+def merge_sanitizer_case_logs(case_log_dir):
     """将一个 sanitizer case 的结果文件追加到 worker 临时日志。"""
     case_tmp_dir = case_log_dir / ".tmp"
     if not case_tmp_dir.exists():
@@ -340,7 +409,7 @@ def merge_case_logs(case_log_dir):
             shutil.copyfileobj(in_f, out_f)
 
 
-def clean_case_logs():
+def clean_sanitizer_case_logs():
     """删除所有隔离的 sanitizer case 目录。"""
     shutil.rmtree(TMP_LOG_PATH / "sanitizer", ignore_errors=True)
 
@@ -350,35 +419,71 @@ def get_case_id(api_config_str):
     return hashlib.sha1(api_config_str.encode("utf-8", errors="replace")).hexdigest()[:12]
 
 
-def write_case_begin(api_config_str):
-    """写入 case 开始 tag 并返回其 ID。"""
+def write_case_begin(api_config_str, *, worker_pid=None, slot=None, gpu=None, paddle_version=None):
+    """写入包含执行元数据的 case 起始行并返回其 ID。"""
     case_id = get_case_id(api_config_str)
-    print(f"{CASE_BEGIN_TAG} case_id={case_id}", flush=True)
+    fields = [f"case_id={case_id}"]
+    if worker_pid is not None:
+        fields.append(f"worker_pid={worker_pid}")
+    if slot is not None:
+        fields.append(f"slot={slot}")
+    if gpu is not None:
+        fields.append(f"gpu={gpu}")
+    if paddle_version is not None:
+        fields.append(f"paddle_version={paddle_version}")
+    fields.append(f"timestamp={datetime.now().isoformat()}")
+    print(f"{CASE_BEGIN_TAG} {' '.join(fields)}")
     return case_id
 
 
-def write_case_end(status, case_id=None, api_config_str=None):
-    """为指定 ID 或配置写入 case 结束 tag。"""
+def _case_results(api_config_str):
+    return sorted(_case_result_types.get(api_config_str, set()))
+
+
+def write_case_end(status, case_id=None, api_config_str=None, duration_ms=None, results=None):
+    """为指定 ID 或配置写入 case 结束 tag，支持多个终态结果。"""
     if api_config_str is not None:
         case_id = get_case_id(api_config_str)
-    print(f"{CASE_END_TAG} case_id={case_id} status={status}", flush=True)
+    fields = [f"case_id={case_id}", f"status={status}"]
+    if results is None and api_config_str is not None:
+        results = _case_results(api_config_str)
+    if results:
+        fields.append(f"results={','.join(sorted(set(results)))}")
+    if duration_ms is not None:
+        fields.append(f"duration_ms={duration_ms}")
+    print(f"{CASE_END_TAG} {' '.join(fields)}", flush=True)
+    return get_worker_log_offset()
+
+
+def get_worker_log_offset(pid=None):
+    """返回 worker 日志当前安全文件末尾；当前 worker 优先避免路径 stat。"""
+    worker_pid = os.getpid() if pid is None else pid
+    try:
+        if worker_pid == os.getpid() and stdout_fd is not None:
+            return os.fstat(stdout_fd).st_size
+        return (TMP_LOG_PATH / f"log_{worker_pid}.log").stat().st_size
+    except (FileNotFoundError, OSError):
+        return None
 
 
 def append_case_end_to_worker_log(pid, status, case_id=None, api_config_str=None):
     """worker 停止后补写 synthetic case 结束 tag。"""
-    end_line = f"{CASE_END_TAG} case_id={case_id or get_case_id(api_config_str)} status={status}"
+    end_line = (
+        f"{CASE_END_TAG} case_id={case_id or get_case_id(api_config_str)} "
+        f"status={status} results={status}"
+    )
     try:
         log_file = TMP_LOG_PATH / f"log_{pid}.log"
         log_file.parent.mkdir(parents=True, exist_ok=True)
         with log_file.open("a", encoding="utf-8") as f:
             f.write(f"{end_line}\n")
-        return True
+        return log_file.stat().st_size
     except Exception as err:
         print(f"Error writing case end to worker log {pid}: {err}", flush=True)
-        return False
+        return None
 
 
-def _copy_inorder_range(file_path, out_f, start_offset, end_offset, *, clear=False):
+def _copy_inorder_range(file_path, out_f, start_offset, end_offset):
     """复制已完成字节区间，并限制每个物理行最多 200000 字节。"""
     if end_offset > start_offset:
         with file_path.open("rb") as in_f:
@@ -396,56 +501,39 @@ def _copy_inorder_range(file_path, out_f, start_offset, end_offset, *, clear=Fal
                 while remaining and not line.endswith(b"\n"):
                     line = in_f.readline(min(4 * 1024 * 1024, remaining))
                     remaining -= len(line)
-    if clear:
-        _inorder_offsets.pop(file_path, None)
-    else:
-        _inorder_offsets[file_path] = end_offset
 
 
-def mark_inorder_case_complete(pid=None, *, flush=False):
-    """将 worker 新完成的 case block 加入有序聚合队列。"""
+def mark_inorder_case_complete(pid, completed_offset):
+    """记录 worker 最后一个已完成 case 的安全读取上界。"""
     if not _use_worker_tmp_logs:
         return True
-    worker_pid = os.getpid() if pid is None else pid
-    file_path = TMP_LOG_PATH / f"log_{worker_pid}.log"
-    if not file_path.exists():
-        return True
-    try:
-        end_offset = file_path.stat().st_size
-    except Exception as err:
-        print(f"Error reading worker log size {file_path}: {err}", flush=True)
+    if completed_offset is None:
         return False
-    start_offset = _inorder_offsets.get(file_path, 0)
-    for pending_path, _, pending_end in reversed(_pending_inorder_blocks):
-        if pending_path == file_path:
-            start_offset = pending_end
-            break
-    if end_offset < start_offset:
-        start_offset = 0
-    if end_offset > start_offset:
-        _pending_inorder_blocks.append((file_path, start_offset, end_offset))
-    if flush or len(_pending_inorder_blocks) >= INORDER_FLUSH_CASE_BLOCKS:
-        return flush_inorder_case_blocks(force=True)
+    file_path = TMP_LOG_PATH / f"log_{pid}.log"
+    _inorder_completed_offsets[file_path] = max(
+        completed_offset, _inorder_completed_offsets.get(file_path, 0)
+    )
     return True
 
 
-def flush_inorder_case_blocks(force=False):
-    """强制或达到批量阈值时刷出已完成的 case block。"""
-    if not _pending_inorder_blocks:
-        return True
-    if not force and len(_pending_inorder_blocks) < INORDER_FLUSH_CASE_BLOCKS:
+def flush_completed_inorder_logs():
+    """按 worker 一次读取所有已完成 case，并在成功后推进聚合 offset。"""
+    if not _inorder_completed_offsets:
         return True
     out_file = TEST_LOG_PATH / "log_inorder.log"
     try:
         with out_file.open("ab") as out_f:
-            while _pending_inorder_blocks:
-                file_path, start_offset, end_offset = _pending_inorder_blocks[0]
+            for file_path, end_offset in list(_inorder_completed_offsets.items()):
+                start_offset = _inorder_offsets.get(file_path, 0)
+                if end_offset < start_offset:
+                    start_offset = 0
                 _copy_inorder_range(file_path, out_f, start_offset, end_offset)
-                _pending_inorder_blocks.popleft()
+                out_f.flush()
+                _inorder_offsets[file_path] = end_offset
+                _inorder_completed_offsets.pop(file_path, None)
         return True
     except Exception as err:
         print(f"Error flushing case blocks to {out_file}: {err}", flush=True)
-        out_file.unlink(missing_ok=True)
         return False
 
 
@@ -465,7 +553,6 @@ def _aggregate_text_logs(log_files, out_file, cleanup):
                 f.writelines(f"{line}\n" for line in sorted(all_lines))
     except Exception as err:
         print(f"Error writing to {out_file}: {err}", flush=True)
-        out_file.unlink(missing_ok=True)
         return False
     _save_result_offsets(pending_offsets, cleanup)
     return True
@@ -485,7 +572,7 @@ def _aggregate_inorder_logs(cleanup, tmp_exists):
     """刷出安全 block，并聚合已停止 worker 的剩余输出。"""
     if not tmp_exists:
         return True
-    if not flush_inorder_case_blocks(force=True):
+    if not flush_completed_inorder_logs():
         return False
     log_files = sorted(TMP_LOG_PATH.glob("log_*.log"))
     if not log_files:
@@ -500,16 +587,19 @@ def _aggregate_inorder_logs(cleanup, tmp_exists):
                     end_offset = file_path.stat().st_size
                     if end_offset < start_offset:
                         start_offset = 0
-                    _copy_inorder_range(file_path, out_f, start_offset, end_offset, clear=cleanup)
+                    _copy_inorder_range(file_path, out_f, start_offset, end_offset)
+                    out_f.flush()
                     if cleanup:
+                        _inorder_offsets.pop(file_path, None)
+                        _inorder_completed_offsets.pop(file_path, None)
                         file_path.unlink()
+                    else:
+                        _inorder_offsets[file_path] = end_offset
                 except Exception as err:
                     print(f"Error reading {file_path}: {err}", flush=True)
-                    out_file.unlink(missing_ok=True)
                     return False
     except Exception as err:
         print(f"Error writing to {out_file}: {err}", flush=True)
-        out_file.unlink(missing_ok=True)
         return False
     return True
 
@@ -540,11 +630,9 @@ def _aggregate_csv_logs(log_files, out_file, header, cleanup):
                             writer.writerow(row)
                 except Exception as err:
                     print(f"Error reading {file_path}: {err}", flush=True)
-                    out_file.unlink(missing_ok=True)
                     return False
     except Exception as err:
         print(f"Error writing to {out_file}: {err}", flush=True)
-        out_file.unlink(missing_ok=True)
         return False
 
     _save_result_offsets(pending_offsets, cleanup)
@@ -725,7 +813,7 @@ def aggregate_logs(end=False, cleanup=False):
     if cleanup_tmp:
         all_success = _aggregate_inorder_logs(cleanup_tmp, tmp_exists) and all_success
     else:
-        all_success = flush_inorder_case_blocks() and all_success
+        all_success = flush_completed_inorder_logs() and all_success
     all_success = (
         _aggregate_csv_logs(
             sorted(TMP_LOG_PATH.glob("tol_*.csv")) if tmp_exists else [],
@@ -944,7 +1032,7 @@ def log_accuracy_tolerance(error_msg, api, config, dtype, is_backward=False):
 
 def log_accuracy_stable(error_msg, api, config, dtype, comp):
     """记录一个比较模式下的稳定性误差。"""
-    print(f"comp={comp} {config}\n{error_msg}", flush=True)
+    print(f"comp={comp} result={error_msg}", flush=True)
     abs_pattern = (
         r"(?:Absolute|Greatest absolute|Max absolute) difference(?: among violations)?: "
         r"(\d+\.?\d*(?:[eE][+-]?\d+)?|nan|inf)\b"

--- a/tester/api_config/log_writer.py
+++ b/tester/api_config/log_writer.py
@@ -388,12 +388,6 @@ def append_case_end_to_worker_log(pid, status, case_id=None, api_config_str=None
     try:
         log_file = _get_worker_log_file(pid)
         log_file.parent.mkdir(parents=True, exist_ok=True)
-        if log_file.exists() and " case_id=" in end_line:
-            with log_file.open("rb") as f:
-                f.seek(max(0, log_file.stat().st_size - 65536))
-                tail = f.read().decode("utf-8", errors="replace")
-            if end_line.rsplit(" status=", 1)[0] in tail:
-                return True
         with log_file.open("a", encoding="utf-8") as f:
             f.write(f"{end_line}\n")
         return True

--- a/tester/api_config/log_writer.py
+++ b/tester/api_config/log_writer.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import csv
+import hashlib
 import io
 import os
 import re
@@ -72,12 +73,17 @@ COMP_TO_DIMENSION = {
 ALL_DIMENSIONS = sorted(set(COMP_TO_DIMENSION.values()))
 TOL_HEADER = ["API", "config", "dtype", "mode", "max_abs_diff", "max_rel_diff"]
 STABLE_HEADER = ["API", "config", "dtype", "comp", "max_abs_diff", "max_rel_diff"]
+INORDER_FLUSH_CASE_BLOCKS = 1000
+CASE_BEGIN_TAG = "[CASE_BEGIN]"
+CASE_END_TAG = "[CASE_END]"
 
 _use_worker_tmp_logs = False
 
 _process_file_handlers = {}
 _aggregated_offsets = {}
 _process_terminal_configs = {}
+_inorder_case_starts = {}
+_pending_inorder_blocks = []
 # 每维度的 terminal configs 追踪: dimension -> {config_line -> log_type}
 _comp_terminal_configs: dict[str, dict[str, str]] = {}
 
@@ -102,6 +108,8 @@ def _reset_runtime():
     close_process_files()
     _aggregated_offsets.clear()
     _process_terminal_configs.clear()
+    _inorder_case_starts.clear()
+    _pending_inorder_blocks.clear()
     _comp_terminal_configs.clear()
 
 
@@ -347,6 +355,120 @@ def _save_offsets(pending_offsets, cleanup):
             file_path.unlink()
 
 
+def _get_worker_log_file(pid=None):
+    worker_pid = os.getpid() if pid is None else pid
+    return TMP_LOG_PATH / f"log_{worker_pid}.log"
+
+
+def get_case_id(api_config_str):
+    return hashlib.sha1(api_config_str.encode("utf-8", errors="replace")).hexdigest()[:12]
+
+
+def write_case_begin(api_config_str):
+    case_id = get_case_id(api_config_str)
+    print(f"{CASE_BEGIN_TAG} case_id={case_id}", flush=True)
+    return case_id
+
+
+def _format_case_end(status, case_id=None, api_config_str=None):
+    if case_id is None and api_config_str is not None:
+        case_id = get_case_id(api_config_str)
+    case_part = f" case_id={case_id}" if case_id else ""
+    return f"{CASE_END_TAG}{case_part} status={status}"
+
+
+def write_case_end(status, case_id=None, api_config_str=None):
+    print(_format_case_end(status, case_id, api_config_str), flush=True)
+
+
+def append_case_end_to_worker_log(pid, status, case_id=None, api_config_str=None):
+    if pid is None:
+        return False
+    end_line = _format_case_end(status, case_id, api_config_str)
+    try:
+        log_file = _get_worker_log_file(pid)
+        log_file.parent.mkdir(parents=True, exist_ok=True)
+        if log_file.exists() and " case_id=" in end_line:
+            with log_file.open("rb") as f:
+                f.seek(max(0, log_file.stat().st_size - 65536))
+                tail = f.read().decode("utf-8", errors="replace")
+            if end_line.rsplit(" status=", 1)[0] in tail:
+                return True
+        with log_file.open("a", encoding="utf-8") as f:
+            f.write(f"{end_line}\n")
+        return True
+    except Exception as err:
+        print(f"Error writing case end to worker log {pid}: {err}", flush=True)
+        return False
+
+
+def _copy_log_range(file_path, out_f, start_offset, end_offset):
+    with file_path.open("rb") as in_f:
+        in_f.seek(start_offset)
+        remaining = max(0, end_offset - start_offset)
+        while remaining > 0:
+            data = in_f.read(min(4 * 1024 * 1024, remaining))
+            if not data:
+                break
+            remaining -= len(data)
+            in_buf = io.BytesIO(data)
+            while True:
+                lines = in_buf.readlines(4 * 1024 * 1024)
+                if not lines:
+                    break
+                for line in lines:
+                    out_f.write(line[:200000] + b"\n" if len(line) > 200000 else line)
+
+
+def _copy_and_mark_inorder_range(file_path, out_f, start_offset, end_offset, *, clear=False):
+    if end_offset < start_offset:
+        start_offset = 0
+    if end_offset > start_offset:
+        _copy_log_range(file_path, out_f, start_offset, end_offset)
+    _save_offset(file_path, end_offset, clear=clear)
+    _inorder_case_starts[file_path] = end_offset
+
+
+def mark_inorder_case_complete(pid=None, *, flush=False):
+    if not _use_worker_tmp_logs:
+        return True
+    file_path = _get_worker_log_file(pid)
+    if not file_path.exists():
+        return True
+    try:
+        end_offset = file_path.stat().st_size
+    except Exception as err:
+        print(f"Error reading worker log size {file_path}: {err}", flush=True)
+        return False
+    start_offset = _inorder_case_starts.get(file_path, _aggregated_offsets.get(file_path, 0))
+    if end_offset < start_offset:
+        start_offset = 0
+    if end_offset > start_offset:
+        _pending_inorder_blocks.append((file_path, start_offset, end_offset))
+    _inorder_case_starts[file_path] = end_offset
+    if flush or len(_pending_inorder_blocks) >= INORDER_FLUSH_CASE_BLOCKS:
+        return flush_inorder_case_blocks(force=True)
+    return True
+
+
+def flush_inorder_case_blocks(force=False):
+    if not _pending_inorder_blocks:
+        return True
+    if not force and len(_pending_inorder_blocks) < INORDER_FLUSH_CASE_BLOCKS:
+        return True
+    out_file = TEST_LOG_PATH / "log_inorder.log"
+    try:
+        with out_file.open("ab") as out_f:
+            while _pending_inorder_blocks:
+                file_path, start_offset, end_offset = _pending_inorder_blocks.pop(0)
+                _copy_and_mark_inorder_range(file_path, out_f, start_offset, end_offset)
+        return True
+    except Exception as err:
+        print(f"Error flushing case blocks to {out_file}: {err}", flush=True)
+        out_file.unlink(missing_ok=True)
+        return False
+
+
 def _read_lines(log_files, cleanup):
     all_lines = set()
     pending_offsets = {}
@@ -389,25 +511,26 @@ def _agg_results(cleanup, tmp_exists):
 
 
 def _agg_inorder(cleanup, tmp_exists):
-    log_files = sorted(TMP_LOG_PATH.glob("log_*.log")) if tmp_exists else []
+    if not tmp_exists:
+        return True
+    if not flush_inorder_case_blocks(force=True):
+        return False
+    log_files = sorted(TMP_LOG_PATH.glob("log_*.log"))
     if not log_files:
         return True
 
     out_file = TEST_LOG_PATH / "log_inorder.log"
-    pending_offsets = {}
     try:
         with out_file.open("ab") as out_f:
             for file_path in log_files:
                 try:
-                    data, _, end_offset = _read_pending_bytes(file_path, end=cleanup)
-                    pending_offsets[file_path] = end_offset
-                    in_f = io.BytesIO(data)
-                    while True:
-                        lines = in_f.readlines(4 * 1024 * 1024)
-                        if not lines:
-                            break
-                        for line in lines:
-                            out_f.write(line[:200000] + b"\n" if len(line) > 200000 else line)
+                    start_offset = _aggregated_offsets.get(file_path, 0)
+                    end_offset = file_path.stat().st_size
+                    _copy_and_mark_inorder_range(
+                        file_path, out_f, start_offset, end_offset, clear=cleanup
+                    )
+                    if cleanup:
+                        file_path.unlink()
                 except Exception as err:
                     print(f"Error reading {file_path}: {err}", flush=True)
                     out_file.unlink(missing_ok=True)
@@ -416,8 +539,6 @@ def _agg_inorder(cleanup, tmp_exists):
         print(f"Error writing to {out_file}: {err}", flush=True)
         out_file.unlink(missing_ok=True)
         return False
-
-    _save_offsets(pending_offsets, cleanup)
     return True
 
 
@@ -627,7 +748,10 @@ def aggregate_logs(end=False, cleanup=False):
     tol_file = TEST_LOG_PATH / "tol.csv"
     stable_file = TEST_LOG_PATH / "stable.csv"
     all_success = _agg_results(cleanup_tmp, tmp_exists)
-    all_success = _agg_inorder(cleanup_tmp, tmp_exists) and all_success
+    if cleanup_tmp:
+        all_success = _agg_inorder(cleanup_tmp, tmp_exists) and all_success
+    else:
+        all_success = flush_inorder_case_blocks() and all_success
     all_success = (
         _agg_csv(
             sorted(TMP_LOG_PATH.glob("tol_*.csv")) if tmp_exists else [],

--- a/tools/error_stat/error_stat.py
+++ b/tools/error_stat/error_stat.py
@@ -10,7 +10,11 @@ import re
 import shutil
 from pathlib import Path
 
-from tester.api_config.log_writer import CASE_BEGIN_TAG, CASE_END_TAG, LOG_PREFIXES
+from tester.api_config.log_writer import (
+    CASE_BEGIN_TAG,
+    CASE_END_TAG,
+    LOG_PREFIXES,
+)
 
 DEFAULT_TEST_LOG_PATH = Path("tester/api_config/test_log_big_tensor")
 RESULT_DIR_NAME = "error_stat_result"
@@ -88,12 +92,6 @@ def _parse_tagged_logs(input_text):
             match = re.search(r"case_id=([^\s]+)", line)
             current_case_id = match.group(1) if match else None
             continue
-        if "test begin" in line and current_case_id is None:
-            if current_content:
-                logs.append("\n".join(current_content))
-            current_content = [line]
-            current_case_id = None
-            continue
         if current_content:
             current_content.append(line)
             if line.startswith(CASE_END_TAG):
@@ -145,7 +143,7 @@ def _parse_legacy_logs(input_text):
 
 
 def parse_logs(input_path):
-    # 优先按 CASE tag 分割；旧日志 fallback 到 "test begin" 分割。
+    # 新日志按 CASE tag 分割；无 tag 的存量日志按 test begin 分割。
     log_path = Path(input_path) / "log_inorder.log"
     if not log_path.exists():
         print(f"{log_path} not exists", flush=True)
@@ -161,8 +159,10 @@ def parse_logs(input_path):
     return logs
 
 
-def get_sort_key(content):
-    match = re.search(r"test begin: (.*)$", content.split("\n", 1)[0])
+def get_config_key(content):
+    # Structured logs are split at CASE_BEGIN; the config remains on the
+    # test-begin line inside each block. Legacy blocks use the same line.
+    match = re.search(r"test begin: ([^\r\n]*)", content)
     return match.group(1).strip() if match else ""
 
 
@@ -171,7 +171,7 @@ def classify_by_config(logs, config_sets):
     # 同一 case 理论上只出现在一个终态文件中；checkpoint 不作为分类输出，跳过。
     classified_logs = {}
     for content in logs:
-        key = get_sort_key(content)
+        key = get_config_key(content)
         if not key:
             continue
         for log_type, configs in config_sets.items():

--- a/tools/error_stat/error_stat.py
+++ b/tools/error_stat/error_stat.py
@@ -10,30 +10,10 @@ import re
 import shutil
 from pathlib import Path
 
+from tester.api_config.log_writer import CASE_BEGIN_TAG, CASE_END_TAG, LOG_PREFIXES
+
 DEFAULT_TEST_LOG_PATH = Path("tester/api_config/test_log_big_tensor")
 RESULT_DIR_NAME = "error_stat_result"
-
-# 终态分类到结果文件前缀的映射，与 tester/api_config/log_writer.py 中 LOG_PREFIXES 保持一致。
-# checkpoint 仅用于读取已完成 case 集合，不作为统计分类输出。
-LOG_PREFIXES = {
-    "checkpoint": "checkpoint",
-    "pass": "api_config_pass",
-    "skip": "api_config_skip",
-    # Paddle 问题：需重点定位 Paddle bug 或稳定性问题
-    "paddle_error": "api_config_paddle_error",
-    "paddle_accuracy": "api_config_paddle_accuracy",
-    "paddle_bitwise": "api_config_paddle_bitwise",
-    "paddle_cuda": "api_config_paddle_cuda",
-    "paddle_crash": "api_config_paddle_crash",
-    # 可重测：资源或超时，调整资源或放宽时间后可重试
-    "oom": "api_config_oom",
-    "timeout": "api_config_timeout",
-    # 测试侧问题：对照侧或配置问题，不代表 Paddle 本身有 bug
-    "torch_error": "api_config_torch_error",
-    "config_input": "api_config_config_input",
-    "config_parse": "api_config_config_parse",
-    "config_convert": "api_config_config_convert",
-}
 
 # 默认汇总模式下的输出分组（--split-errors 时按每个终态分类单独输出）：
 #   paddle_issue  — Paddle 问题，需重点定位
@@ -91,17 +71,54 @@ def load_config_sets(input_path):
     return config_sets
 
 
-def parse_logs(input_path):
-    # 从 log_inorder.log 中按 "test begin" 分割出每个 case 的完整日志块。
-    # 过滤掉 gpu_resources.cc 和内存等待行，避免干扰 case 边界识别。
-    # "Worker PID" 行标志上一个 case 日志块结束（worker 重启分隔符）。
-    log_path = Path(input_path) / "log_inorder.log"
-    if not log_path.exists():
-        print(f"{log_path} not exists", flush=True)
-        return []
-    with log_path.open("r") as f:
-        input_text = f.read()
+def _parse_tagged_logs(input_text):
+    logs = []
+    current_content = []
+    current_case_id = None
+    begin_count = 0
+    end_count = 0
+    for line in input_text.split("\n"):
+        if "gpu_resources.cc" in line or "Waiting for available memory" in line:
+            continue
+        if line.startswith(CASE_BEGIN_TAG):
+            begin_count += 1
+            if current_content:
+                logs.append("\n".join(current_content))
+            current_content = [line]
+            match = re.search(r"case_id=([^\s]+)", line)
+            current_case_id = match.group(1) if match else None
+            continue
+        if "test begin" in line and current_case_id is None:
+            if current_content:
+                logs.append("\n".join(current_content))
+            current_content = [line]
+            current_case_id = None
+            continue
+        if current_content:
+            current_content.append(line)
+            if line.startswith(CASE_END_TAG):
+                end_count += 1
+                match = re.search(r"case_id=([^\s]+)", line)
+                end_case_id = match.group(1) if match else None
+                if current_case_id and end_case_id and current_case_id != end_case_id:
+                    print(
+                        f"[WARNING] case_id mismatch: begin={current_case_id}, end={end_case_id}",
+                        flush=True,
+                    )
+                logs.append("\n".join(current_content))
+                current_content = []
+                current_case_id = None
+    if current_content:
+        logs.append("\n".join(current_content))
+    if begin_count != end_count:
+        print(
+            f"[WARNING] CASE tag count mismatch: begin={begin_count}, end={end_count}",
+            flush=True,
+        )
+    return logs
 
+
+def _parse_legacy_logs(input_text):
     logs = []
     in_test_block = False
     current_content = []
@@ -109,13 +126,13 @@ def parse_logs(input_path):
         if "gpu_resources.cc" in line or "Waiting for available memory" in line:
             continue
         if "test begin" in line:
-            if in_test_block and current_content:
+            if current_content:
                 logs.append("\n".join(current_content))
-            in_test_block = True
             current_content = [line]
+            in_test_block = True
             continue
         if "Worker PID" in line:
-            if in_test_block and current_content:
+            if current_content:
                 logs.append("\n".join(current_content))
             in_test_block = False
             current_content = []
@@ -124,6 +141,22 @@ def parse_logs(input_path):
             current_content.append(line)
     if current_content:
         logs.append("\n".join(current_content))
+    return logs
+
+
+def parse_logs(input_path):
+    # 优先按 CASE tag 分割；旧日志 fallback 到 "test begin" 分割。
+    log_path = Path(input_path) / "log_inorder.log"
+    if not log_path.exists():
+        print(f"{log_path} not exists", flush=True)
+        return []
+    with log_path.open("r") as f:
+        input_text = f.read()
+
+    if CASE_BEGIN_TAG in input_text or CASE_END_TAG in input_text:
+        logs = _parse_tagged_logs(input_text)
+    else:
+        logs = _parse_legacy_logs(input_text)
     print(f"Found {len(logs)} logs", flush=True)
     return logs
 


### PR DESCRIPTION
## 🧭 背景

PaddleAPITest 的并发执行引擎需要在 worker 临时日志、按序日志与终态分类日志之间可靠地归集结果。该链路既为测试执行提供可追溯的 case 日志，也为后续的错误统计和重测筛选提供输入，因此重复写入、日志截断和多进程文件句柄管理都会直接影响问题定位效率。

本次改动完善 engineV2、engineV4 与日志统计工具的日志归集能力，并在此基础上收敛单用途 helper 和冗长命名，使核心写入路径更直观且保持原有缓存、清理与聚合行为。

## 🛠️ 实现方案

日志写入器继续按进程缓存打开的文件句柄，并根据运行模式选择正式日志或 worker 临时日志。将仅负责打开缓存句柄和解析输出路径的薄封装内联到唯一调用处，减少不必要跳转；Sanitizer case 临时目录相关操作保留为独立边界，但统一使用简短的 case 语义命名。

## 🔧 主要变更

### 1. 完善日志归集与终态记录

执行引擎为 case 写入起止标记，并在 worker 日志、按序日志及分类终态日志之间归集数据。日志写入器支持增量聚合、终态去重、Sanitizer case 日志合并与清理，错误统计工具可依据 case 标记解析日志并生成分类结果。

### 2. 收敛日志写入实现

移除仅被单一写入流程使用的文件句柄打开与路径解析 helper，将逻辑直接置于写入路径。Sanitizer 临时日志接口改为 `get_case_log_dir`、`merge_case_logs` 和 `clean_case_logs`，调用点语义更清晰且名称更短。

## 📁 改动文件

| 类别 | 文件 | 功能说明 |
| --- | --- | --- |
| 执行引擎 | `engineV2.py` | 接入 case 日志与终态记录流程 |
| 执行引擎 | `engineV4.py` | 接入 Sanitizer case 日志归集并使用收敛后的接口 |
| 日志基础设施 | `tester/api_config/log_writer.py` | 管理日志写入、聚合、终态去重及临时文件清理 |
| 日志分析 | `tools/error_stat/error_stat.py` | 按 case 标记解析并汇总日志分类 |
