### PR TITLE
支持更多 Paddle Tensor API 的 Torch 精度对齐

### DIFF
--- a/engineV2.py
+++ b/engineV2.py
@@ -440,8 +440,6 @@ def validate_gpu_options(options) -> tuple:
             "expected -1 or a positive integer"
         )
     if getattr(options, "accuracy_stable_dual_gpu", False):
-        if getattr(options, "test_cpu", False):
-            raise ValueError("--accuracy_stable_dual_gpu=True does not support --test_cpu=True")
         if options.num_gpus < 2 or options.num_gpus % 2:
             raise ValueError("--accuracy_stable_dual_gpu=True requires an even --num_gpus")
         if options.num_workers_per_gpu != 1:
@@ -460,6 +458,29 @@ def normalize_accuracy_stable_dual_gpu_options(options):
         )
         options.use_gpu_mode = True
     options.accuracy_stable = True
+
+
+def _mode_runs_torch_gpu_reference(options):
+    """只有执行 Torch reference 的模式才要求保留 GPU 运行时。"""
+    return any(
+        getattr(options, mode, False)
+        for mode in (
+            "accuracy",
+            "accuracy_stable",
+            "accuracy_stable_dual_gpu",
+            "torch_gpu_performance",
+            "paddle_torch_gpu_performance",
+        )
+    )
+
+
+def _requires_gpu_runtime(options):
+    """test_cpu 与 use_gpu_mode 正交地决定 GPU 运行时需求。"""
+    return bool(
+        not getattr(options, "test_cpu", False)
+        or getattr(options, "use_gpu_mode", False)
+        or _mode_runs_torch_gpu_reference(options)
+    )
 
 
 def _resolve_dump_options(parser, options):
@@ -496,9 +517,7 @@ def _apply_single_config_gpu_defaults(options):
 
 def _prepare_single_config_gpu(options):
     normalize_accuracy_stable_dual_gpu_options(options)
-    if getattr(options, "accuracy_stable_dual_gpu", False) and getattr(options, "test_cpu", False):
-        raise ValueError("--accuracy_stable_dual_gpu=True does not support --test_cpu=True")
-    if options.test_cpu:
+    if not _requires_gpu_runtime(options):
         options.gpu_workers_per_gpu_map = {}
         options.gpu_total_memory_map = {}
         options.runtime_config = TestRuntimeConfig.from_options(options)
@@ -1074,7 +1093,7 @@ def main():
         )
         return
     normalize_accuracy_stable_dual_gpu_options(options)
-    if options.api_config and not options.test_cpu:
+    if options.api_config and _requires_gpu_runtime(options):
         _apply_single_config_gpu_defaults(options)
 
     mode = [

--- a/engineV4.py
+++ b/engineV4.py
@@ -1135,6 +1135,29 @@ def normalize_accuracy_stable_dual_gpu_options(options):
     options.accuracy_stable = True
 
 
+def _mode_runs_torch_gpu_reference(options):
+    """只有执行 Torch reference 的模式才要求保留 GPU 运行时。"""
+    return any(
+        getattr(options, mode, False)
+        for mode in (
+            "accuracy",
+            "accuracy_stable",
+            "accuracy_stable_dual_gpu",
+            "torch_gpu_performance",
+            "paddle_torch_gpu_performance",
+        )
+    )
+
+
+def _requires_gpu_runtime(options):
+    """test_cpu 与 use_gpu_mode 正交地决定 GPU 运行时需求。"""
+    return bool(
+        not getattr(options, "test_cpu", False)
+        or getattr(options, "use_gpu_mode", False)
+        or _mode_runs_torch_gpu_reference(options)
+    )
+
+
 def validate_gpu_options(options) -> tuple:
     """Validate and normalize GPU-related options."""
     normalize_accuracy_stable_dual_gpu_options(options)
@@ -1162,8 +1185,6 @@ def validate_gpu_options(options) -> tuple:
             "expected -1 or a positive integer"
         )
     if getattr(options, "accuracy_stable_dual_gpu", False):
