### PR TITLE
测试基建：🔧 优化 API 测试日志结构与 sanitizer 降噪

### DIFF
--- a/engineV2.py
+++ b/engineV2.py
@@ -526,20 +526,19 @@ def init_worker_gpu(gpu_worker_list, lock, available_gpus, max_workers_per_gpu, 
 
         os.environ["CUDA_VISIBLE_DEVICES"] = str(assigned_gpu)
 
-        import paddle
+        with suppress_startup_output():
+            import paddle
 
-        # Load custom ops from paddlefleet to register _run_custom_op operators
-        try:
-            import paddlefleet_ops
-        except ImportError:
-            pass
-        try:
-            import FusedQuantOps
-        except ImportError:
-            pass
-
-        globals()["paddle"] = paddle
-        globals().update(_load_test_classes(options))
+            try:
+                import paddlefleet_ops
+            except ImportError:
+                pass
+            try:
+                import FusedQuantOps
+            except ImportError:
+                pass
+            globals()["paddle"] = paddle
+            globals().update(_load_test_classes(options))
 
         def signal_handler(*args):
             _clear_device_cache(options)
@@ -574,11 +573,6 @@ def run_test_case(api_config_str, options):
     runtime_config = runtime_config_for_gpu(options, gpu_id)
     case_status = "done"
     try:
-        print(
-            f"test begin: {api_config_str}",
-            flush=True,
-        )
-
         if options.show_runtime_status:
             total_memory, used_memory_before = get_memory_info(gpu_id)
             print(
@@ -696,7 +690,6 @@ def run_test_case(api_config_str, options):
 
 def main():
     start_time = time.time()
-    print(f"Main process id: {os.getpid()}")
     set_start_method("spawn")
 
     try:
@@ -904,8 +897,7 @@ def main():
 
     options = parser.parse_args()
     options.paddle_version = paddle_version
-    print(f"Options: {vars(options)}", flush=True)
-    print(f"PaddlePaddle version: {paddle_version}", flush=True)
+    print_run_header(options, paddle_version)
     if options.random_seed != parser.get_default("random_seed"):
         np.random.seed(options.random_seed)
 
@@ -1105,7 +1097,6 @@ def main():
 
         # read checkpoint
         finish_configs = read_log("checkpoint")
-        print(len(finish_configs), "cases in checkpoint.", flush=True)
 
         api_config_count = 0
         skipped_non_config = 0
@@ -1127,7 +1118,6 @@ def main():
                 return
         if skipped_non_config:
             print(f"{skipped_non_config} non-config lines skipped.", flush=True)
-        print(api_config_count, "cases in total.", flush=True)
         dup_case = api_config_count - len(api_configs)
         if dup_case > 0:
             print(dup_case, "cases are duplicates and removed.", flush=True)
@@ -1138,7 +1128,10 @@ def main():
         finish_case = api_config_count - all_case
         if finish_case:
             print(finish_case, "cases already tested.", flush=True)
-        print(all_case, "cases will be tested.", flush=True)
+        print("--- PREPARING")
+        print(
+            f"{'Cases':<11}{api_config_count} total | {len(finish_configs)} checkpointed | {all_case} pending"
+        )
         del api_config_count, dup_case, finish_case
 
         # validate GPU visibility and derive per-GPU worker counts
@@ -1218,8 +1211,6 @@ def main():
                         try:
                             worker_pid, completed_offset = future.result()
                             mark_inorder_case_complete(worker_pid, completed_offset)
-                            if options.show_runtime_status or tested_case % 10000 == 0:
-                                print(f"[info] Test case succeeded for {config}", flush=True)
                         except TimeoutError as err:
                             write_terminal_log("timeout", config)
                             worker_pid = getattr(err, "pid", None)
@@ -1281,7 +1272,7 @@ def main():
                             tested_case += 1
                             if options.show_runtime_status or tested_case % 10000 == 0:
                                 print(
-                                    f"[{tested_case}/{all_case}] Testing {config}",
+                                    f"[{tested_case}/{all_case}] DONE | {config}",
                                     flush=True,
                                 )
                 aggregate_logs()
@@ -1290,16 +1281,19 @@ def main():
         except Exception as e:
             print(f"Unexpected error: {e}", flush=True)
             cleanup(pool)
-            total_time = time.time() - start_time
-            print(f"Test time: {round(total_time / 60, 3)} minutes.", flush=True)
         finally:
-            print(f"{tested_case} cases have been tested.", flush=True)
             log_counts = aggregate_logs(end=True)
             print_log_info(max(all_case - tested_case, 0), log_counts)
             end_time = time.time()
             total_time = end_time - start_time
-            print(f"Test time: {round(total_time / 60, 3)} minutes.", flush=True)
-    print("Done.")
+            print_run_footer(
+                all_case,
+                tested_case,
+                max(all_case - tested_case, 0),
+                log_counts,
+                total_time,
+                options.log_dir,
+            )
 
 
 if __name__ == "__main__":

--- a/engineV4.py
+++ b/engineV4.py
@@ -5,7 +5,6 @@ import gc
 import multiprocessing as mp
 import os
 import queue
-import re
 import shlex
 import shutil
 import signal
@@ -43,6 +42,7 @@ if TYPE_CHECKING:
     )
 
 from tester.api_config.log_writer import *
+from tester.api_config.sanitizer_output import analyze_sanitizer_output
 from tester.runtime_config import TestRuntimeConfig, runtime_config_for_gpu
 
 os.environ["FLAGS_use_system_allocator"] = "1"
@@ -146,19 +146,19 @@ def _init_worker_runtime(slot_index, gpu_id, options, *, redirect_output):
     if gpu_id is not None:
         os.environ["CUDA_VISIBLE_DEVICES"] = str(gpu_id)
 
-    import paddle
+    with suppress_startup_output():
+        import paddle
 
-    try:
-        import paddlefleet_ops  # noqa: F401
-    except ImportError:
-        pass
-    try:
-        import FusedQuantOps  # noqa: F401
-    except ImportError:
-        pass
-
-    globals()["paddle"] = paddle
-    globals().update(_load_test_classes(options))
+        try:
+            import paddlefleet_ops  # noqa: F401
+        except ImportError:
+            pass
+        try:
+            import FusedQuantOps  # noqa: F401
+        except ImportError:
+            pass
+        globals()["paddle"] = paddle
+        globals().update(_load_test_classes(options))
 
     if options.test_cpu:
         paddle.device.set_device("cpu")
@@ -372,25 +372,26 @@ def _sanitizer_worker_loop(slot_index, gpu_id, input_queue, result_queue, option
                 child_process = None
                 output_file.seek(0)
                 if returncode == options.sanitizer_error_exitcode:
-                    analysis = _analyze_sanitizer_output(
+                    analysis = analyze_sanitizer_output(
                         output_file.read(), returncode, options.sanitizer_error_exitcode
                     )
-                    if analysis.filtered_output:
+                    if analysis.output:
                         print(
-                            analysis.filtered_output,
-                            end="" if analysis.filtered_output.endswith("\n") else "\n",
+                            analysis.output,
+                            end="" if analysis.output.endswith("\n") else "\n",
                             flush=True,
                         )
                 else:
-                    analysis = SanitizerOutputAnalysis("", False)
+                    analysis = None
                     shutil.copyfileobj(output_file, sys.stdout)
                     sys.stdout.flush()
 
-                if returncode in (0, 2) or analysis.ignore_error_exitcode:
+                ignored = analysis is not None and analysis.only_ignored_diagnostics
+                if returncode in (0, 2) or ignored:
                     merge_sanitizer_case_logs(case_log_dir)
                 shutil.rmtree(case_log_dir, ignore_errors=True)
 
-                if returncode == 0 or analysis.ignore_error_exitcode:
+                if returncode == 0 or ignored:
                     completed_offset = write_case_end("completed", case_id=case_id)
                     result_queue.put(
                         ("done", slot_index, api_config_str, os.getpid(), completed_offset)
@@ -1112,103 +1113,6 @@ def _prepare_single_config_gpu(options):
     return gpu_ids[0]
 
 
-SANITIZER_PREFIX = "========="
-SANITIZER_CUDA_API_ERROR = "CUDA API Error:"
-SANITIZER_PROGRAM_HIT = "Program hit"
-SANITIZER_ERROR_SUMMARY = "ERROR SUMMARY:"
-CUDA_VERSION_ERROR_RE = re.compile(
-    r"cudaVersion argument \(\d+\) exceeds the driver version \(\d+\)"
-)
-
-
-@dataclass(frozen=True)
-class SanitizerOutputAnalysis:
-    filtered_output: str
-    ignore_error_exitcode: bool
-
-
-def _is_sanitizer_block_boundary(line):
-    return line.startswith(SANITIZER_PREFIX) and (
-        SANITIZER_CUDA_API_ERROR in line
-        or SANITIZER_PROGRAM_HIT in line
-        or SANITIZER_ERROR_SUMMARY in line
-    )
-
-
-def _is_cuda_version_error_block(block_lines):
-    first_line = block_lines[0] if block_lines else ""
-    return (
-        SANITIZER_CUDA_API_ERROR in first_line
-        and CUDA_VERSION_ERROR_RE.search("\n".join(block_lines)) is not None
-    )
-
-
-def _is_cu_get_proc_address_invalid_value_block(block_lines):
-    first_line = block_lines[0] if block_lines else ""
-    return "CUDA_ERROR_INVALID_VALUE" in first_line and "cuGetProcAddress_v2" in first_line
-
-
-def _analyze_sanitizer_output(output, returncode, sanitizer_error_exitcode):
-    if returncode != sanitizer_error_exitcode:
-        return SanitizerOutputAnalysis(output, False)
-
-    lines = output.splitlines()
-    filtered_lines = []
-    ignored_line_indices = set()
-    ignored_any = False
-    saw_cuda_version_error = False
-    kept_sanitizer_error = False
-    index = 0
-
-    while index < len(lines):
-        line = lines[index]
-        if not _is_sanitizer_block_boundary(line):
-            index += 1
-            continue
-
-        block_end = index + 1
-        while block_end < len(lines) and not _is_sanitizer_block_boundary(lines[block_end]):
-            block_end += 1
-
-        block_lines = lines[index:block_end]
-        sanitizer_line_indices = [
-            line_index
-            for line_index in range(index, block_end)
-            if lines[line_index].startswith(SANITIZER_PREFIX)
-        ]
-        if _is_cuda_version_error_block(block_lines):
-            ignored_line_indices.update(sanitizer_line_indices)
-            ignored_any = True
-            saw_cuda_version_error = True
-        elif _is_cu_get_proc_address_invalid_value_block(block_lines):
-            ignored_line_indices.update(sanitizer_line_indices)
-            ignored_any = True
-        elif SANITIZER_PROGRAM_HIT in line or SANITIZER_CUDA_API_ERROR in line:
-            kept_sanitizer_error = True
-
-        index = block_end
-
-    ignore_error_exitcode = ignored_any and saw_cuda_version_error and not kept_sanitizer_error
-    for index, line in enumerate(lines):
-        if index in ignored_line_indices:
-            continue
-        if ignore_error_exitcode and SANITIZER_ERROR_SUMMARY in line:
-            continue
-        filtered_lines.append(line)
-
-    return SanitizerOutputAnalysis("\n".join(filtered_lines), ignore_error_exitcode)
-
-
-def _is_ignored_cuda_version_sanitizer_error(output, returncode, sanitizer_error_exitcode):
-    return _analyze_sanitizer_output(
-        output, returncode, sanitizer_error_exitcode
-    ).ignore_error_exitcode
-
-
-def _filter_sanitizer_output(output, returncode, sanitizer_error_exitcode):
-    return _analyze_sanitizer_output(output, returncode, sanitizer_error_exitcode).filtered_output
-
-
 def _validate_sanitizer_command(command):
     try:
         sanitizer_cmd = shlex.split(command)
@@ -1257,16 +1161,16 @@ def _run_single_config_with_sanitizer(options):
         errors="replace",
     )
     raw_output = f"{result.stdout or ''}{result.stderr or ''}"
-    analysis = _analyze_sanitizer_output(
+    analysis = analyze_sanitizer_output(
         raw_output, result.returncode, options.sanitizer_error_exitcode
     )
-    if analysis.filtered_output:
+    if analysis.output:
         print(
-            analysis.filtered_output,
-            end="" if analysis.filtered_output.endswith("\n") else "\n",
+            analysis.output,
+            end="" if analysis.output.endswith("\n") else "\n",
             flush=True,
         )
-    if analysis.ignore_error_exitcode:
+    if analysis.only_ignored_diagnostics:
         return 0
     if result.returncode == options.sanitizer_error_exitcode:
         print(
@@ -1309,7 +1213,6 @@ def run_test_case(api_config_str, options):
         )
     case_status = "done"
     try:
-        print(f"test begin: {api_config_str}", flush=True)
         runtime_config = runtime_config_for_gpu(options, gpu_id)
 
         try:
@@ -1640,9 +1543,7 @@ def main():
     options = parser.parse_args()
     options.paddle_version = paddle_version
     if not options._sanitizer_child:
-        print(f"Main process id: {os.getpid()}")
-        print(f"Options: {vars(options)}", flush=True)
-        print(f"PaddlePaddle version: {paddle_version}", flush=True)
+        print_run_header(options, paddle_version)
     if options.random_seed != parser.get_default("random_seed"):
         np.random.seed(options.random_seed)
 
@@ -1816,7 +1717,6 @@ def main():
 
         # read checkpoint
         finish_configs = read_log("checkpoint")
-        print(len(finish_configs), "cases in checkpoint.", flush=True)
 
         api_config_count = 0
         skipped_non_config = 0
@@ -1838,7 +1738,6 @@ def main():
                 return
         if skipped_non_config:
             print(f"{skipped_non_config} non-config lines skipped.", flush=True)
-        print(api_config_count, "cases in total.", flush=True)
         dup_case = api_config_count - len(api_configs)
         if dup_case > 0:
             print(dup_case, "cases are duplicates and removed.", flush=True)
@@ -1849,7 +1748,10 @@ def main():
         finish_case = api_config_count - all_case
         if finish_case:
             print(finish_case, "cases already tested.", flush=True)
-        print(all_case, "cases will be tested.", flush=True)
+        print("--- PREPARING")
+        print(
+            f"{'Cases':<11}{api_config_count} total | {len(finish_configs)} checkpointed | {all_case} pending"
+        )
         del api_config_count, dup_case, finish_case
 
         # validate GPU visibility and derive per-GPU worker counts
@@ -2011,14 +1913,11 @@ def main():
 
                 if options.show_runtime_status or tested_case % 10000 == 0:
                     print(
-                        f"[{tested_case}/{all_case}] Testing {config}",
+                        f"[{tested_case}/{all_case}] {msg_type.upper()} | {config}",
                         flush=True,
                     )
 
-                if msg_type == "done":
-                    if options.show_runtime_status or tested_case % 10000 == 0:
-                        print(f"[info] Test case succeeded for {config}", flush=True)
-                elif msg_type == "timeout":
+                if msg_type == "timeout":
                     write_to_log("timeout", config)
                     print(
                         f"[error] Test case timed out for {config}",
@@ -2087,19 +1986,22 @@ def main():
         except Exception as e:
             print(f"Unexpected error: {e}", flush=True)
             cleanup(pool)
-            total_time = time.time() - start_time
-            print(f"Test time: {round(total_time / 60, 3)} minutes.", flush=True)
         finally:
             pool.shutdown()
             if options.use_compute_sanitizer:
                 clean_sanitizer_case_logs()
-            print(f"{tested_case} cases have been tested.", flush=True)
             log_counts = aggregate_logs(end=True)
             print_log_info(max(all_case - tested_case, 0), log_counts)
             end_time = time.time()
             total_time = end_time - start_time
-            print(f"Test time: {round(total_time / 60, 3)} minutes.", flush=True)
-    print("Done.")
+            print_run_footer(
+                all_case,
+                tested_case,
+                max(all_case - tested_case, 0),
+                log_counts,
+                total_time,
+                options.log_dir,
+            )
 
 
 if __name__ == "__main__":

--- a/tester/api_config/log_writer.py
+++ b/tester/api_config/log_writer.py
@@ -72,6 +72,7 @@ import io
 import os
 import re
 import shutil
+from contextlib import contextmanager
 from datetime import datetime
 from pathlib import Path
 from typing import Literal
@@ -140,8 +141,8 @@ COMP_TO_DIMENSION = {
 ALL_DIMENSIONS = sorted(set(COMP_TO_DIMENSION.values()))
 TOL_HEADER = ["API", "config", "dtype", "mode", "max_abs_diff", "max_rel_diff"]
 STABLE_HEADER = ["API", "config", "dtype", "comp", "max_abs_diff", "max_rel_diff"]
-CASE_BEGIN_TAG = "[CASE_BEGIN]"
-CASE_END_TAG = "[CASE_END]"
+CASE_BEGIN_TAG = ">>> CASE"
+CASE_END_TAG = "<<< CASE"
 
 _use_worker_tmp_logs = False
 
@@ -153,6 +154,7 @@ _inorder_completed_offsets = {}
 # 配置 -> 全局终态类型；comp 日志写入后也同步到这里，供 checkpoint 逻辑使用。
 _process_terminal_configs = {}
 _case_result_types: dict[str, set[str]] = {}
+_case_comparisons: list[tuple[str, str]] = []
 # dimension -> {config_line -> log_type}，只负责 comp 维度内去重。
 _comp_terminal_configs: dict[str, dict[str, str]] = {}
 
@@ -181,6 +183,7 @@ def _reset_runtime():
     _inorder_completed_offsets.clear()
     _process_terminal_configs.clear()
     _case_result_types.clear()
+    _case_comparisons.clear()
     _comp_terminal_configs.clear()
 
 
@@ -422,17 +425,19 @@ def get_case_id(api_config_str):
 def write_case_begin(api_config_str, *, worker_pid=None, slot=None, gpu=None, paddle_version=None):
     """写入包含执行元数据的 case 起始行并返回其 ID。"""
     case_id = get_case_id(api_config_str)
-    fields = [f"case_id={case_id}"]
-    if worker_pid is not None:
-        fields.append(f"worker_pid={worker_pid}")
-    if slot is not None:
-        fields.append(f"slot={slot}")
-    if gpu is not None:
-        fields.append(f"gpu={gpu}")
+    timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S.%f")[:-3]
+    fields = [f"{CASE_BEGIN_TAG} {case_id}", timestamp]
     if paddle_version is not None:
-        fields.append(f"paddle_version={paddle_version}")
-    fields.append(f"timestamp={datetime.now().isoformat()}")
-    print(f"{CASE_BEGIN_TAG} {' '.join(fields)}")
+        fields.append(f"Paddle {paddle_version}")
+    if gpu is not None:
+        fields.append(f"GPU {gpu}")
+    if worker_pid is not None:
+        fields.append(f"PID {worker_pid}")
+    if slot is not None:
+        fields.append(f"Slot {slot}")
+    print(" | ".join(fields), flush=True)
+    print(api_config_str, flush=True)
+    print(flush=True)
     return case_id
 
 
@@ -444,14 +449,27 @@ def write_case_end(status, case_id=None, api_config_str=None, duration_ms=None, 
     """为指定 ID 或配置写入 case 结束 tag，支持多个终态结果。"""
     if api_config_str is not None:
         case_id = get_case_id(api_config_str)
-    fields = [f"case_id={case_id}", f"status={status}"]
     if results is None and api_config_str is not None:
         results = _case_results(api_config_str)
-    if results:
-        fields.append(f"results={','.join(sorted(set(results)))}")
+    result_types = set(results or ())
+    if result_types == {"pass"}:
+        outcome = "PASS"
+    elif result_types == {"skip"}:
+        outcome = "SKIP"
+    elif result_types:
+        outcome = "FAIL"
+    else:
+        outcome = status.upper()
+    if _case_comparisons:
+        for start in range(0, len(_case_comparisons), 3):
+            values = _case_comparisons[start : start + 3]
+            print(" | ".join(f"{comp} {result}" for comp, result in values), flush=True)
+        _case_comparisons.clear()
+        print(flush=True)
+    fields = [f"{CASE_END_TAG} {case_id}", outcome]
     if duration_ms is not None:
-        fields.append(f"duration_ms={duration_ms}")
-    print(f"{CASE_END_TAG} {' '.join(fields)}", flush=True)
+        fields.append(f"{duration_ms} ms")
+    print(" | ".join(fields) + "\n\n", flush=True)
     return get_worker_log_offset()
 
 
@@ -468,19 +486,110 @@ def get_worker_log_offset(pid=None):
 
 def append_case_end_to_worker_log(pid, status, case_id=None, api_config_str=None):
     """worker 停止后补写 synthetic case 结束 tag。"""
-    end_line = (
-        f"{CASE_END_TAG} case_id={case_id or get_case_id(api_config_str)} "
-        f"status={status} results={status}"
-    )
+    end_line = f"{CASE_END_TAG} {case_id or get_case_id(api_config_str)} | {status.upper()}"
     try:
         log_file = TMP_LOG_PATH / f"log_{pid}.log"
         log_file.parent.mkdir(parents=True, exist_ok=True)
         with log_file.open("a", encoding="utf-8") as f:
-            f.write(f"{end_line}\n")
+            f.write(f"{end_line}\n\n\n")
         return log_file.stat().st_size
     except Exception as err:
         print(f"Error writing case end to worker log {pid}: {err}", flush=True)
         return None
+
+
+@contextmanager
+def suppress_startup_output():
+    """在 Paddle 和扩展初始化期间静默 stdout/stderr。"""
+    saved_stdout = os.dup(1)
+    saved_stderr = os.dup(2)
+    try:
+        with open(os.devnull, "w") as devnull:
+            os.dup2(devnull.fileno(), 1)
+            os.dup2(devnull.fileno(), 2)
+            yield
+    finally:
+        os.dup2(saved_stdout, 1)
+        os.dup2(saved_stderr, 2)
+        os.close(saved_stdout)
+        os.close(saved_stderr)
+
+
+def format_duration(seconds):
+    """按运行时长选择秒、分钟或小时单位。"""
+    if seconds >= 3600:
+        return f"{seconds / 3600:.2f} h"
+    if seconds >= 60:
+        return f"{seconds / 60:.2f} min"
+    return f"{seconds:.2f} s"
+
+
+def print_run_header(options, paddle_version):
+    """打印一次测试的紧凑启动信息和有效配置。"""
+    modes = (
+        "accuracy",
+        "paddle_only",
+        "paddle_cinn",
+        "paddle_gpu_performance",
+        "torch_gpu_performance",
+        "paddle_torch_gpu_performance",
+        "accuracy_stable",
+        "paddle_custom_device",
+        "custom_device_vs_gpu",
+    )
+    mode = next((name for name in modes if getattr(options, name, False)), "unknown")
+    source = options.api_config_file or options.api_config_file_pattern or "single config"
+    timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S.%f")[:-3]
+    print(f">>> TEST RUN | {timestamp} | Paddle {paddle_version} | PID {os.getpid()}\n")
+    print("--- OPTIONS")
+    print(f"{'Input':<11}{source}")
+    print(f"{'Output':<11}{options.log_dir or 'tester/api_config/test_log'}")
+    print(f"{'Mode':<11}{mode.replace('_', ' ').title()}")
+    device = "CPU" if options.test_cpu else "GPU " + (options.gpu_ids or "all")
+    print(f"{'Device':<11}{device}")
+    data_mode = (
+        "GPU mode"
+        if options.use_gpu_mode
+        else "Cached NumPy"
+        if options.use_cached_numpy
+        else "NumPy"
+    )
+    print(f"{'Data':<11}{data_mode}")
+    print(f"{'Tolerance':<11}atol {options.atol} | rtol {options.rtol}")
+    print(f"{'Timeout':<11}{options.timeout} s")
+    print(f"{'Runtime':<11}{'detailed' if options.show_runtime_status else 'errors only'}\n")
+
+
+def print_run_footer(total_case, tested_case, remaining_case, log_counts, elapsed, log_dir):
+    """打印统一结果摘要、结束时间和总用时。"""
+    counts = {key: value for key, value in (log_counts or {}).items() if not key.startswith("_")}
+    paddle_types = (
+        "paddle_error",
+        "paddle_accuracy",
+        "paddle_bitwise",
+        "paddle_cuda",
+        "paddle_crash",
+    )
+    test_types = ("torch_error", "config_input", "config_parse", "config_convert")
+    paddle_issues = sum(counts.get(key, 0) for key in paddle_types)
+    test_issues = sum(counts.get(key, 0) for key in test_types)
+    retest = sum(counts.get(key, 0) for key in ("oom", "timeout"))
+    outcome = (
+        "PASS" if remaining_case == 0 and paddle_issues + test_issues + retest == 0 else "DONE"
+    )
+    print("\n--- RESULT")
+    print(
+        f"{'Cases':<11}{tested_case} tested | {counts.get('pass', 0)} pass | "
+        f"{counts.get('skip', 0)} skip | {remaining_case} remaining"
+    )
+    print(f"{'Issues':<11}{paddle_issues} Paddle | {test_issues} test | {retest} retest")
+    print(f"{'Duration':<11}{format_duration(elapsed)}")
+    print(f"{'Logs':<11}{log_dir}")
+    timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S.%f")[:-3]
+    print(
+        f"\n<<< TEST RUN | {outcome} | {tested_case}/{total_case} completed | {timestamp} | {format_duration(elapsed)}",
+        flush=True,
+    )
 
 
 def _copy_inorder_range(file_path, out_f, start_offset, end_offset):
@@ -911,24 +1020,6 @@ def print_log_info(remaining_case, log_counts=None):
     ]
     test_types = ["torch_error", "config_input", "config_parse", "config_convert"]
 
-    print("\n" + "=" * 50)
-    print("Test Case Statistics".center(50))
-    print("=" * 50)
-    print(f"{'Remaining cases':<30}: {remaining_case:>8}")
-    print(f"{'Tested cases':<30}: {counts.get('checkpoint', 0):>8}")
-    print(f"{'Pass cases':<30}: {counts.get('pass', 0):>8}")
-    print(f"{'Skip cases':<30}: {counts.get('skip', 0):>8}")
-    print(f"{'Paddle issue cases':<30}: {sum(counts.get(key, 0) for key in paddle_types):>8}")
-    print(f"{'Test issue cases':<30}: {sum(counts.get(key, 0) for key in test_types):>8}")
-    print(f"{'Retest cases':<30}: {sum(counts.get(key, 0) for key in ('oom', 'timeout')):>8}")
-    if counts:
-        print("-" * 50)
-        print("Log Type Breakdown:")
-        if is_multi_classification and has_multi_result_overlap:
-            print("  Note: In accuracy_stable mode, one config may appear in multiple result sets.")
-        for log_type, count in counts.items():
-            print(f"  {log_type:<28}: {count:>8}")
-    print("=" * 50 + "\n")
     if is_multi_classification:
         _print_comp_duplicate_classifications(comp_integrity_errors)
     else:
@@ -1032,7 +1123,10 @@ def log_accuracy_tolerance(error_msg, api, config, dtype, is_backward=False):
 
 def log_accuracy_stable(error_msg, api, config, dtype, comp):
     """记录一个比较模式下的稳定性误差。"""
-    print(f"comp={comp} result={error_msg}", flush=True)
+    if "\n" in error_msg:
+        print(f"{comp} {error_msg}", flush=True)
+    else:
+        _case_comparisons.append((comp, error_msg))
     abs_pattern = (
         r"(?:Absolute|Greatest absolute|Max absolute) difference(?: among violations)?: "
         r"(\d+\.?\d*(?:[eE][+-]?\d+)?|nan|inf)\b"

--- a/tester/api_config/sanitizer_output.py
+++ b/tester/api_config/sanitizer_output.py
@@ -1,0 +1,89 @@
+"""Parse compute-sanitizer output and remove known non-actionable diagnostics."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+SANITIZER_PREFIX = "========="
+SANITIZER_CUDA_API_ERROR = "CUDA API Error:"
+SANITIZER_PROGRAM_HIT = "Program hit"
+SANITIZER_ERROR_SUMMARY = "ERROR SUMMARY:"
+CUDA_VERSION_ERROR_RE = re.compile(
+    r"cudaVersion argument [(][0-9]+[)] exceeds the driver version [(][0-9]+[)]"
+)
+
+
+@dataclass(frozen=True)
+class SanitizerAnalysis:
+    """Filtered output and whether the sanitizer failure is entirely ignorable."""
+
+    output: str
+    only_ignored_diagnostics: bool
+
+
+def _is_diagnostic_header(line):
+    return line.startswith(SANITIZER_PREFIX) and (
+        SANITIZER_CUDA_API_ERROR in line or SANITIZER_PROGRAM_HIT in line
+    )
+
+
+def _is_summary(line):
+    return line.startswith(SANITIZER_PREFIX) and SANITIZER_ERROR_SUMMARY in line
+
+
+def _is_ignored_diagnostic(block):
+    text = "\n".join(block)
+    first_line = block[0]
+    if SANITIZER_CUDA_API_ERROR in first_line and CUDA_VERSION_ERROR_RE.search(text):
+        return True
+    return "CUDA_ERROR_INVALID_VALUE" in first_line and "cuGetProcAddress_v2" in text
+
+
+def _diagnostic_end(lines, start):
+    """Return the end of one prefixed sanitizer diagnostic block."""
+    end = start + 1
+    while end < len(lines):
+        line = lines[end]
+        if _is_diagnostic_header(line) or _is_summary(line):
+            break
+        if not line.startswith(SANITIZER_PREFIX):
+            break
+        end += 1
+    return end
+
+
+def analyze_sanitizer_output(output, returncode, sanitizer_error_exitcode):
+    """Remove complete known-noise blocks and classify the sanitizer exit status."""
+    if returncode != sanitizer_error_exitcode:
+        return SanitizerAnalysis(output, False)
+
+    lines = output.splitlines()
+    kept_lines = []
+    summaries = []
+    ignored_any = False
+    actionable_error = False
+    index = 0
+
+    while index < len(lines):
+        line = lines[index]
+        if _is_diagnostic_header(line):
+            end = _diagnostic_end(lines, index)
+            block = lines[index:end]
+            if _is_ignored_diagnostic(block):
+                ignored_any = True
+            else:
+                actionable_error = True
+                kept_lines.extend(block)
+            index = end
+            continue
+        if _is_summary(line):
+            summaries.append(line)
+        else:
+            kept_lines.append(line)
+        index += 1
+
+    only_ignored = ignored_any and not actionable_error
+    if actionable_error:
+        kept_lines.extend(summaries)
+    return SanitizerAnalysis("\n".join(kept_lines), only_ignored)

--- a/tester/api_config/test_sanitizer_output.py
+++ b/tester/api_config/test_sanitizer_output.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import unittest
+
+from tester.api_config.sanitizer_output import analyze_sanitizer_output
+
+
+class SanitizerOutputTest(unittest.TestCase):
+    def analyze(self, output, returncode=86):
+        return analyze_sanitizer_output(output, returncode, 86)
+
+    def test_cuda_version_diagnostic_is_completely_silent(self):
+        result = self.analyze(
+            "========= CUDA API Error: cudaErrorInvalidValue (error 1)\n"
+            "========= cudaVersion argument (12090) exceeds the driver version (12080)\n"
+            "=========     Saved host backtrace up to driver entry point\n"
+            "========= ERROR SUMMARY: 1 error\n"
+        )
+        self.assertEqual(result.output, "")
+        self.assertTrue(result.only_ignored_diagnostics)
+
+    def test_cu_get_proc_address_diagnostic_is_completely_silent(self):
+        result = self.analyze(
+            "========= CUDA API Error: CUDA_ERROR_INVALID_VALUE\n"
+            "=========     cuGetProcAddress_v2\n"
+            "========= ERROR SUMMARY: 1 error\n"
+        )
+        self.assertEqual(result.output, "")
+        self.assertTrue(result.only_ignored_diagnostics)
+
+    def test_real_error_is_preserved_when_mixed_with_ignored_error(self):
+        result = self.analyze(
+            "child output\n"
+            "========= CUDA API Error: cudaErrorInvalidValue\n"
+            "========= cudaVersion argument (13000) exceeds the driver version (12080)\n"
+            "========= Program hit cudaErrorIllegalAddress\n"
+            "=========     at kernel.cu:10\n"
+            "========= ERROR SUMMARY: 2 errors\n"
+        )
+        self.assertEqual(
+            result.output,
+            "child output\n"
+            "========= Program hit cudaErrorIllegalAddress\n"
+            "=========     at kernel.cu:10\n"
+            "========= ERROR SUMMARY: 2 errors",
+        )
+        self.assertFalse(result.only_ignored_diagnostics)
+
+    def test_non_sanitizer_exit_is_not_filtered(self):
+        output = (
+            "========= CUDA API Error: CUDA_ERROR_INVALID_VALUE\n========= cuGetProcAddress_v2\n"
+        )
+        result = self.analyze(output, returncode=2)
+        self.assertEqual(result.output, output)
+        self.assertFalse(result.only_ignored_diagnostics)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/error_stat/error_stat.py
+++ b/tools/error_stat/error_stat.py
@@ -89,14 +89,16 @@ def _parse_tagged_logs(input_text):
             if current_content:
                 logs.append("\n".join(current_content))
             current_content = [line]
-            match = re.search(r"case_id=([^\s]+)", line)
+            match = re.match(rf"{re.escape(CASE_BEGIN_TAG)} ([^|\s]+)", line)
             current_case_id = match.group(1) if match else None
             continue
         if current_content:
-            current_content.append(line)
             if line.startswith(CASE_END_TAG):
+                while current_content and not current_content[-1].strip():
+                    current_content.pop()
+                current_content.append(line)
                 end_count += 1
-                match = re.search(r"case_id=([^\s]+)", line)
+                match = re.match(rf"{re.escape(CASE_END_TAG)} ([^|\s]+)", line)
                 end_case_id = match.group(1) if match else None
                 if current_case_id and end_case_id and current_case_id != end_case_id:
                     print(
@@ -106,6 +108,8 @@ def _parse_tagged_logs(input_text):
                 logs.append("\n".join(current_content))
                 current_content = []
                 current_case_id = None
+            else:
+                current_content.append(line)
     if current_content:
         logs.append("\n".join(current_content))
     if begin_count != end_count:
@@ -160,8 +164,10 @@ def parse_logs(input_path):
 
 
 def get_config_key(content):
-    # Structured logs are split at CASE_BEGIN; the config remains on the
-    # test-begin line inside each block. Legacy blocks use the same line.
+    # 新格式把 config 固定在 CASE 首行之后；旧日志继续识别 test begin。
+    lines = content.splitlines()
+    if lines and lines[0].startswith(CASE_BEGIN_TAG) and len(lines) > 1:
+        return lines[1].strip()
     match = re.search(r"test begin: ([^\r\n]*)", content)
     return match.group(1).strip() if match else ""
 


### PR DESCRIPTION
## 🧭 背景
API 测试并发执行时，原始启动、用例和汇总日志包含较多重复或初始化噪声，且用例边界与配置内容不够直观，影响排查和后续错误统计。compute-sanitizer 在驱动版本不匹配等已知无效诊断下也会返回错误码，容易造成误判。

## 🛠️ 实现方案
统一用例起止标记、运行头尾和结果摘要的输出格式，将配置、执行环境、比较结果及耗时组织到同一用例日志块中；统计工具同步按新标记解析，同时保留旧版 `test begin` 日志兼容。sanitizer 输出解析抽离为独立模块，只在错误码匹配时过滤完整的已知无效诊断块，保留实际异常。

## 🔧 主要变更
### 1. 规范测试运行与用例日志
为 engineV2 和 engineV4 增加紧凑的运行头尾、准备信息和结果汇总；用 `>>> CASE` / `<<< CASE` 标记用例边界，输出配置、Paddle 版本、GPU、进程和耗时，并聚合稳定性比较结果。初始化 Paddle 与扩展期间抑制 stdout/stderr，减少无关噪声。

### 2. 兼容新的日志解析与错误统计
错误统计工具按新的 CASE 标记提取 case id 和配置，去除结束标记前的空行；未包含新标记的存量日志继续通过 `test begin` 解析。

### 3. 降低 compute-sanitizer 误报
新增 sanitizer 输出分析模块，过滤 `cudaVersion` 超出驱动版本及 `cuGetProcAddress_v2` 的已知无效诊断；仅当全部诊断均可忽略时将 sanitizer 错误码视为成功，混合或真实错误仍完整输出并失败。

## 📁 改动文件
| 类别 | 文件 | 功能说明 |
| --- | --- | --- |
| 测试引擎 | `engineV2.py`、`engineV4.py` | 接入统一运行/用例日志，处理 sanitizer 输出 |
| 日志基础设施 | `tester/api_config/log_writer.py` | 定义 CASE 格式、运行摘要和启动静默逻辑 |
| Sanitizer | `tester/api_config/sanitizer_output.py` | 解析并过滤已知无效 sanitizer 诊断 |
| 测试 | `tester/api_config/test_sanitizer_output.py` | 覆盖可忽略、混合真实错误和非 sanitizer 退出码场景 |
| 统计工具 | `tools/error_stat/error_stat.py` | 兼容新旧日志格式的解析 |