-        if getattr(options, "test_cpu", False):
-            raise ValueError("--accuracy_stable_dual_gpu=True does not support --test_cpu=True")
         if options.num_gpus < 2 or options.num_gpus % 2:
             raise ValueError("--accuracy_stable_dual_gpu=True requires an even --num_gpus")
         if options.num_workers_per_gpu != 1:
@@ -1205,9 +1226,7 @@ def _apply_single_config_gpu_defaults(options):
 
 def _prepare_single_config_gpu(options):
     normalize_accuracy_stable_dual_gpu_options(options)
-    if getattr(options, "accuracy_stable_dual_gpu", False) and getattr(options, "test_cpu", False):
-        raise ValueError("--accuracy_stable_dual_gpu=True does not support --test_cpu=True")
-    if options.test_cpu:
+    if not _requires_gpu_runtime(options):
         options.gpu_workers_per_gpu_map = {}
         options.gpu_total_memory_map = {}
         options.runtime_config = TestRuntimeConfig.from_options(options)
@@ -1745,7 +1764,7 @@ def main():
         )
         return
     normalize_accuracy_stable_dual_gpu_options(options)
-    if options.api_config and not options.test_cpu:
+    if options.api_config and _requires_gpu_runtime(options):
         _apply_single_config_gpu_defaults(options)
 
     mode = [

--- a/tester/api_config/config_analyzer.py
+++ b/tester/api_config/config_analyzer.py
@@ -3486,7 +3486,9 @@ class TensorConfig:
                     if self.dtype == "bfloat16"
                     else ("float16" if self.dtype in FLOAT8_DTYPES else self.dtype)
                 )
-                operator_place = paddle.CPUPlace() if getattr(api_config, "test_cpu", False) else self.place
+                operator_place = (
+                    paddle.CPUPlace() if getattr(api_config, "test_cpu", False) else self.place
+                )
                 self.paddle_tensor = paddle.to_tensor(
                     self.get_numpy_tensor(api_config),
                     dtype=intermediate_dtype,
@@ -3522,7 +3524,9 @@ class TensorConfig:
         try:
             intermediate_dtype = "float16" if self.dtype in FLOAT8_DTYPES else self.dtype
             storage_size = self._strided_storage_size()
-            operator_place = paddle.CPUPlace() if getattr(api_config, "test_cpu", False) else self.place
+            operator_place = (
+                paddle.CPUPlace() if getattr(api_config, "test_cpu", False) else self.place
+            )
             flat_tensor = paddle.zeros(
                 [storage_size],
                 dtype=intermediate_dtype,

--- a/tester/api_config/config_analyzer.py
+++ b/tester/api_config/config_analyzer.py
@@ -315,11 +315,30 @@ class TensorConfig:
         return get_cached_numpy_array(dtype, shape, generation_kind=generation_kind, scale=scale)
 
     def _use_gpu(self, api_config=None, dtype=None):
+        """判断是否启用 GPU tensor 生成；不代表 Paddle kernel 的 place。"""
         if not is_gpu_mode():
             return False
         if self.place is not None and "cpu" in str(self.place).lower():
             return False
         return "gpu" in paddle.device.get_device()
+
+    def _paddle_kernel_uses_gpu(self, api_config):
+        """test_cpu 只决定 Paddle kernel，不能被 use_gpu_mode 覆盖。"""
+        if self.place is not None and "cpu" in str(self.place).lower():
+            return False
+        if getattr(api_config, "test_cpu", False):
+            return False
+        return "gpu" in paddle.device.get_device()
+
+    def _torch_source_device_for_paddle(self, api_config):
+        """返回送入 Paddle 前的 Torch 源设备，遵守 Paddle kernel place。"""
+        if self.place is not None and "cpu" in str(self.place).lower():
+            return torch.device("cpu")
+        if getattr(api_config, "test_cpu", False):
+            return torch.device("cpu")
+        if self._paddle_kernel_uses_gpu(api_config):
+            return torch.device("cuda", torch.cuda.current_device())
+        return torch.device("cpu")
 
     def _supports_autograd(self, dtype=None):
         dtype = dtype or self.dtype
@@ -3433,10 +3452,12 @@ class TensorConfig:
                 and self._use_gpu(api_config)
             ):
                 self.paddle_tensor = self._make_gpu_paddle_tensor(api_config)
+                if getattr(api_config, "test_cpu", False):
+                    self.paddle_tensor = self.paddle_tensor._copy_to(paddle.CPUPlace(), False)
                 return self.paddle_tensor
             if self.cpu_tensor is not None:
                 torch_tensor = self.cpu_tensor.to(
-                    device=torch.device("cuda:0") if self._use_gpu(api_config) else "cpu",
+                    device=self._torch_source_device_for_paddle(api_config),
                     copy=True,
                 )
                 self.paddle_tensor = paddle.utils.dlpack.from_dlpack(
@@ -3445,7 +3466,10 @@ class TensorConfig:
                 self.paddle_tensor.stop_gradient = not self._requires_autograd(api_config)
                 return self.paddle_tensor
             if self.numpy_tensor is None and self._use_gpu(api_config):
-                return self.get_gpu_paddle_tensor(api_config)
+                tensor = self.get_gpu_paddle_tensor(api_config)
+                if getattr(api_config, "test_cpu", False):
+                    self.paddle_tensor = tensor._copy_to(paddle.CPUPlace(), False)
+                return self.paddle_tensor
             if not self.is_contiguous and self.strides is not None:
                 self.paddle_tensor = self._create_strided_paddle_tensor(api_config)
                 print(
@@ -3462,10 +3486,11 @@ class TensorConfig:
                     if self.dtype == "bfloat16"
                     else ("float16" if self.dtype in FLOAT8_DTYPES else self.dtype)
                 )
+                operator_place = paddle.CPUPlace() if getattr(api_config, "test_cpu", False) else self.place
                 self.paddle_tensor = paddle.to_tensor(
                     self.get_numpy_tensor(api_config),
                     dtype=intermediate_dtype,
-                    place=self.place,
+                    place=operator_place,
                 )
 
                 if self.dtype == "bfloat16":
@@ -3497,10 +3522,11 @@ class TensorConfig:
         try:
             intermediate_dtype = "float16" if self.dtype in FLOAT8_DTYPES else self.dtype
             storage_size = self._strided_storage_size()
+            operator_place = paddle.CPUPlace() if getattr(api_config, "test_cpu", False) else self.place
             flat_tensor = paddle.zeros(
                 [storage_size],
                 dtype=intermediate_dtype,
-                device=self.place,
+                device=operator_place,
             )
             tensor = paddle.as_strided(flat_tensor, self.shape, self.strides)
             logical_tensor = self.get_numpy_tensor(api_config)
@@ -3508,7 +3534,7 @@ class TensorConfig:
                 tensor[...] = paddle.to_tensor(
                     logical_tensor,
                     dtype=intermediate_dtype,
-                    place=self.place,
+                    place=operator_place,
                 )
             if self.dtype in FLOAT8_DTYPES:
                 flat_tensor = paddle.cast(flat_tensor, dtype=self.dtype)

--- a/tester/base.py
+++ b/tester/base.py
@@ -493,8 +493,11 @@ class APITestBase:
     def __init__(self, api_config, use_torch=True, runtime_config=None):
         self.api_config = api_config
         self.api_config.use_torch = use_torch
+        self.use_torch = bool(use_torch)
         self.runtime_config = runtime_config or TestRuntimeConfig()
         self.gpu_mode_config = self.runtime_config.gpu_mode
+        # TensorConfig 需要知道 kernel place，不能从 GPU mode 反推。
+        self.api_config.test_cpu = self.runtime_config.test_cpu
         self.dump_context = (
             DumpContext(
                 os.environ.get("DUMP_DIR") or DEFAULT_DUMP_DIR, api_config=api_config.config
@@ -507,6 +510,14 @@ class APITestBase:
         if use_torch:
             torch.set_num_threads(8)
             torch.set_printoptions(threshold=100, linewidth=120)
+
+    def torch_operator_device(self):
+        """返回当前 worker 的 Torch reference 设备。"""
+        return torch.device(f"{self.runtime_config.torch_operator_device_type}:0")
+
+    def requires_gpu_runtime(self):
+        """算子执行或 GPU mode 任一需要 GPU 时返回 True。"""
+        return self.use_torch or not self.runtime_config.test_cpu or self.gpu_mode_config.enabled
 
     def run_with_dump(self):
         """Execute the test with dump output capture and lifecycle reporting."""

--- a/tester/base.py
+++ b/tester/base.py
@@ -406,6 +406,12 @@ _COPS_API_PUBLIC_ALIAS: dict[str, str] = {
 # differs materially from any public API.
 no_signature_api_mappings.update(
     {
+        # copy_ 是内建方法，无法通过 inspect 获取签名。
+        "paddle.Tensor.copy_": {
+            "self": lambda cfg: get_arg(cfg, 0, "self"),
+            "other": lambda cfg: get_arg(cfg, 1, "other"),
+            "blocking": lambda cfg: get_arg(cfg, 2, "blocking", True),
+        },
         # adamw_(param, grad, lr, moment1, moment2, moment2_max,
         #        beta1_pow, beta2_pow, master_param, skip_update,
         #        beta1, beta2, epsilon, lr_ratio, coeff, with_decay,

--- a/tester/base_config.yaml
+++ b/tester/base_config.yaml
@@ -173,6 +173,7 @@ handle_axes_api:
 
 forward_only_apis:
   - _run_custom_op
+  - copy_
   - moe_permute
   - moe_unpermute
   - fp8_quant_blockwise

--- a/tester/log_writer/log_report.py
+++ b/tester/log_writer/log_report.py
@@ -66,16 +66,32 @@ def print_run_header(options, paddle_version):
             )
         )
 
+    torch_reference_gpu = any(
+        getattr(options, name, False)
+        for name in (
+            "accuracy",
+            "accuracy_stable",
+            "accuracy_stable_dual_gpu",
+            "torch_gpu_performance",
+            "paddle_torch_gpu_performance",
+        )
+    )
+    requires_gpu = not options.test_cpu or options.use_gpu_mode or torch_reference_gpu
+    compute = [
+        ("paddle_kernel_device", "CPU" if options.test_cpu else "GPU"),
+        ("torch_reference_device", "GPU" if torch_reference_gpu else "N/A"),
+        ("input_compare_device", "GPU" if options.use_gpu_mode else "CPU"),
+    ]
     if options.test_cpu:
-        compute = [("--test_cpu", True)]
-    else:
+        compute.append(("--test_cpu", True))
+    if requires_gpu:
         if not options.gpu_ids:
             gpu_ids_display = "all visible"
         elif options.gpu_ids == "-1":
             gpu_ids_display = "-1 (all visible)"
         else:
             gpu_ids_display = options.gpu_ids
-        compute = [("--gpu_ids", gpu_ids_display)]
+        compute.append(("--gpu_ids", gpu_ids_display))
         if options.use_gpu_mode:
             compute.append(("--use_gpu_mode", True))
             if getattr(options, "accuracy_stable_dual_gpu", False):

--- a/tester/paddle_cinn_vs_dygraph.py
+++ b/tester/paddle_cinn_vs_dygraph.py
@@ -9,7 +9,12 @@ from .log_writer.log_worker import write_to_log
 
 class APITestCINNVSDygraph(APITestBase):
     def __init__(self, api_config, **kwargs):
-        super().__init__(api_config)
+        # CINN 只执行 Paddle kernel，不应丢失 worker 的 test_cpu 设备协议。
+        super().__init__(
+            api_config,
+            use_torch=False,
+            runtime_config=kwargs.get("runtime_config"),
+        )
         self.test_amp = kwargs.get("test_amp", False)
         self.test_backward = kwargs.get("test_backward", False)
 

--- a/tester/paddle_to_torch/mapping.json
+++ b/tester/paddle_to_torch/mapping.json
@@ -5049,5 +5049,48 @@
     },
     "paddle._C_ops._run_custom_op": {
         "Rule": "CopsRunCustomOpRule"
+    },
+    "paddle.Tensor.add_": {
+        "Rule": "CopsAdd_Rule"
+    },
+    "paddle.Tensor.contiguous": {
+        "torch_api": "torch.Tensor.contiguous"
+    },
+    "paddle.Tensor.copy_": {
+        "torch_api": "torch.Tensor.copy_",
+        "torch_args": [],
+        "torch_kwargs": {
+            "other": "other",
+            "non_blocking": "not blocking"
+        }
+    },
+    "paddle.Tensor.flatten_": {
+        "Rule": "CopsFlatten_Rule"
+    },
+    "paddle.Tensor.multiply_": {
+        "Rule": "CopsMultiply_Rule"
+    },
+    "paddle.Tensor.put_along_axis_": {
+        "Rule": "CopsPutAlongAxis_Rule"
+    },
+    "paddle.Tensor.scale_": {
+        "Rule": "CopsScale_Rule"
+    },
+    "paddle.Tensor.subtract_": {
+        "Rule": "CopsSubtract_Rule"
+    },
+    "paddle.Tensor.to": {
+        "Rule": "TensorToRule"
+    },
+    "paddle.randint": {
+        "torch_api": "torch.randint",
+        "torch_args": [
+            "low",
+            "high",
+            "tuple(shape) if isinstance(shape, list) else shape"
+        ],
+        "torch_kwargs": {
+            "dtype": "locals().get(\"dtype\") if locals().get(\"dtype\") is not None else torch.int64"
+        }
     }
 }

--- a/tester/paddle_to_torch/rules.py
+++ b/tester/paddle_to_torch/rules.py
@@ -7400,8 +7400,9 @@ class CopsSubtract_Rule(BaseRule):
         core = """
 x = locals().get("x")
 y = locals().get("y")
+alpha = locals().get("alpha", 1)
 with torch.no_grad():
-    x.sub_(y)
+    x.sub_(y.to(x.dtype), alpha=alpha)
 result = x
 """
         code = Code(core=core.splitlines())
@@ -7421,8 +7422,9 @@ class CopsAdd_Rule(BaseRule):
         core = """
 x = locals().get("x")
 y = locals().get("y")
+alpha = locals().get("alpha", 1)
 with torch.no_grad():
-    x.add_(y.to(x.dtype))
+    x.add_(y.to(x.dtype), alpha=alpha)
 result = x
 """
         code = Code(core=core.splitlines())
@@ -7513,7 +7515,7 @@ class CopsPutAlongAxis_Rule(BaseRule):
 
     def apply(self, paddle_api: str) -> ConvertResult:
         core = """
-arr          = locals().get("arr")
+arr          = locals().get("arr", locals().get("x"))
 indices      = locals().get("indices")
 values       = locals().get("values")
 axis         = locals().get("axis")
@@ -7604,6 +7606,41 @@ result = x
 """
         code = Code(core=core.splitlines())
         return ConvertResult.success(paddle_api, code, is_torch_corresponding=False)
+
+
+class TensorToRule(BaseRule):
+    """Translate Paddle Tensor.to device and dtype values for Torch."""
+
+    def apply(self, paddle_api: str) -> ConvertResult:
+        core = """
+tensor = locals().get("self")
+to_args = list(locals().get("args", ()))
+to_kwargs = dict(locals().get("kwargs", {}))
+to_kwargs.pop("self", None)
+to_kwargs.pop("args", None)
+dtype_names = {
+    "bool", "float16", "float32", "float64", "bfloat16",
+    "int8", "int16", "int32", "int64", "uint8", "complex64", "complex128",
+}
+
+def _translate_to_value(value, dtype_names=dtype_names):
+    if isinstance(value, str) and value.startswith("gpu"):
+        return "cuda" + value[3:]
+    dtype_name = str(value).split(".")[-1]
+    if dtype_name in dtype_names:
+        return getattr(torch, dtype_name)
+    return value
+
+if to_args:
+    to_args[0] = _translate_to_value(to_args[0])
+if "device" in to_kwargs:
+    to_kwargs["device"] = _translate_to_value(to_kwargs["device"])
+if "dtype" in to_kwargs:
+    to_kwargs["dtype"] = _translate_to_value(to_kwargs["dtype"])
+result = tensor.to(*to_args, **to_kwargs) if to_args or to_kwargs else tensor
+"""
+        code = Code(core=core.splitlines())
+        return ConvertResult.success(paddle_api, code)
 
 
 class CopsTransposeRule(BaseRule):

--- a/tester/runtime_config.py
+++ b/tester/runtime_config.py
@@ -23,7 +23,18 @@ class TestRuntimeConfig:
     random_seed: int = 0
     bitwise_alignment: bool = False
     exit_on_error: bool = False
+    # test_cpu 只控制 Paddle kernel；GPU mode 另行控制输入和比较策略。
+    test_cpu: bool = False
     gpu_mode: GpuModeConfig = field(default_factory=GpuModeConfig)
+
+    @property
+    def paddle_kernel_device_type(self):
+        return "cpu" if self.test_cpu else "cuda"
+
+    @property
+    def torch_operator_device_type(self):
+        # accuracy 模式始终执行 GPU Torch reference，即使 Paddle kernel 在 CPU。
+        return "cuda"
 
     @classmethod
     def from_options(cls, options):
@@ -37,6 +48,7 @@ class TestRuntimeConfig:
             random_seed=int(options.random_seed),
             bitwise_alignment=bool(options.bitwise_alignment),
             exit_on_error=bool(options.exit_on_error),
+            test_cpu=bool(getattr(options, "test_cpu", False)),
             gpu_mode=gpu_mode,
         )
 


### PR DESCRIPTION
  ## 支持的 API

  - `paddle.Tensor.add_`
  - `paddle.Tensor.contiguous`
  - `paddle.Tensor.copy_`
  - `paddle.Tensor.flatten_`
  - `paddle.Tensor.multiply_`
  - `paddle.Tensor.put_along_axis_`
  - `paddle.Tensor.scale_`
  - `paddle.Tensor.subtract_`
  - `paddle.Tensor.to`
  - `paddle.randint`

  ## 主要改动

  ### Tensor 原地算子

  复用 main 分支已有的 `_C_ops` 转换规则，为对应的 `paddle.Tensor.*` 方法增加映射，避免重复实现相同的原地计算逻辑。

  涉及：

  - `add_`
  - `flatten_`
  - `multiply_`
  - `put_along_axis_`
  - `scale_`
  - `subtract_`

  `add_` 和 `subtract_` 补充以下兼容处理：

  - 支持 Paddle API 的 `alpha` 参数。
  - 在执行 Torch 原地运算前，将第二个 Tensor 转换为目标 Tensor 的 dtype。
  - 解决 `float32` 与 `bfloat16` 等混合 dtype 输入下 Paddle 和 Torch 行为不一致的问题。
  - 使用 Torch 原地算子保持输入修改语义与 Paddle 一致。

  `put_along_axis_` 同时兼容 `_C_ops` 使用的 `arr` 参数名和 Tensor 方法使用的 `x` 接收者参数名。

  ### `paddle.Tensor.copy_`

  - 为无法通过 `inspect.signature` 获取签名的内建方法增加手工参数绑定。
  - 支持 `self`、`other` 和 `blocking` 参数。
  - 将 Paddle 的 `blocking` 转换为 Torch `copy_` 的 `non_blocking` 参数。
  - 将 `copy_` 加入 forward-only API，避免对原地修改后的 Tensor 执行无意义的反向精度比较。

  ### `paddle.Tensor.contiguous`

  直接映射到 `torch.Tensor.contiguous`，沿用 main 分支现有的 Tensor 方法调用机制。

  ### `paddle.Tensor.to`

  新增独立转换规则，处理 Paddle 与 Torch 在设备和 dtype 参数上的差异：

  - 将 Paddle 的 `gpu`、`gpu:<id>` 转换为 Torch 的 `cuda`、`cuda:<id>`。
  - 将 Paddle dtype、字符串 dtype 转换为对应的 `torch.dtype`。
  - 支持位置参数和关键字参数形式。
  - 过滤 main 分支执行协议中的 `self`、`args` 元数据，避免这些内部参数被重复传递给 `torch.Tensor.to`。
  - 无显式转换参数时保持原 Tensor 结果。

  ### `paddle.randint`

  新增到 `torch.randint` 的参数映射：

  - 将 Paddle 的 `shape` 列表转换为 Torch 接受的 tuple。
  - 保持 `low` 和 `high` 参数顺序。
  - 未显式提供 dtype 时使用 `torch.int64`，与 Paddle 默认行为对齐。
  - 使用 `locals().get("dtype")` 读取可选参数，避免缺省 dtype 时产生未定义变量错误。