### PR TITLE
测试修复：⚡ 优化 GPU 调度与 accuracy 输入生成

### DIFF
--- a/.claude/skills/optimize-api-seq-derivation/agents/openai.yaml
+++ b/.claude/skills/optimize-api-seq-derivation/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Optimize API Seq Derivation"
+  short_description: "Optimize cross-model API seq derivation accuracy"
+  default_prompt: "Use $optimize-api-seq-derivation to optimize and validate cross-model API sequence configuration derivation."

--- a/.claude/skills/paddle-apitest-config-generator/SKILL.md
+++ b/.claude/skills/paddle-apitest-config-generator/SKILL.md
@@ -44,7 +44,7 @@ first positional argument and match `PD_BUILD_OP(...).Inputs(...).Attrs(...)` ex
 Use the bundled script for deterministic shape expansion:
 
 ```bash
-python .claude/skills/paddle-apitest-config-generator/scripts/expand_from_seeds.py \
+python .agents/skills/paddle-apitest-config-generator/scripts/expand_from_seeds.py \
   --api paddle.some_api \
   --seed-file apitest_config/path/to/seeds.txt \
   --output-dir generated_api_configs \
@@ -94,7 +94,7 @@ Record every edge/invalid reason in `violations`. When the contract is uncertain
 Run validation after every generation change:
 
 ```bash
-python .claude/skills/paddle-apitest-config-generator/scripts/validate_case_tree.py \
+python .agents/skills/paddle-apitest-config-generator/scripts/validate_case_tree.py \
   generated_api_configs \
   --expected-per-file 512 \
   --require-zero \
@@ -118,7 +118,7 @@ validator uses the bundled parser by default; inside PaddleAPITest, also run an
 authoritative compatibility pass with:
 
 ```bash
-python .claude/skills/paddle-apitest-config-generator/scripts/validate_case_tree.py \
+python .agents/skills/paddle-apitest-config-generator/scripts/validate_case_tree.py \
   generated_api_configs \
   --official-analyzer \
   --apitest-root .

--- a/.claude/skills/paddle-apitest-config-generator/agents/openai.yaml
+++ b/.claude/skills/paddle-apitest-config-generator/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "PaddleAPITest Config Generator"
+  short_description: "Generate and expand PaddleAPITest API cases"
+  default_prompt: "Use $paddle-apitest-config-generator to generate broad 4096, 1M, and 0size cases for the provided Paddle API or seed configs."

--- a/.claude/skills/paddle-apitest-config-generator/references/generator-pattern.md
+++ b/.claude/skills/paddle-apitest-config-generator/references/generator-pattern.md
@@ -14,7 +14,7 @@ from pathlib import Path
 SCRIPT_PATH = Path(__file__).resolve()
 for candidate in (SCRIPT_PATH.parent, *SCRIPT_PATH.parents):
     SKILL_SCRIPTS = (
-        candidate / ".claude/skills/paddle-apitest-config-generator/scripts"
+        candidate / ".agents/skills/paddle-apitest-config-generator/scripts"
     )
     if SKILL_SCRIPTS.is_dir():
         APITEST_ROOT = candidate

--- a/.claude/skills/paddle-apitest-config-generator/scripts/apitest_config_utils.py
+++ b/.claude/skills/paddle-apitest-config-generator/scripts/apitest_config_utils.py
@@ -17,14 +17,9 @@ from typing import Any
 
 import numpy
 
-# 这些规格名同时出现在输出文件名、索引和校验逻辑中，不能任意改写。
-# 统一保留字符串形式，避免把 1M 在不同阶段解释成不同的整数。
 SPECS = ("4096", "1M", "0size")
-# custom op 的第一个参数是 op_name，API 名称需要据此单独归类。
 RUN_CUSTOM_OP = "paddle._C_ops._run_custom_op"
 
-# 4096 规格优先覆盖常见边界，尾部再使用稳定递增的扩展值。
-# 边界表不代表某个 API 的契约，只用于扩大静态样本的形状覆盖面。
 ROW_BOUNDARIES_4096 = (
     1,
     2,
@@ -56,8 +51,6 @@ ROW_BOUNDARIES_4096 = (
     8193,
     16384,
 )
-# 1M 规格靠近上限和对齐点取样，避免静态生成真的分配百万级数据。
-# 这里的值只写入配置文本，实际内存行为由后续运行时决定。
 ROW_BOUNDARIES_1M = (
     999_872,
     999_936,
@@ -73,8 +66,6 @@ ROW_BOUNDARIES_1M = (
     1_048_577,
     1_048_704,
 )
-# 宽度边界用于 API-aware 生成器选择次级维度。
-# 保留 1、2、4 等小值可以覆盖标量和向量化分支。
 WIDTH_BOUNDARIES = (
     1,
     2,
@@ -112,8 +103,6 @@ WIDTH_BOUNDARIES = (
 
 @dataclass(frozen=True)
 class RawExpression:
-    # 无法安全求值的表达式原样保留，保证配置解析不会破坏未知协议。
-    # 重新序列化时仍使用原文，因此官方 analyzer 可以继续接管语义校验。
     text: str
 
     def __str__(self) -> str:
@@ -121,8 +110,6 @@ class RawExpression:
 
 
 class TensorConfig:
-    # 这是一个最小 Tensor 模型，只承担形状关联和静态物化职责。
-    # 它不模拟 Paddle kernel，避免生成工具隐式依赖运行时环境。
     def __init__(
         self,
         shape: Sequence[int],
@@ -131,16 +118,13 @@ class TensorConfig:
         is_contiguous: bool = True,
         strides: Sequence[int] | None = None,
     ) -> None:
-        # 复制输入形状，防止后续变异反向修改 seed 配置。
         self.shape = list(shape)
-        # dtype、place 和布局属性必须原样保留，生成器只调整选定形状。
         self.dtype = dtype
         self.place = place
         self.is_contiguous = is_contiguous
         self.strides = list(strides) if strides is not None else None
 
     def __str__(self) -> str:
-        # 输出格式与 APIConfig 的 round-trip 约束一致，便于逐行比较。
         result = f"Tensor({self.shape},{dump_item(self.dtype)}"
         if self.place is not None:
             result += f",place={dump_item(self.place)}"
@@ -153,7 +137,6 @@ class TensorConfig:
     __repr__ = __str__
 
     def get_numpy_tensor(self, *_args, **_kwargs):
-        # 只在 validator 请求时物化；1M 的非零 Tensor 不会走到这里。
         dtype = {
             "bfloat16": "float32",
             "float8_e4m3fn": "float16",
@@ -195,8 +178,6 @@ class APIConfig:
 
 @dataclass(frozen=True)
 class CaseRecord:
-    # manifest 记录携带生成原因，便于区分有效、边界和故意非法样本。
-    # config 保留结构化对象，最终写文件时再统一做 round-trip 检查。
     spec: str
     api: str
     index: int
@@ -207,8 +188,6 @@ class CaseRecord:
 
 
 def find_top_level_open_paren(text: str) -> int:
-    # 不能用 text.find("(")，因为字符串属性中也可能出现括号。
-    # 当前状态机只处理引号和转义，足以定位 API 调用的最外层入口。
     quote = None
     escaped = False
     for index, char in enumerate(text):
@@ -227,12 +206,9 @@ def find_top_level_open_paren(text: str) -> int:
 
 
 def split_top_level(text: str, delimiter: str = ",") -> list[str]:
-    # 配置参数允许嵌套 list、tuple、dict 和 Tensor，分隔符只能在顶层生效。
-    # 发现不平衡结构立即失败，避免生成一份表面可写、实际不可解析的配置。
     parts = []
     start = 0
     stack: list[str] = []
-    # pairs 用于在遇到闭括号时确认嵌套类型没有交叉。
     pairs = {")": "(", "]": "[", "}": "{"}
     quote = None
     escaped = False
@@ -262,8 +238,6 @@ def split_top_level(text: str, delimiter: str = ",") -> list[str]:
 
 
 def split_top_level_keyword(text: str) -> tuple[str, str] | None:
-    # 关键字等号与容器内部的等号含义不同，只接受顶层等号。
-    # 关键字名按 Python 标识符校验，保证 dump 后仍能被同一解析器识别。
     stack: list[str] = []
     pairs = {")": "(", "]": "[", "}": "{"}
     quote = None
@@ -293,7 +267,6 @@ def split_top_level_keyword(text: str) -> tuple[str, str] | None:
 
 
 def call_body(text: str, names: Sequence[str]) -> str | None:
-    # 仅匹配完整调用名，避免把普通字符串或带后缀的表达式误判成 Tensor。
     for name in names:
         prefix = name + "("
         if text.startswith(prefix) and text.endswith(")"):
@@ -302,15 +275,12 @@ def call_body(text: str, names: Sequence[str]) -> str | None:
 
 
 def parse_sequence(body: str) -> list[Any]:
-    # 空参数列表是合法的 tuple/list 表达，不能被当成解析失败。
     if not body.strip():
         return []
     return [parse_value(part) for part in split_top_level(body) if part]
 
 
 def parse_tensor(body: str) -> TensorConfig:
-    # Tensor 的前两个位置参数是形状和 dtype，其余字段按关键字保留。
-    # 形状必须是整数列表，否则无法可靠地进行跨 Tensor 关联变换。
     positional = []
     kwargs = {}
     for part in split_top_level(body):
@@ -325,7 +295,6 @@ def parse_tensor(body: str) -> TensorConfig:
     if len(positional) < 2:
         raise ValueError(f"Tensor requires shape and dtype: Tensor({body})")
     shape, dtype = positional[:2]
-    # dtype 允许未知字符串，工具不替 API 契约做额外的白名单裁剪。
     if not isinstance(shape, list) or not all(isinstance(dim, int) for dim in shape):
         raise ValueError(f"invalid Tensor shape: {shape}")
     if not isinstance(dtype, str):
@@ -340,8 +309,6 @@ def parse_tensor(body: str) -> TensorConfig:
 
 
 def parse_value(text: str) -> Any:
-    # 解析优先处理 Paddle 配置中的结构化包装，再回退到 literal_eval。
-    # 回退到 RawExpression 是兼容未知属性表达式的关键，而不是吞掉错误。
     value = text.strip()
     tensor_body = call_body(value, ("Tensor", "TensorConfig"))
     if tensor_body is not None:
@@ -364,7 +331,6 @@ def parse_value(text: str) -> Any:
         return parse_sequence(value[5:-1])
     if value.startswith("[") and value.endswith("]"):
         return parse_sequence(value[1:-1])
-    # 字典可能包含非 Python literal 的表达式，失败时必须保持原文。
     if value.startswith("{") and value.endswith("}"):
         try:
             return ast.literal_eval(value)
@@ -383,13 +349,10 @@ def parse_value(text: str) -> Any:
 
 
 def dump_plain_list(values: Sequence[Any]) -> str:
-    # 该函数只负责列表外壳，元素格式由 dump_item 统一决定。
     return "[" + ", ".join(dump_item(value) for value in values) + "]"
 
 
 def dump_item(item: Any) -> str:
-    # 序列化顺序按最具体类型到标量类型排列，避免 bool 被当成 int 输出。
-    # 字符串使用 JSON 转义，确保换行和引号不会破坏一行一个配置的约定。
     if isinstance(item, TensorConfig):
         return str(item)
     if isinstance(item, RawExpression):
@@ -421,8 +384,6 @@ def dump_item(item: Any) -> str:
 
 
 def find_apitest_root(start: Path | str) -> Path:
-    # 官方 analyzer 是可选兼容校验，因此通过文件探测根目录而不硬编码 cwd。
-    # 找不到根目录时明确报错，调用方可以选择关闭 official-analyzer。
     path = Path(start).resolve()
     for candidate in (path, *path.parents):
         if (candidate / "tester/api_config/config_analyzer.py").is_file():
@@ -431,7 +392,6 @@ def find_apitest_root(start: Path | str) -> Path:
 
 
 def import_official_config_types(apitest_root: Path | str):
-    # 只在用户显式要求时导入仓库实现，普通静态生成保持自包含。
     root = find_apitest_root(apitest_root)
     root_text = str(root)
     if root_text not in sys.path:
@@ -443,14 +403,12 @@ def import_official_config_types(apitest_root: Path | str):
 
 
 def api_key(config: Any) -> str:
-    # 普通 API 以 api_name 分组，custom op 以真实 op_name 分组。
     if config.api_name == RUN_CUSTOM_OP and config.args and isinstance(config.args[0], str):
         return config.args[0]
     return config.api_name
 
 
 def api_slug(name: str) -> str:
-    # 目录名只使用可移植字符；完整 API 名仍保存在 manifest 的 api 字段中。
     short_name = name.rsplit(".", 1)[-1]
     slug = re.sub(r"[^a-zA-Z0-9_-]+", "_", short_name).strip("_").lower()
     if not slug:
@@ -462,8 +420,6 @@ def iter_tensor_configs(
     value: Any,
     tensor_type: type = TensorConfig,
 ) -> Iterator[Any]:
-    # 递归遍历参数容器，覆盖 Tensor、Tensor 列表和嵌套字典。
-    # 只识别指定 tensor_type，方便官方 analyzer 类型与本地模型切换。
     if isinstance(value, tensor_type):
         yield value
     elif isinstance(value, (list, tuple)):
@@ -478,13 +434,11 @@ def config_tensors(
     config: Any,
     tensor_type: type = TensorConfig,
 ) -> list[Any]:
-    # args 与 kwargs 都可能包含 Tensor，统一视图避免漏掉可选关键字输入。
     values = (*config.args, *config.kwargs.values())
     return [tensor for value in values for tensor in iter_tensor_configs(value, tensor_type)]
 
 
 def clone_config(config: Any) -> Any:
-    # 每个 case 从独立副本开始，禁止一次变异污染同一 seed 的后续样本。
     return copy.deepcopy(config)
 
 
@@ -492,8 +446,6 @@ def parse_config_lines(
     paths: Iterable[Path | str],
     api_config_type: type = APIConfig,
 ) -> list[tuple[Path, int, Any]]:
-    # 输入文件按非空、非注释、完整调用逐行读取，保留来源行号用于 manifest。
-    # 这里不执行 kernel，也不主动过滤契约非法配置，职责只限于结构化解析。
     parsed = []
     for raw_path in paths:
         path = Path(raw_path).resolve()
@@ -504,7 +456,6 @@ def parse_config_lines(
             if "(" not in line or not line.endswith(")"):
                 continue
             config = api_config_type(line)
-            # 解析后立即重新打印，尽早发现 parser 丢失字段或改变转义的缺陷。
             normalized = str(config)
             if str(api_config_type(normalized)) != normalized:
                 raise ValueError(f"non-round-trip seed at {path}:{line_number}")
@@ -516,7 +467,6 @@ def serialize_config(
     config: Any,
     api_config_type: type = APIConfig,
 ) -> str:
-    # 写盘前再次解析序列化结果，保证 validator 可以使用相同的稳定表示。
     line = str(config)
     reparsed = api_config_type(line)
     if str(reparsed) != line:
@@ -525,7 +475,6 @@ def serialize_config(
 
 
 def anchor_value(spec: str, index: int) -> int:
-    # 规格决定主维度的边界策略，index 负责在固定 case 数下持续提供唯一值。
     if spec == "0size":
         return 0
     if spec == "4096":
@@ -540,7 +489,6 @@ def anchor_value(spec: str, index: int) -> int:
 
 
 def case_category(index: int) -> str:
-    # 四格轮换只提供默认分类；API-aware 生成器可以覆盖更精确的违规原因。
     slot = index % 4
     if slot == 2:
         return "edge"
@@ -553,7 +501,6 @@ def ensure_zero_dimension(
     config: Any,
     tensor_type: type = TensorConfig,
 ) -> bool:
-    # 0size 只要求至少一个维度为零，不改变已有零维 Tensor 的布局信息。
     tensors = config_tensors(config, tensor_type)
     if not tensors or any(0 in tensor.shape for tensor in tensors):
         return False
@@ -562,7 +509,6 @@ def ensure_zero_dimension(
 
 
 def write_atomic(path: Path, content: str) -> None:
-    # 临时文件与目标同目录，replace 在同一文件系统内提供原子替换语义。
     path.parent.mkdir(parents=True, exist_ok=True)
     temporary = path.with_suffix(path.suffix + ".tmp")
     temporary.write_text(content, encoding="utf-8")
@@ -574,34 +520,27 @@ def write_case_tree(
     records: Sequence[CaseRecord],
     api_config_type: type = APIConfig,
 ) -> None:
-    # 先按 API/spec 聚合，随后同时写配置文件、manifest 和根 index。
-    # 所有重复、API 不匹配和 round-trip 错误都在写入前失败，避免半成品目录。
     output_root = Path(output_dir).resolve()
     grouped: dict[str, dict[str, list[CaseRecord]]] = collections.defaultdict(
         lambda: collections.defaultdict(list)
     )
-    # grouped 的嵌套 default dict 保持输出目录结构与规格顺序相互独立。
     for record in records:
         if api_key(record.config) != record.api:
             raise ValueError(f"record API does not match config: {record.api}")
         grouped[record.api][record.spec].append(record)
 
-    # index 只记录每个规格文件的摘要，详细 case 信息留在 manifest.jsonl。
     index_records = []
     for name, by_spec in grouped.items():
         api_dir = output_root / api_slug(name)
         manifest_lines = []
-        # 按 SPECS 固定顺序输出，避免文件系统遍历顺序导致结果不稳定。
         for spec in SPECS:
             spec_records = by_spec.get(spec, [])
             if not spec_records:
                 continue
-            # 先完成整组序列化和去重，再创建目标文件。
             lines = [serialize_config(record.config, api_config_type) for record in spec_records]
             if len(lines) != len(set(lines)):
                 raise ValueError(f"duplicate configurations for {name}/{spec}")
             write_atomic(api_dir / f"{spec}.txt", "\n".join(lines) + "\n")
-            # manifest 与配置行一一对应，validator 会按这个顺序反向核对。
             for record, line in zip(spec_records, lines):
                 payload = {
                     "api": record.api,

--- a/.claude/skills/paddle-apitest-config-generator/scripts/expand_from_seeds.py
+++ b/.claude/skills/paddle-apitest-config-generator/scripts/expand_from_seeds.py
@@ -23,8 +23,6 @@ from apitest_config_utils import (
 
 
 def normalized_axis(shape: list[int], axis: int) -> int:
-    # 负轴沿用 Python 约定，统一转换后再访问 shape，错误在生成前暴露。
-    # 轴越界说明 seed 与调用参数不匹配，不能静默改用最后一维。
     resolved = axis if axis >= 0 else len(shape) + axis
     if resolved < 0 or resolved >= len(shape):
         raise ValueError(f"anchor axis {axis} is invalid for shape {shape}")
@@ -39,8 +37,6 @@ def mutate_seed(
     anchor_tensor: int,
     anchor_axis: int,
 ) -> tuple[object, tuple[str, ...]]:
-    # 每个规格都从原始 seed 的深拷贝派生，保证不同 case 之间没有共享状态。
-    # anchor_tensor/axis 只决定主关联维度，其他维度尽量维持 seed 的结构。
     config = clone_config(seed)
     tensors = config_tensors(config, tensor_type)
     if not tensors:
@@ -55,15 +51,12 @@ def mutate_seed(
     if old_anchor <= 0:
         raise ValueError(f"seed anchor dimension must be positive, got {old_anchor}")
 
-    # target 来自规格边界表，不依赖某个 API 的 hidden size 或实现常量。
     target = anchor_value(spec, index)
     mutations = [f"anchor:{old_anchor}->{target}"]
     original_shapes = [list(tensor.shape) for tensor in tensors]
-    # 只替换与旧 anchor 完全相等的维度，保护比例不同的派生维度。
     for tensor, original_shape in zip(tensors, original_shapes):
         tensor.shape = [target if dim == old_anchor else dim for dim in original_shape]
 
-    # 0size 需要显式零维，同时用非 anchor 维度乘数避免输出重复。
     if spec == "0size":
         multiplier = index + 1
         for tensor, original_shape in zip(tensors, original_shapes):
@@ -78,7 +71,6 @@ def mutate_seed(
 
 
 def generate_records(args: argparse.Namespace) -> list[CaseRecord]:
-    # 先解析全部 seed，再按 api 名筛选，保证请求缺失时能给出明确诊断。
     parsed = parse_config_lines(args.seed_file, APIConfig)
     requested = set(args.api or [])
     seeds_by_api: dict[str, list[tuple[Path, int, object]]] = {}
@@ -93,12 +85,10 @@ def generate_records(args: argparse.Namespace) -> list[CaseRecord]:
     if not seeds_by_api:
         raise ValueError("no matching seed configs found")
 
-    # 输出按 API、规格、索引排序，便于 manifest 稳定复现和差异审查。
     records = []
     for name, seeds in sorted(seeds_by_api.items()):
         for spec in args.spec:
             seen: set[str] = set()
-            # 循环复用 seed，但每次 mutate_seed 都会创建独立配置对象。
             for index in range(args.cases_per_spec):
                 path, line_number, seed = seeds[index % len(seeds)]
                 config, mutations = mutate_seed(
@@ -110,7 +100,6 @@ def generate_records(args: argparse.Namespace) -> list[CaseRecord]:
                     args.anchor_axis,
                 )
                 line = serialize_config(config, APIConfig)
-                # 某些 seed 的零维变换可能仍碰撞，追加 rank marker 只作为唯一性兜底。
                 if line in seen and spec == "0size":
                     first_tensor = config_tensors(config, TensorConfig)[0]
                     first_tensor.shape.append(index + 1)
@@ -137,7 +126,6 @@ def generate_records(args: argparse.Namespace) -> list[CaseRecord]:
 
 
 def parse_args() -> argparse.Namespace:
-    # CLI 默认生成三类规格；显式 --spec 可缩小范围以便快速验证。
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--api", action="append", help="API name or custom op_name")
     parser.add_argument("--seed-file", action="append", type=Path, required=True)
@@ -147,7 +135,6 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--anchor-tensor", type=int, default=0)
     parser.add_argument("--anchor-axis", type=int, default=0)
     args = parser.parse_args()
-    # argparse 的 None 与空列表语义不同，这里统一成完整默认规格集合。
     args.spec = args.spec or list(SPECS)
     if args.cases_per_spec <= 0:
         parser.error("--cases-per-spec must be positive")
@@ -155,7 +142,6 @@ def parse_args() -> argparse.Namespace:
 
 
 def main() -> None:
-    # 生成和写盘分两步，任何 case 错误都会在目录创建前终止。
     args = parse_args()
     records = generate_records(args)
     write_case_tree(args.output_dir, records)

--- a/.claude/skills/paddle-apitest-config-generator/scripts/validate_case_tree.py
+++ b/.claude/skills/paddle-apitest-config-generator/scripts/validate_case_tree.py
@@ -19,7 +19,6 @@ from apitest_config_utils import (
 
 
 def validate(args: argparse.Namespace) -> None:
-    # official analyzer 只在显式开关下加载，默认校验不要求 Paddle 运行时。
     official_api_config = None
     if args.official_analyzer:
         official_api_config, _ = import_official_config_types(args.apitest_root)
@@ -27,16 +26,13 @@ def validate(args: argparse.Namespace) -> None:
     index_path = root / "index.json"
     if not index_path.is_file():
         raise FileNotFoundError(f"missing {index_path}")
-    # index 是遍历输出树的权威入口，禁止通过目录扫描悄悄跳过遗漏文件。
     index_records = json.loads(index_path.read_text(encoding="utf-8"))
     if not isinstance(index_records, list) or not index_records:
         raise ValueError("index.json must contain a non-empty list")
 
-    # 这些计数既用于最终摘要，也帮助发现 manifest 与实际文件数量不一致。
     parsed_count = 0
     zero_tensor_count = 0
     manifest_cache: dict[Path, list[dict]] = {}
-    # 每个 index 记录对应一个 API/spec 文件，逐项核对路径、数量和分类摘要。
     for index_record in index_records:
         path = root / index_record["path"]
         if path.name not in {f"{spec}.txt" for spec in SPECS}:
@@ -44,17 +40,14 @@ def validate(args: argparse.Namespace) -> None:
         lines = path.read_text(encoding="utf-8").splitlines()
         if args.expected_per_file is not None and len(lines) != args.expected_per_file:
             raise ValueError(f"{path} has {len(lines)} cases, expected {args.expected_per_file}")
-        # 配置重复会降低样本覆盖率，因此在任何语义检查前直接拒绝。
         if len(lines) != len(set(lines)):
             raise ValueError(f"duplicate configs in {path}")
 
         manifest_path = path.parent / "manifest.jsonl"
-        # 同一个 API 的 manifest 可能被多个规格记录复用，只读取一次。
         if manifest_path not in manifest_cache:
             manifest_cache[manifest_path] = [
                 json.loads(line) for line in manifest_path.read_text(encoding="utf-8").splitlines()
             ]
-        # manifest 的 spec 过滤后必须仍与目标文本逐行同序。
         records = [
             record
             for record in manifest_cache[manifest_path]
@@ -66,7 +59,6 @@ def validate(args: argparse.Namespace) -> None:
         if categories != index_record["categories"]:
             raise ValueError(f"category count mismatch for {path}")
 
-        # 先做本地 round-trip，再按需调用官方 analyzer，区分格式错误和契约错误。
         for record, line in zip(records, lines):
             config = APIConfig(line)
             if str(config) != line:
@@ -78,14 +70,12 @@ def validate(args: argparse.Namespace) -> None:
             if api_key(config) != record["api"] or record["api"] != index_record["api"]:
                 raise ValueError(f"API mismatch in {path}: {line}")
             parsed_count += 1
-            # 非 0size 文件不需要做零维物化，但仍必须经过上述完整结构校验。
             if index_record["spec"] != "0size":
                 continue
             tensors = config_tensors(config, TensorConfig)
             zero_tensors = [tensor for tensor in tensors if 0 in tensor.shape]
             if args.require_zero and tensors and not zero_tensors:
                 raise ValueError(f"0size case contains no zero-dimension Tensor: {line}")
-            # 只有显式 --materialize-zero 才分配 numpy 对象，避免误触百万级数据。
             if args.materialize_zero:
                 for position, tensor in enumerate(zero_tensors):
                     array = tensor.get_numpy_tensor(config, index=position)
@@ -100,7 +90,6 @@ def validate(args: argparse.Namespace) -> None:
 
 
 def parse_args() -> argparse.Namespace:
-    # expected-per-file 和 zero 选项可组合使用，便于 CI 与本地最小复现共享入口。
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("case_tree", type=Path)
     parser.add_argument("--official-analyzer", action="store_true")

--- a/.claude/skills/reviewing-and-optimizing-code/SKILL.md
+++ b/.claude/skills/reviewing-and-optimizing-code/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: reviewing-and-optimizing-code
+description: Use when reviewing or simplifying mature code paths, especially when correctness must come before simplification, readability, helper removal, logging ownership, or global-state cleanup.
+---
+
+# Reviewing and Optimizing Code
+
+## Core Principle
+
+Correctness first. A cleaner shape that changes behavior, error handling, cleanup, or protocol
+contracts is a regression. Once behavior is sound, prefer the simplest direct structure that
+makes ownership obvious.
+
+## Review Phases
+
+### 1. Correctness
+
+- Check behavior, exit codes, cleanup, and invariants first.
+- Verify failure paths before style changes.
+- Look for hidden protocol changes between producer and consumer code.
+- Treat tests and call sites as evidence, not assumptions.
+
+### 2. Ownership
+
+- Find the one clear owner for each policy.
+- Avoid duplicated policy across main flow, helpers, and logging layers.
+- Keep boundaries explicit when a function owns a protocol or state transition.
+
+### 3. Simplification
+
+- Remove helpers only when the caller stays clearer without them.
+- Delete wrappers that only forward one call, one condition, or one append.
+- Keep helpers that encode real policy, a protocol boundary, or shared behavior.
+- Prefer direct code over compatibility scaffolding unless an external contract depends on it.
+
+### 4. Organization
+
+- Group globals by purpose, not by accident of history.
+- Prefer short comments that explain intent, not history.
+- Keep logging, banner, and report formatting in the layer that already owns output shape.
+- Watch for long relay chains where one function only re-exports another decision.
+
+### 5. Verification
+
+- Re-run the narrowest tests that prove the behavior still holds.
+- Compile or type-check when structure changes touch imports or signatures.
+- If a change removes a layer, verify the live call graph still reaches the same owner.
+
+## Optimization Rules
+
+- Simplify the main path before polishing helpers.
+- Inline one-off wrappers unless they form a stable boundary.
+- Move shared policy upward when multiple callers need the same rule.
+- Do not split files unless the boundary is genuinely hard to understand in one place.
+- Do not preserve dead compatibility shims just because they are familiar.
+
+## What To Look For
+
+- over-thin helpers
+- duplicated branches with one owner missing
+- long pass-through chains
+- scattered global state
+- misplaced output formatting
+- comments that explain old history instead of current intent
+- compatibility code without a live consumer
+
+## Review Output
+
+- Findings first, ordered by severity.
+- Cite file and line numbers.
+- Separate correctness issues from style issues.
+- If something is only an optimization preference, say so clearly.
+- End with a short judgment on whether the code is ready.

--- a/.claude/skills/scoring-code-cleanliness/SKILL.md
+++ b/.claude/skills/scoring-code-cleanliness/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: scoring-code-cleanliness
+description: Use when judging code quality, cleanliness, or maintainability and a concise, file-agnostic scoring rubric is needed.
+---
+
+# Scoring Code Cleanliness
+
+## Overview
+
+This is a rubric for scoring mature code after correctness has been checked. It is meant for
+plain review judgments, not for implementation guidance.
+
+## Scoring Order
+
+Always score in this order:
+
+1. Correctness and safety
+2. Ownership and boundaries
+3. Simplification and duplication
+4. Organization and naming
+5. Readability and local polish
+
+If correctness is weak, the overall score should stay low even when the code looks neat.
+
+## Score Bands
+
+Use a 10-point scale:
+
+- 9.0-10.0: Excellent. Clean ownership, minimal noise, clear boundaries, no obvious cleanup left.
+- 8.0-8.9: Strong. Good structure with a few remaining simplifications or heavy areas.
+- 7.0-7.9: Acceptable. Works and is readable, but still has noticeable clutter or uneven boundaries.
+- 6.0-6.9: Fair. Correct enough, but repetitive, tangled, or harder to extend than it should be.
+- Below 6.0: Needs work. Correctness, structure, or maintainability is still too shaky.
+
+## Review Checklist
+
+- Is behavior stable and verified?
+- Is each policy owned by one clear place?
+- Are there thin wrappers, relay chains, or duplicated branches?
+- Are globals grouped and named by purpose?
+- Are comments current, not historical?
+- Does the main path read directly?
+- Is logging/report formatting owned by the output layer?
+- Are helper functions small because they matter, not because they were left behind?
+
+## Common Deductions
+
+- Hidden protocol coupling
+- Over-thin helpers without a real boundary
+- Duplicate policy across layers
+- Scattered global state
+- Overloaded entry points
+- Output formatting in the wrong layer
+- Comments that explain history instead of intent
+
+## Final Judgment Template
+
+Use one short sentence:
+
+- `Correctness is solid, structure is mostly clean, and the remaining issues are polish-level.`
+- `Correctness is acceptable, but the code still carries too much structural noise.`
+- `The code is not ready yet because the main ownership or behavior boundary is still unclear.`

--- a/README.md
+++ b/README.md
@@ -76,11 +76,11 @@ python engineV4.py \
 ```bash
 python engineV4.py \
   --paddle_only=True \
-  --api_config_file_pattern='tester/api_config/7_0_size/*.txt,tester/api_config/8_big_tensor/*.txt' \
+  --api_config_file='tester/api_config/7_0_size/*.txt,tester/api_config/8_big_tensor/*.txt' \
   --log_dir=tester/api_config/test_log
 ```
 
-`--api_config`、`--api_config_file`、`--api_config_file_pattern` 和下文的 `--retest` 必须且只能选择一个。完整参数以 `python engineV4.py --help` 为准。
+`--api_config`、`--api_config_file` 和下文的 `--retest` 必须且只能选择一个。完整参数以 `python engineV4.py --help` 为准。
 
 ### 快速复测分类
 

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -25,19 +25,15 @@ python engineV4.py INPUT MODE [OPTIONS]
 
 直接运行一条 API config。配置含双引号时用单引号包裹。普通单条模式使用一张 GPU，双卡模式使用一对 GPU。默认：空。
 
-#### `--api_config_file=PATH`
+#### `--api_config_file=INPUT...`
 
-从文件逐行读取 API config。默认：空。
-
-#### `--api_config_file_pattern=GLOB[,GLOB...]`
-
-读取一个或多个逗号分隔 glob 匹配的文件。默认：空。
+接收一个或多个文件、目录或 glob；目录展开当前层 `.txt` 文件，glob 支持递归 `**`，多个输入可用空格或逗号分隔。默认：空。
 
 #### `--retest=CLASS[,CLASS...]`
 
 重跑 `--log_dir` 中已有的分类，例如 `config_input,timeout`；开始前会清除这些 case 的旧结构化结果。默认：空。
 
-`--api_config`、`--api_config_file`、`--api_config_file_pattern`、`--retest` 互斥，必须且只能选择一个。
+`--api_config`、`--api_config_file`、`--retest` 互斥，必须且只能选择一个。
 
 #### `--log_dir=PATH`
 
@@ -177,9 +173,9 @@ python run.py [-c CONFIG] [OVERRIDES] [ENGINE_OPTIONS]
 
 ### 输入和引擎覆盖
 
-#### `--api-config VALUE`、`-i FILE`、`--input FILE`、`--api-config-file FILE`、`--api-config-file-pattern GLOB`
+#### `--api-config VALUE`、`-i FILE...`、`--input FILE...`、`--api-config-file FILE...`
 
-分别覆盖 `input.api_config`、`input.api_config_file`、`input.api_config_file_pattern`。
+分别覆盖 `input.api_config`、`input.api_config_file`。
 
 #### `-o DIR`、`--output DIR`、`--log-dir DIR`
 
@@ -208,7 +204,7 @@ python run.py [-c CONFIG] [OVERRIDES] [ENGINE_OPTIONS]
 顶层键为 `name`、`runner`、`env`、`input`、`output`、`retest`、`engine_args`。
 
 - `runner`：`engine`、`foreground`、`dry_run`、`pid_file`。
-- `input`：`api_config`、`api_config_file`、`api_config_file_pattern` 三选一。
+- `input`：`api_config`、`api_config_file` 二选一。
 - `output`：`log_dir`。
 - `retest`：`enabled`、`rounds`、`error_configs`、`log_dir_template`、`skip_unavailable`。
 - `engine_args`：去掉 `--` 的 engineV4 参数名。

--- a/docs/engineV2-README.md
+++ b/docs/engineV2-README.md
@@ -38,8 +38,7 @@
 | 参数                             | 类型  | 说明                                                                                   |
 | -------------------------------- | ----- | -------------------------------------------------------------------------------------- |
 | `--api_config`                   | str   | API 配置字符串（单条测试）                                                             |
-| `--api_config_file`              | str   | API 配置文件路径（如`tester/api_config/5_accuracy/accuracy_1.txt`）                    |
-| `--api_config_file_pattern`      | str   | API 配置文件 glob 模式，以逗号分隔（如 `tester/api_config/5_accuracy/accuracy_*.txt`） |
+| `--api_config_file`              | list  | 文件、目录或 glob 输入，可用空格或逗号分隔                                       |
 | `--retest`                       | str   | 从当前 `--log_dir` 按分类快速复测，多个分类以逗号分隔（如 `config_input,timeout`）      |
 | `--paddle_only`                  | bool  | 运行 Paddle 测试（默认 False）                                                         |
 | `--accuracy`                     | bool  | 运行 Paddle vs Torch 精度测试（默认 False）                                            |

--- a/docs/engineV4-README.md
+++ b/docs/engineV4-README.md
@@ -24,7 +24,7 @@ python engineV4.py --help
 
 每次运行必须同时指定：
 
-1. 一个输入源：`--api_config`、`--api_config_file`、`--api_config_file_pattern` 或
+1. 一个输入源：`--api_config`、`--api_config_file` 或
    `--retest`。
 2. 一个主模式：例如 `--paddle_only=True` 或 `--accuracy=True`。
 
@@ -74,7 +74,7 @@ python engineV4.py \
 ```bash
 python engineV4.py \
   --paddle_only=True \
-  --api_config_file_pattern='tester/api_config/7_0_size/*.txt,tester/api_config/8_big_tensor/*.txt'
+  --api_config_file='tester/api_config/7_0_size/*.txt,tester/api_config/8_big_tensor/*.txt'
 ```
 
 未指定 `--log_dir` 时，批量模式默认写入 `logs/test_log_<timestamp>`，单条模式默认写入

--- a/engineV2.py
+++ b/engineV2.py
@@ -52,6 +52,7 @@ from tester.reporting.dump_writer import (
     record_dump_terminal_status,
     resolve_dump_options,
 )
+from tester.runtime.config_file_loader import resolve_config_files
 from tester.runtime.runtime_config import (
     TestRuntimeConfig,
     limit_worker_layout,
@@ -862,16 +863,12 @@ def main():
     parser = argparse.ArgumentParser(description="Run Paddle API test cases", allow_abbrev=False)
     parser.add_argument(
         "--api_config_file",
-        default="",
+        nargs="+",
+        default=None,
         help=(
-            "Path to a config file. Mutually exclusive with "
-            "--api_config_file_pattern, --api_config, and --retest."
+            "One or more config files, directories, or glob patterns. Mutually exclusive "
+            "with --api_config and --retest."
         ),
-    )
-    parser.add_argument(
-        "--api_config_file_pattern",
-        default="",
-        help="Glob pattern(s) for config files; comma-separated patterns are supported.",
     )
     parser.add_argument(
         "--api_config",
@@ -1097,14 +1094,12 @@ def main():
     input_sources = (
         bool(options.api_config),
         bool(options.api_config_file),
-        bool(options.api_config_file_pattern),
         bool(options.retest),
     )
     if sum(input_sources) != 1:
         _print_argument(
             ARGUMENT_ERROR_PREFIX,
-            "exactly one of --api_config, --api_config_file, "
-            "--api_config_file_pattern, or --retest is required",
+            "exactly one of --api_config, --api_config_file, or --retest is required",
         )
         return
     normalize_dual_gpu_options(options)
@@ -1141,7 +1136,7 @@ def main():
         return
     log_report.print_run_header(options, paddle_version)
     if options.use_dump:
-        if not options.api_config or options.api_config_file or options.api_config_file_pattern:
+        if not options.api_config or options.api_config_file:
             _print_argument(ARGUMENT_ERROR_PREFIX, "dump only supports single --api_config runs")
             return
         if not (options.accuracy or options.paddle_only):
@@ -1262,33 +1257,20 @@ def main():
             )
         if single_case_error is not None:
             sys.exit(1)
-    elif options.api_config_file or options.api_config_file_pattern or options.retest:
+    elif options.api_config_file or options.retest:
         # get config files
         if options.retest:
             config_files = []
-        elif options.api_config_file_pattern:
-            import glob
-
-            config_files = []
-            patterns = options.api_config_file_pattern.split(",")
-            for pattern in patterns:
-                pattern = pattern.strip()
-                config_files.extend(glob.glob(pattern))
-            if not config_files:
-                print(
-                    f"No config files found: {options.api_config_file_pattern}",
-                    flush=True,
-                )
+        else:
+            try:
+                config_files = resolve_config_files(options.api_config_file)
+            except (FileNotFoundError, ValueError) as err:
+                print(str(err), flush=True)
                 return
             config_files.sort()
             print("Config files to be tested:", flush=True)
             for i, config_file in enumerate(config_files, 1):
                 print(f"{i}. {config_file}", flush=True)
-        else:
-            if not os.path.exists(options.api_config_file):
-                print(f"No config file found: {options.api_config_file}", flush=True)
-                return
-            config_files = [options.api_config_file]
 
         init_log(options.log_dir)
 

--- a/engineV4.py
+++ b/engineV4.py
@@ -62,6 +62,7 @@ from tester.reporting import (
     log_runtime,
     log_worker,
 )
+from tester.runtime.config_file_loader import resolve_config_files
 from tester.runtime.runtime_config import (
     TestRuntimeConfig,
     limit_worker_layout,
@@ -3689,13 +3690,11 @@ def _validate_input_sources(options):
     input_sources = (
         bool(options.api_config),
         bool(options.api_config_file),
-        bool(options.api_config_file_pattern),
         bool(options.retest),
     )
     if sum(input_sources) != 1:
         return _argument_error(
-            "exactly one of --api_config, --api_config_file, "
-            "--api_config_file_pattern, or --retest is required"
+            "exactly one of --api_config, --api_config_file, or --retest is required"
         )
     return None
 
@@ -3874,7 +3873,7 @@ def _prepare_common_options(options):
         return mode_error
 
     if options.use_dump:
-        if not options.api_config or options.api_config_file or options.api_config_file_pattern:
+        if not options.api_config or options.api_config_file:
             return _argument_error("dump only supports single --api_config runs")
         if not (options.accuracy or options.paddle_only):
             return _argument_error("dump currently supports only --accuracy or --paddle_only")
@@ -4020,24 +4019,10 @@ def _load_retest_configs(options):
 
 
 def _load_file_configs(options, finish_configs, removed_stale_logs):
-    if options.api_config_file_pattern:
-        import glob
-
-        config_files = []
-        patterns = options.api_config_file_pattern.split(",")
-        for pattern in patterns:
-            pattern = pattern.strip()
-            config_files.extend(glob.glob(pattern))
-        if not config_files:
-            raise FileNotFoundError(f"No config files found: {options.api_config_file_pattern}")
-        config_files.sort()
-        print("Config files to be tested:", flush=True)
-        for i, config_file in enumerate(config_files, 1):
-            print(f"{i}. {config_file}", flush=True)
-    else:
-        if not os.path.exists(options.api_config_file):
-            raise FileNotFoundError(f"No config file found: {options.api_config_file}")
-        config_files = [options.api_config_file]
+    config_files = resolve_config_files(options.api_config_file)
+    print("Config files to be tested:", flush=True)
+    for i, config_file in enumerate(config_files, 1):
+        print(f"{i}. {config_file}", flush=True)
 
     api_config_count = 0
     skipped_non_config = 0
@@ -4264,16 +4249,12 @@ def _build_argument_parser():
     parser = argparse.ArgumentParser(description="Run Paddle API test cases", allow_abbrev=False)
     parser.add_argument(
         "--api_config_file",
-        default="",
+        nargs="+",
+        default=None,
         help=(
-            "Path to a config file. Mutually exclusive with "
-            "--api_config_file_pattern, --api_config, and --retest."
+            "One or more config files, directories, or glob patterns. Mutually exclusive "
+            "with --api_config and --retest."
         ),
-    )
-    parser.add_argument(
-        "--api_config_file_pattern",
-        default="",
-        help="Glob pattern(s) for config files; comma-separated patterns are supported.",
     )
     parser.add_argument(
         "--api_config",
@@ -4538,7 +4519,7 @@ def main():
 
     if options.api_config:
         return _run_single_case_mode(options, start_time)
-    if options.api_config_file or options.api_config_file_pattern or options.retest:
+    if options.api_config_file or options.retest:
         return _run_batch_case_mode(options, start_time)
     return 0
 

--- a/engineV4.py
+++ b/engineV4.py
@@ -513,6 +513,22 @@ GPU_MEMORY_DEFER_MAX_BACKOFF_SECONDS = 30.0
 GPU_MEMORY_DEFER_RETIRE_AFTER = 2
 SANITIZER_COMPUTE_BUDGET_ENV = "PADDLEAPITEST_SANITIZER_COMPUTE_BUDGET_GIB"
 SANITIZER_COMPARISON_BUDGET_ENV = "PADDLEAPITEST_SANITIZER_COMPARISON_BUDGET_GIB"
+
+
+def _is_unavailable_gpu_error(error_msg):
+    """识别设备级初始化失败；普通 case 异常仍沿用原有重试路径。"""
+    text = str(error_msg).lower()
+    return any(
+        marker in text
+        for marker in (
+            "cudaerrordevicesunavailable",
+            "cuda error(46)",
+            "cudaerrordevicelost",
+            "cuda error(45)",
+        )
+    )
+
+
 SANITIZER_TIMING_FILE_ENV = "PADDLEAPITEST_SANITIZER_TIMING_FILE"
 # 调度只需要有限候选；窗口随最大并发放大，保留跳过大 case 的能力。
 CANDIDATE_WINDOW_PER_WORKER = 32
@@ -1501,6 +1517,8 @@ class WorkerPool:
         self._lock = threading.Lock()  # 保护 slot 状态修改
         self._spawn_lock = threading.Lock()
         self._closed = False
+        # 记录初始化阶段确认不可用的物理卡，避免故障 slot 无限复活。
+        self._quarantined_gpus: set[int] = set()
         # CPU worker 使用 gpu_id=None；只有需要 GPU 运行时时才建立 GPU 槽位。
         idx = 0
         if cpu_worker_count:
@@ -1538,12 +1556,51 @@ class WorkerPool:
     def slot_can_schedule(self, slot_index):
         # scheduler 只依赖可调度语义，不读取可变的 WorkerSlot 状态对象。
         with self._lock:
-            return self.slots[slot_index].state in {"idle", "dead", "suspended"}
+            slot = self.slots[slot_index]
+            return (
+                slot.gpu_id not in self._quarantined_gpus
+                and slot.comparison_gpu_id not in self._quarantined_gpus
+                and slot.state in {"idle", "dead", "suspended"}
+            )
 
     def slot_can_start(self, slot_index):
         # 仅离线 slot 可启动；idle slot 已持有进程，不能创建第二代 worker。
         with self._lock:
-            return self.slots[slot_index].state in {"dead", "suspended"}
+            slot = self.slots[slot_index]
+            return (
+                slot.gpu_id not in self._quarantined_gpus
+                and slot.comparison_gpu_id not in self._quarantined_gpus
+                and slot.state in {"dead", "suspended"}
+            )
+
+    def slot_is_quarantined(self, slot_index):
+        # 双卡 slot 任一设备故障都必须停止复用，避免半损坏 pair 继续进入调度。
+        with self._lock:
+            slot = self.slots[slot_index]
+            return (
+                slot.gpu_id in self._quarantined_gpus
+                or slot.comparison_gpu_id in self._quarantined_gpus
+            )
+
+    def quarantine_gpu(self, gpu_id, *, reason):
+        """隔离不可用物理卡，阻止其 slot 被重新启动或调度。"""
+        if gpu_id is None:
+            return
+        with self._lock:
+            if gpu_id in self._quarantined_gpus:
+                return
+            self._quarantined_gpus.add(gpu_id)
+            affected = [
+                slot.index
+                for slot in self.slots
+                if slot.gpu_id == gpu_id or slot.comparison_gpu_id == gpu_id
+            ]
+            for slot_index in affected:
+                slot = self.slots[slot_index]
+                # busy slot 先完成当前终态，空闲/启动 slot 立即失去复活资格。
+                if slot.state in {"dead", "suspended", "starting", "loaded", "preparing"}:
+                    slot.state = "quarantined"
+        print(f"[gpu] GPU_QUARANTINED | physical_gpu={gpu_id} | {reason}", flush=True)
 
     def slot_is_idle(self, slot_index):
         # idle 是 dispatch 的必要前置条件，状态检查由 pool 串行化。
@@ -1822,6 +1879,8 @@ class WorkerPool:
             if child_pid is not None:
                 self._kill_process_group(child_pid)
             self._join_process(process, timeout=1)
+            if _is_unavailable_gpu_error(error_msg):
+                self.quarantine_gpu(slot.gpu_id, reason=error_msg)
             # init_failed 常见于 bootstrap OOM，slot 必须退出 planned 启动屏障。
             return True
         return True
@@ -3183,8 +3242,12 @@ class ContinuousGpuBatchScheduler:
     def cancel_failed_startup(self, pending_dispatch):
         # 初始化失败只回队当前 slot，其他在途 assignment 仍可继续完成。
         for assignment_id, assignment in tuple(self.assignments.items()):
-            if assignment.dispatched or not self.pool.slot_can_start(assignment.slot_index):
+            if assignment.dispatched:
                 continue
+            if not self.pool.slot_can_start(assignment.slot_index):
+                # 普通 suspended 仍可能等待 watchdog 回收；只有 quarantine 才能回队。
+                if not self.pool.slot_is_quarantined(assignment.slot_index):
+                    continue
             self.groups[assignment.group_key]["ledger"].mark_release_pending(assignment_id)
             # 未形成业务终态的 assignment 必须回队，不能只释放 reservation。
             pending_dispatch.appendleft(assignment.pending)
@@ -3608,6 +3671,14 @@ def _run_batch_mode(
         if options.use_compute_sanitizer:
             log_worker.clean_sanitizer_case_logs()
         log_counts = log_aggregation.finalize_logs()
+        if batch_state.tested_case != all_case and batch_state.batch_exit_code == 0:
+            # 未产生全部业务终态时不能以成功退出，避免损坏 GPU 留下假成功批次。
+            batch_state.batch_exit_code = 1
+            print(
+                f"[batch] INCOMPLETE | completed={batch_state.tested_case} "
+                f"total={all_case} | remaining={max(all_case - batch_state.tested_case, 0)}",
+                flush=True,
+            )
         if (
             options.retest
             and batch_state.batch_exit_code == 0

--- a/run-example.sh
+++ b/run-example.sh
@@ -48,7 +48,7 @@ export FLAGS_check_nan_inf=true
 # export PADDLEAPITEST_INPUT_BACKEND=torch
 
 # ── 输入输出 ──────────────────────────────────────────────────
-# input 三选一：--api_config / --api_config_file / --api_config_file_pattern
+# input 三选一：--api_config / --api_config_file / --api_config_file
 # NUM_GPUS!=0 时，引擎不受外部 "CUDA_VISIBLE_DEVICES" 影响
 # API_CONFIG=""
 FILE_INPUT="cfg.txt"
@@ -197,7 +197,7 @@ fi
 IN_OUT_ARGS=(
     # --api_config="$API_CONFIG"
     --api_config_file="$FILE_INPUT"
-    # --api_config_file_pattern="$FILE_PATTERN"
+    # --api_config_file="$FILE_PATTERN"
     --log_dir="$LOG_DIR"
 )
 

--- a/run.py
+++ b/run.py
@@ -33,7 +33,7 @@ DEFAULT_RETEST_ERROR_CONFIGS = [
 
 TOP_LEVEL_KEYS = {"name", "runner", "env", "input", "output", "retest", "engine_args"}
 RUNNER_KEYS = {"engine", "foreground", "dry_run", "pid_file"}
-INPUT_KEYS = {"api_config", "api_config_file", "api_config_file_pattern"}
+INPUT_KEYS = {"api_config", "api_config_file"}
 OUTPUT_KEYS = {"log_dir"}
 RETEST_KEYS = {
     "enabled",
@@ -80,6 +80,14 @@ ENGINE_ARG_TYPES = {
     "sanitizer_command": str,
     "sanitizer_error_exitcode": int,
 }
+
+
+def normalize_api_config_files(value: Any) -> list[str]:
+    """将 YAML 单路径和多路径写法统一为引擎需要的列表。"""
+    files = [value] if isinstance(value, str) else value
+    if not isinstance(files, list) or not files or not all(isinstance(item, str) for item in files):
+        raise TypeError("input.api_config_file 类型应为字符串或非空字符串数组")
+    return files
 
 
 def reject_unknown_keys(section: str, mapping: dict[str, Any], allowed_keys: set[str]) -> None:
@@ -130,12 +138,13 @@ def validate_yaml_config(config: dict[str, Any]) -> None:
     reject_unknown_keys("input", input_config, INPUT_KEYS)
     configured_inputs = [value for value in input_config.values() if value]
     if len(configured_inputs) != 1:
-        raise ValueError(
-            "input.api_config、input.api_config_file、input.api_config_file_pattern 必须且只能配置一个"
+        raise ValueError("input.api_config 或 input.api_config_file 必须且只能配置一个")
+    if "api_config" in input_config:
+        require_type("input.api_config", input_config["api_config"], str)
+    if "api_config_file" in input_config:
+        input_config["api_config_file"] = normalize_api_config_files(
+            input_config["api_config_file"]
         )
-    for key in INPUT_KEYS:
-        if key in input_config:
-            require_type(f"input.{key}", input_config[key], str)
 
     output = ensure_mapping(config, "output")
     reject_unknown_keys("output", output, OUTPUT_KEYS)
@@ -260,7 +269,7 @@ def default_pid_file(config_path: Path, config: dict[str, Any]) -> Path:
     return PROJECT_ROOT / ".run" / f"{safe_name}.pid"
 
 
-def set_input_config(input_config: dict[str, Any], key: str, value: str | None) -> None:
+def set_input_config(input_config: dict[str, Any], key: str, value: Any) -> None:
     if value:
         for k in INPUT_KEYS:
             input_config[k] = None
@@ -285,7 +294,6 @@ def apply_overrides(config: dict[str, Any], args: argparse.Namespace) -> None:
 
     set_input_config(input_config, "api_config", args.api_config)
     set_input_config(input_config, "api_config_file", args.api_config_file)
-    set_input_config(input_config, "api_config_file_pattern", args.api_config_file_pattern)
     if args.log_dir:
         output["log_dir"] = args.log_dir
 
@@ -326,14 +334,11 @@ def validate_config(config_path: Path, config: dict[str, Any]) -> tuple[str, Pat
 
     api_config = input_config.get("api_config")
     api_config_file = input_config.get("api_config_file")
-    api_config_pattern = input_config.get("api_config_file_pattern")
-    configured_inputs = [
-        value for value in (api_config, api_config_file, api_config_pattern) if value
-    ]
+    if api_config_file:
+        api_config_file = normalize_api_config_files(api_config_file)
+    configured_inputs = [value for value in (api_config, api_config_file) if value]
     if len(configured_inputs) != 1:
-        raise ValueError(
-            "input.api_config、input.api_config_file、input.api_config_file_pattern 必须且只能配置一个"
-        )
+        raise ValueError("input.api_config 或 input.api_config_file 必须且只能配置一个")
 
     log_dir = output.get("log_dir")
     if not log_dir:
@@ -356,13 +361,11 @@ def build_engine_command(engine: str, config: dict[str, Any], passthrough: list[
     command = [sys.executable, f"{engine}.py"]
     api_config = input_config.get("api_config")
     api_config_file = input_config.get("api_config_file")
-    api_config_pattern = input_config.get("api_config_file_pattern")
     if api_config:
         command.append(f"--api_config={api_config}")
     if api_config_file:
-        command.append(f"--api_config_file={api_config_file}")
-    if api_config_pattern:
-        command.append(f"--api_config_file_pattern={api_config_pattern}")
+        command.append("--api_config_file")
+        command.extend(normalize_api_config_files(api_config_file))
     command.append(f"--log_dir={output['log_dir']}")
 
     for key, value in engine_args.items():
@@ -379,20 +382,15 @@ def command_to_display(command: list[str]) -> str:
     return shlex.join(display_command)
 
 
-def input_value_from_config(config: dict[str, Any]) -> str | None:
+def input_value_from_config(config: dict[str, Any]) -> Any:
     input_config = ensure_mapping(config, "input")
-    return (
-        input_config.get("api_config")
-        or input_config.get("api_config_file")
-        or input_config.get("api_config_file_pattern")
-    )
+    return input_config.get("api_config") or input_config.get("api_config_file")
 
 
 def set_api_config_file(config: dict[str, Any], api_config_file: str) -> None:
     input_config = ensure_mapping(config, "input")
     input_config["api_config"] = None
-    input_config["api_config_file"] = api_config_file
-    input_config["api_config_file_pattern"] = None
+    input_config["api_config_file"] = [api_config_file]
 
 
 def retest_error_name(error_config: str) -> str:
@@ -672,9 +670,9 @@ def parse_args() -> argparse.Namespace:
         "--input",
         "--api-config-file",
         dest="api_config_file",
-        help="覆盖 input.api_config_file（-i/--input 为别名）",
+        nargs="+",
+        help="覆盖 input.api_config_file（-i/--input 为别名），可传多个文件、目录或 glob",
     )
-    parser.add_argument("--api-config-file-pattern", help="覆盖 input.api_config_file_pattern")
     parser.add_argument(
         "-o",
         "--output",
@@ -752,7 +750,6 @@ def run_once(
     hidden_options = {
         "--api_config",
         "--api_config_file",
-        "--api_config_file_pattern",
         "--log_dir",
     }
     if engine_args.get("num_gpus") == -1:

--- a/test_pipeline/CINN/README_test_cinn.md
+++ b/test_pipeline/CINN/README_test_cinn.md
@@ -82,7 +82,7 @@ TEST_MODE_ARGS=(
 
 IN_OUT_ARGS=(
     --api_config_file="$FILE_INPUT"
-    # --api_config_file_pattern="$FILE_PATTERN"
+    # --api_config_file="$FILE_PATTERN"
     --log_dir="$LOG_DIR"
 )
 

--- a/test_pipeline/CINN/run_cinn.sh
+++ b/test_pipeline/CINN/run_cinn.sh
@@ -31,7 +31,7 @@ TEST_MODE_ARGS=(
 
 IN_OUT_ARGS=(
     --api_config_file="$FILE_INPUT"
-    # --api_config_file_pattern="$FILE_PATTERN"
+    # --api_config_file="$FILE_PATTERN"
     --log_dir="$LOG_DIR"
 )
 

--- a/test_pipeline/V2/cpu_0size.md
+++ b/test_pipeline/V2/cpu_0size.md
@@ -79,7 +79,7 @@ TEST_MODE_ARGS=(
 
 IN_OUT_ARGS=(
     # --api_config_file="$FILE_INPUT"
-    --api_config_file_pattern="$FILE_PATTERN"
+    --api_config_file="$FILE_PATTERN"
     --log_dir="$LOG_DIR"
 )
 
@@ -134,7 +134,7 @@ TEST_MODE_ARGS=(
 
 若不使用 `run_0_cpu.sh`，以测试 0 size cpu accuracy 为例，可直接执行以下命令：（建议使用 nohup 避免终端终止时停止主进程）
 ```bash
-python engineV2.py --api_config_file_pattern="tester/api_config/7_0_size/0_size_tensor_1_8_[1-2].txt" --accuracy=True --test_cpu=True --num_gpus=-1 --num_workers_per_gpu=15 --log_dir="tester/api_config/test_log_0_size_cpu_accuracy" >> "tester/api_config/test_log_0_size_cpu_accuracy/log.log" 2>&1
+python engineV2.py --api_config_file="tester/api_config/7_0_size/0_size_tensor_1_8_[1-2].txt" --accuracy=True --test_cpu=True --num_gpus=-1 --num_workers_per_gpu=15 --log_dir="tester/api_config/test_log_0_size_cpu_accuracy" >> "tester/api_config/test_log_0_size_cpu_accuracy/log.log" 2>&1
 ```
 
 或者直接运行 run_0_cpu.sh：

--- a/test_pipeline/V2/cpu_accuracy.md
+++ b/test_pipeline/V2/cpu_accuracy.md
@@ -92,7 +92,7 @@ TEST_MODE_ARGS=(
 
 IN_OUT_ARGS=(
     # --api_config_file="$FILE_INPUT"
-    --api_config_file_pattern="$FILE_PATTERN"
+    --api_config_file="$FILE_PATTERN"
     --log_dir="$LOG_DIR"
 )
 
@@ -167,7 +167,7 @@ TEST_MODE_ARGS=(
 
 若不使用 `run_cpu.sh`，以测试 cpu accuracy 为例，可直接执行以下命令：（建议使用 nohup 避免终端终止时停止主进程）
 ```bash
-python engineV2.py --api_config_file_pattern="tester/api_config/5_accuracy/accuracy_[1-8].txt" --accuracy=True --test_cpu=True --num_gpus=-1 --num_workers_per_gpu=-1 --log_dir="tester/api_config/test_log_cpu_accuracy" >> "tester/api_config/test_log_cpu_accuracy/log.log" 2>&1
+python engineV2.py --api_config_file="tester/api_config/5_accuracy/accuracy_[1-8].txt" --accuracy=True --test_cpu=True --num_gpus=-1 --num_workers_per_gpu=-1 --log_dir="tester/api_config/test_log_cpu_accuracy" >> "tester/api_config/test_log_cpu_accuracy/log.log" 2>&1
 ```
 
 或者直接运行 run_cpu.sh：

--- a/test_pipeline/V2/gpu_0size.md
+++ b/test_pipeline/V2/gpu_0size.md
@@ -79,7 +79,7 @@ TEST_MODE_ARGS=(
 
 IN_OUT_ARGS=(
     # --api_config_file="$FILE_INPUT"
-    --api_config_file_pattern="$FILE_PATTERN"
+    --api_config_file="$FILE_PATTERN"
     --log_dir="$LOG_DIR"
 )
 
@@ -133,7 +133,7 @@ TEST_MODE_ARGS=(
 
 若不使用 `run_0_gpu.sh`，以测试 0 size gpu accuracy 为例，可直接执行以下命令：（建议使用 nohup 避免终端终止时停止主进程）
 ```bash
-python engineV2.py --api_config_file_pattern="tester/api_config/7_0_size/0_size_tensor_1_8_[1-2].txt" --accuracy=True --num_gpus=-1 --num_workers_per_gpu=15 --log_dir="tester/api_config/test_log_0_size_gpu_accuracy" >> "tester/api_config/test_log_0_size_gpu_accuracy/log.log" 2>&1
+python engineV2.py --api_config_file="tester/api_config/7_0_size/0_size_tensor_1_8_[1-2].txt" --accuracy=True --num_gpus=-1 --num_workers_per_gpu=15 --log_dir="tester/api_config/test_log_0_size_gpu_accuracy" >> "tester/api_config/test_log_0_size_gpu_accuracy/log.log" 2>&1
 ```
 
 或者直接运行 run_0_gpu.sh：

--- a/test_pipeline/V2/gpu_accuracy.md
+++ b/test_pipeline/V2/gpu_accuracy.md
@@ -92,7 +92,7 @@ TEST_MODE_ARGS=(
 
 IN_OUT_ARGS=(
     # --api_config_file="$FILE_INPUT"
-    --api_config_file_pattern="$FILE_PATTERN"
+    --api_config_file="$FILE_PATTERN"
     --log_dir="$LOG_DIR"
 )
 
@@ -164,7 +164,7 @@ TEST_MODE_ARGS=(
 
 若不使用 `run_gpu.sh`，以测试 gpu accuracy 为例，可直接执行以下命令：（建议使用 nohup 避免终端终止时停止主进程）
 ```bash
-python engineV2.py --api_config_file_pattern="tester/api_config/5_accuracy/accuracy_[1-8].txt" --accuracy=True --num_gpus=-1 --num_workers_per_gpu=-1 --log_dir="tester/api_config/test_log_gpu_accuracy" >> "tester/api_config/test_log_gpu_accuracy/log.log" 2>&1
+python engineV2.py --api_config_file="tester/api_config/5_accuracy/accuracy_[1-8].txt" --accuracy=True --num_gpus=-1 --num_workers_per_gpu=-1 --log_dir="tester/api_config/test_log_gpu_accuracy" >> "tester/api_config/test_log_gpu_accuracy/log.log" 2>&1
 ```
 
 或者直接运行 run_gpu.sh：

--- a/test_pipeline/V2/gpu_accuracy_tolerance.md
+++ b/test_pipeline/V2/gpu_accuracy_tolerance.md
@@ -88,7 +88,7 @@ TEST_MODE_ARGS=(
 
 IN_OUT_ARGS=(
     # --api_config_file="$FILE_INPUT"
-    --api_config_file_pattern="$FILE_PATTERN"
+    --api_config_file="$FILE_PATTERN"
     --log_dir="$LOG_DIR"
 )
 
@@ -135,7 +135,7 @@ exit 0
 
 若不使用 `run_tol.sh`，以测试 gpu accuracy tolerance 为例，可直接执行以下命令：（建议使用 nohup 避免终端终止时停止主进程）
 ```bash
-python engineV2.py --api_config_file_pattern="tester/api_config/5_accuracy/accuracy_*.txt" --accuracy=True --record_accuracy_tolerance=True --num_gpus=-1 --num_workers_per_gpu=-1 --log_dir="tester/api_config/test_log_tol" >> "tester/api_config/test_log_tol/log.log" 2>&1
+python engineV2.py --api_config_file="tester/api_config/5_accuracy/accuracy_*.txt" --accuracy=True --record_accuracy_tolerance=True --num_gpus=-1 --num_workers_per_gpu=-1 --log_dir="tester/api_config/test_log_tol" >> "tester/api_config/test_log_tol/log.log" 2>&1
 ```
 
 或者直接运行 run_tol.sh：

--- a/test_pipeline/V2/gpu_bigtensor.md
+++ b/test_pipeline/V2/gpu_bigtensor.md
@@ -76,7 +76,7 @@ TEST_MODE_ARGS=(
 
 IN_OUT_ARGS=(
     --api_config_file="$FILE_INPUT"
-    # --api_config_file_pattern="$FILE_PATTERN"
+    # --api_config_file="$FILE_PATTERN"
     --log_dir="$LOG_DIR"
 )
 

--- a/test_pipeline/V2/monitor_script/run_cpu_0size_full.sh
+++ b/test_pipeline/V2/monitor_script/run_cpu_0size_full.sh
@@ -25,7 +25,7 @@ TEST_MODE_ARGS=(
 
 IN_OUT_ARGS=(
     # --api_config_file="$FILE_INPUT"
-    --api_config_file_pattern="$FILE_PATTERN"
+    --api_config_file="$FILE_PATTERN"
     --log_dir="$LOG_DIR"
 )
 

--- a/test_pipeline/V2/monitor_script/run_gpu_0size_full.sh
+++ b/test_pipeline/V2/monitor_script/run_gpu_0size_full.sh
@@ -26,7 +26,7 @@ TEST_MODE_ARGS=(
 
 IN_OUT_ARGS=(
     # --api_config_file="$FILE_INPUT"
-    --api_config_file_pattern="$FILE_PATTERN"
+    --api_config_file="$FILE_PATTERN"
     --log_dir="$LOG_DIR"
 )
 

--- a/test_pipeline/V2/monitor_script/run_gpu_accuracy_full.sh
+++ b/test_pipeline/V2/monitor_script/run_gpu_accuracy_full.sh
@@ -27,7 +27,7 @@ TEST_MODE_ARGS=(
 
 IN_OUT_ARGS=(
     # --api_config_file="$FILE_INPUT"
-    --api_config_file_pattern="$FILE_PATTERN"
+    --api_config_file="$FILE_PATTERN"
     --log_dir="$LOG_DIR"
 )
 SHOW_RUNTIME_STATUS_ARGS=(

--- a/test_pipeline/V2/monitor_script/run_gpu_bigtensor_full.sh
+++ b/test_pipeline/V2/monitor_script/run_gpu_bigtensor_full.sh
@@ -23,7 +23,7 @@ TEST_MODE_ARGS=(
 
 IN_OUT_ARGS=(
     # --api_config_file="$FILE_INPUT"
-    --api_config_file_pattern="$FILE_PATTERN"
+    --api_config_file="$FILE_PATTERN"
     --log_dir="$LOG_DIR"
 )
 

--- a/test_pipeline/V2/run_cpu_0size_full.sh
+++ b/test_pipeline/V2/run_cpu_0size_full.sh
@@ -25,7 +25,7 @@ TEST_MODE_ARGS=(
 
 IN_OUT_ARGS=(
     # --api_config_file="$FILE_INPUT"
-    --api_config_file_pattern="$FILE_PATTERN"
+    --api_config_file="$FILE_PATTERN"
     --log_dir="$LOG_DIR"
 )
 

--- a/test_pipeline/V2/run_cpu_0size_regr.sh
+++ b/test_pipeline/V2/run_cpu_0size_regr.sh
@@ -24,7 +24,7 @@ TEST_MODE_ARGS=(
 
 IN_OUT_ARGS=(
     --api_config_file="$FILE_INPUT"
-    # --api_config_file_pattern="$FILE_PATTERN"
+    # --api_config_file="$FILE_PATTERN"
     --log_dir="$LOG_DIR"
 )
 

--- a/test_pipeline/V2/run_cpu_accuracy_full.sh
+++ b/test_pipeline/V2/run_cpu_accuracy_full.sh
@@ -26,7 +26,7 @@ TEST_MODE_ARGS=(
 
 IN_OUT_ARGS=(
     # --api_config_file="$FILE_INPUT"
-    --api_config_file_pattern="$FILE_PATTERN"
+    --api_config_file="$FILE_PATTERN"
     --log_dir="$LOG_DIR"
 )
 

--- a/test_pipeline/V2/run_cpu_accuracy_regr.sh
+++ b/test_pipeline/V2/run_cpu_accuracy_regr.sh
@@ -23,7 +23,7 @@ TEST_MODE_ARGS=(
 
 IN_OUT_ARGS=(
     --api_config_file="$FILE_INPUT"
-    # --api_config_file_pattern="$FILE_PATTERN"
+    # --api_config_file="$FILE_PATTERN"
     --log_dir="$LOG_DIR"
 )
 

--- a/test_pipeline/V2/run_gpu_0size_full.sh
+++ b/test_pipeline/V2/run_gpu_0size_full.sh
@@ -25,7 +25,7 @@ TEST_MODE_ARGS=(
 
 IN_OUT_ARGS=(
     # --api_config_file="$FILE_INPUT"
-    --api_config_file_pattern="$FILE_PATTERN"
+    --api_config_file="$FILE_PATTERN"
     --log_dir="$LOG_DIR"
 )
 

--- a/test_pipeline/V2/run_gpu_0size_regr.sh
+++ b/test_pipeline/V2/run_gpu_0size_regr.sh
@@ -24,7 +24,7 @@ TEST_MODE_ARGS=(
 
 IN_OUT_ARGS=(
     --api_config_file="$FILE_INPUT"
-    # --api_config_file_pattern="$FILE_PATTERN"
+    # --api_config_file="$FILE_PATTERN"
     --log_dir="$LOG_DIR"
 )
 

--- a/test_pipeline/V2/run_gpu_accuracy_full.sh
+++ b/test_pipeline/V2/run_gpu_accuracy_full.sh
@@ -23,7 +23,7 @@ TEST_MODE_ARGS=(
 
 IN_OUT_ARGS=(
     # --api_config_file="$FILE_INPUT"
-    --api_config_file_pattern="$FILE_PATTERN"
+    --api_config_file="$FILE_PATTERN"
     --log_dir="$LOG_DIR"
 )
 

--- a/test_pipeline/V2/run_gpu_accuracy_regr.sh
+++ b/test_pipeline/V2/run_gpu_accuracy_regr.sh
@@ -24,7 +24,7 @@ TEST_MODE_ARGS=(
 
 IN_OUT_ARGS=(
     --api_config_file="$FILE_INPUT"
-    # --api_config_file_pattern="$FILE_PATTERN"
+    # --api_config_file="$FILE_PATTERN"
     --log_dir="$LOG_DIR"
 )
 

--- a/test_pipeline/V2/run_gpu_accuracy_stable.sh
+++ b/test_pipeline/V2/run_gpu_accuracy_stable.sh
@@ -32,7 +32,7 @@ TEST_MODE_ARGS=(
 
 IN_OUT_ARGS=(
     # --api_config_file="$FILE_INPUT"
-    --api_config_file_pattern="$FILE_PATTERN"
+    --api_config_file="$FILE_PATTERN"
     --log_dir="$LOG_DIR"
 )
 

--- a/test_pipeline/V2/run_gpu_accuracy_tolerance.sh
+++ b/test_pipeline/V2/run_gpu_accuracy_tolerance.sh
@@ -28,7 +28,7 @@ TEST_MODE_ARGS=(
 
 IN_OUT_ARGS=(
     # --api_config_file="$FILE_INPUT"
-    --api_config_file_pattern="$FILE_PATTERN"
+    --api_config_file="$FILE_PATTERN"
     --log_dir="$LOG_DIR"
 )
 

--- a/test_pipeline/V2/run_gpu_bigtensor_full.sh
+++ b/test_pipeline/V2/run_gpu_bigtensor_full.sh
@@ -24,7 +24,7 @@ TEST_MODE_ARGS=(
 
 IN_OUT_ARGS=(
     # --api_config_file="$FILE_INPUT"
-    --api_config_file_pattern="$FILE_PATTERN"
+    --api_config_file="$FILE_PATTERN"
     --log_dir="$LOG_DIR"
 )
 

--- a/test_pipeline/V2/run_gpu_bigtensor_regr.sh
+++ b/test_pipeline/V2/run_gpu_bigtensor_regr.sh
@@ -23,7 +23,7 @@ TEST_MODE_ARGS=(
 
 IN_OUT_ARGS=(
     --api_config_file="$FILE_INPUT"
-    # --api_config_file_pattern="$FILE_PATTERN"
+    # --api_config_file="$FILE_PATTERN"
     --log_dir="$LOG_DIR"
 )
 

--- a/test_pipeline/V2/run_paddle_gpu_performance.sh
+++ b/test_pipeline/V2/run_paddle_gpu_performance.sh
@@ -25,7 +25,7 @@ TEST_MODE_ARGS=(
 
 IN_OUT_ARGS=(
     --api_config_file="$FILE_INPUT"
-    # --api_config_file_pattern="$FILE_PATTERN"
+    # --api_config_file="$FILE_PATTERN"
     --log_dir="$LOG_DIR"
 )
 

--- a/test_pipeline/V4/run_cpu_0size_full.sh
+++ b/test_pipeline/V4/run_cpu_0size_full.sh
@@ -126,7 +126,7 @@ fi
 # ── 组装参数 ──
 IN_OUT_ARGS=(
     # --api_config_file="$FILE_INPUT"
-    --api_config_file_pattern="$FILE_PATTERN"
+    --api_config_file="$FILE_PATTERN"
     --log_dir="$LOG_DIR"
 )
 

--- a/test_pipeline/V4/run_dsv4_0size_accuracy.sh
+++ b/test_pipeline/V4/run_dsv4_0size_accuracy.sh
@@ -146,7 +146,7 @@ fi
 # ── 组装参数 ──
 IN_OUT_ARGS=(
     --api_config_file="$FILE_INPUT"
-    # --api_config_file_pattern="$FILE_PATTERN"
+    # --api_config_file="$FILE_PATTERN"
     --log_dir="$LOG_DIR"
 )
 

--- a/test_pipeline/V4/run_dsv4_0size_paddleonly.sh
+++ b/test_pipeline/V4/run_dsv4_0size_paddleonly.sh
@@ -146,7 +146,7 @@ fi
 # ── 组装参数 ──
 IN_OUT_ARGS=(
     --api_config_file="$FILE_INPUT"
-    # --api_config_file_pattern="$FILE_PATTERN"
+    # --api_config_file="$FILE_PATTERN"
     --log_dir="$LOG_DIR"
 )
 

--- a/test_pipeline/V4/run_dsv4_1M_accuracy.sh
+++ b/test_pipeline/V4/run_dsv4_1M_accuracy.sh
@@ -146,7 +146,7 @@ fi
 # ── 组装参数 ──
 IN_OUT_ARGS=(
     --api_config_file="$FILE_INPUT"
-    # --api_config_file_pattern="$FILE_PATTERN"
+    # --api_config_file="$FILE_PATTERN"
     --log_dir="$LOG_DIR"
 )
 

--- a/test_pipeline/V4/run_dsv4_1M_paddleonly.sh
+++ b/test_pipeline/V4/run_dsv4_1M_paddleonly.sh
@@ -146,7 +146,7 @@ fi
 # ── 组装参数 ──
 IN_OUT_ARGS=(
     --api_config_file="$FILE_INPUT"
-    # --api_config_file_pattern="$FILE_PATTERN"
+    # --api_config_file="$FILE_PATTERN"
     --log_dir="$LOG_DIR"
 )
 

--- a/test_pipeline/V4/run_dsv4_v2_accuracy_manual_threshold.sh
+++ b/test_pipeline/V4/run_dsv4_v2_accuracy_manual_threshold.sh
@@ -149,7 +149,7 @@ fi
 # ── 组装参数 ──
 IN_OUT_ARGS=(
     --api_config_file="$FILE_INPUT"
-    # --api_config_file_pattern="$FILE_PATTERN"
+    # --api_config_file="$FILE_PATTERN"
     --log_dir="$LOG_DIR"
 )
 

--- a/test_pipeline/V4/run_gpu_0size_full.sh
+++ b/test_pipeline/V4/run_gpu_0size_full.sh
@@ -126,7 +126,7 @@ fi
 # ── 组装参数 ──
 IN_OUT_ARGS=(
     # --api_config_file="$FILE_INPUT"
-    --api_config_file_pattern="$FILE_PATTERN"
+    --api_config_file="$FILE_PATTERN"
     --log_dir="$LOG_DIR"
 )
 

--- a/test_pipeline/V4/run_gpu_accuracy_full.sh
+++ b/test_pipeline/V4/run_gpu_accuracy_full.sh
@@ -138,7 +138,7 @@ fi
 # ── 组装参数 ──
 IN_OUT_ARGS=(
     # --api_config_file="$FILE_INPUT"
-    --api_config_file_pattern="$FILE_PATTERN"
+    --api_config_file="$FILE_PATTERN"
     --log_dir="$LOG_DIR"
 )
 

--- a/test_pipeline/V4/run_gpu_bigtensor_full.sh
+++ b/test_pipeline/V4/run_gpu_bigtensor_full.sh
@@ -124,7 +124,7 @@ fi
 # ── 组装参数 ──
 IN_OUT_ARGS=(
     # --api_config_file="$FILE_INPUT"
-    --api_config_file_pattern="$FILE_PATTERN"
+    --api_config_file="$FILE_PATTERN"
     --log_dir="$LOG_DIR"
 )
 

--- a/test_pipeline/V4/run_v2_0size_accuracy.sh
+++ b/test_pipeline/V4/run_v2_0size_accuracy.sh
@@ -146,7 +146,7 @@ fi
 # ── 组装参数 ──
 IN_OUT_ARGS=(
     --api_config_file="$FILE_INPUT"
-    # --api_config_file_pattern="$FILE_PATTERN"
+    # --api_config_file="$FILE_PATTERN"
     --log_dir="$LOG_DIR"
 )
 

--- a/test_pipeline/V4/run_v2_0size_paddleonly.sh
+++ b/test_pipeline/V4/run_v2_0size_paddleonly.sh
@@ -146,7 +146,7 @@ fi
 # ── 组装参数 ──
 IN_OUT_ARGS=(
     --api_config_file="$FILE_INPUT"
-    # --api_config_file_pattern="$FILE_PATTERN"
+    # --api_config_file="$FILE_PATTERN"
     --log_dir="$LOG_DIR"
 )
 

--- a/test_pipeline/V4/run_v2_1M_accuracy.sh
+++ b/test_pipeline/V4/run_v2_1M_accuracy.sh
@@ -146,7 +146,7 @@ fi
 # ── 组装参数 ──
 IN_OUT_ARGS=(
     --api_config_file="$FILE_INPUT"
-    # --api_config_file_pattern="$FILE_PATTERN"
+    # --api_config_file="$FILE_PATTERN"
     --log_dir="$LOG_DIR"
 )
 

--- a/test_pipeline/V4/run_v2_1M_paddleonly.sh
+++ b/test_pipeline/V4/run_v2_1M_paddleonly.sh
@@ -146,7 +146,7 @@ fi
 # ── 组装参数 ──
 IN_OUT_ARGS=(
     --api_config_file="$FILE_INPUT"
-    # --api_config_file_pattern="$FILE_PATTERN"
+    # --api_config_file="$FILE_PATTERN"
     --log_dir="$LOG_DIR"
 )
 

--- a/test_pipeline/config_preprocess/dedup_config.py
+++ b/test_pipeline/config_preprocess/dedup_config.py
@@ -9,7 +9,43 @@ Usage:
 from __future__ import annotations
 
 import argparse
+import heapq
 import os
+import tempfile
+
+CHUNK_BYTES = 64 * 1024 * 1024
+
+
+def _flush_chunk(lines, chunk_dir, chunk_index):
+    """将有限大小的去重块排序落盘，避免大文件全部进入内存。"""
+    # 块内去重先完成，跨块重复交给最终归并处理。
+    if not lines:
+        return None
+    path = os.path.join(chunk_dir, f"chunk_{chunk_index:06d}.txt")
+    with open(path, "w", encoding="utf-8") as output_file:
+        for line in sorted(lines):
+            output_file.write(line + "\n")
+    return path
+
+
+def _merge_chunks(chunk_paths, output_path):
+    """归并分块并去重，保持原脚本的排序输出协议。"""
+    # 文件句柄数量等于块数，控制块大小即可控制归并内存。
+    streams = [open(path, encoding="utf-8") for path in chunk_paths]
+    unique_count = 0
+    previous = None
+    try:
+        with open(output_path, "w", encoding="utf-8") as output_file:
+            for line in heapq.merge(*(stream for stream in streams)):
+                if line == previous:
+                    continue
+                output_file.write(line)
+                previous = line
+                unique_count += 1
+    finally:
+        for stream in streams:
+            stream.close()
+    return unique_count
 
 
 def parse_args():
@@ -40,36 +76,49 @@ def main():
     if output_dir:
         os.makedirs(output_dir, exist_ok=True)
 
-    seen = set()
     total = 0
     blank_lines = 0
     skipped_non_config = 0
-    with open(input_path, encoding="utf-8") as f:
-        for line in f:
-            total += 1
-            line = line.strip()
-            if not line:
-                blank_lines += 1
-                continue
-            # 与引擎入口保持相同边界，预处理产物只能包含 Paddle API 配置。
-            if not line.startswith("paddle."):
-                skipped_non_config += 1
-                continue
-            seen.add(line)
-
-    unique_lines = sorted(seen)
-
-    with open(output_path, "w", encoding="utf-8") as f:
-        for line in unique_lines:
-            f.write(line + "\n")
+    with tempfile.TemporaryDirectory(prefix=".dedup_chunks.", dir=output_dir or ".") as chunk_dir:
+        # 只保留当前块的集合，避免与输入文件总大小线性增长。
+        chunk_paths = []
+        chunk_lines = set()
+        chunk_bytes = 0
+        chunk_index = 0
+        with open(input_path, encoding="utf-8") as input_file:
+            for line in input_file:
+                total += 1
+                line = line.strip()
+                if not line:
+                    blank_lines += 1
+                    continue
+                # 与引擎入口保持相同边界，预处理产物只能包含 Paddle API 配置。
+                if not line.startswith("paddle."):
+                    skipped_non_config += 1
+                    continue
+                # 不跨块查重，避免维护全局 Python set。
+                if line in chunk_lines:
+                    continue
+                chunk_lines.add(line)
+                chunk_bytes += len(line) + 1
+                if chunk_bytes >= CHUNK_BYTES:
+                    path = _flush_chunk(chunk_lines, chunk_dir, chunk_index)
+                    chunk_paths.append(path)
+                    chunk_index += 1
+                    chunk_lines.clear()
+                    chunk_bytes = 0
+        path = _flush_chunk(chunk_lines, chunk_dir, chunk_index)
+        if path is not None:
+            chunk_paths.append(path)
+        unique_count = _merge_chunks(chunk_paths, output_path)
 
     valid_lines = total - blank_lines - skipped_non_config
     print(f"Total lines:   {total}")
     print(f"Blank lines:   {blank_lines}")
     print(f"Non-config:    {skipped_non_config}")
     print(f"Config lines:  {valid_lines}")
-    print(f"Unique lines:  {len(unique_lines)}")
-    print(f"Duplicates:    {valid_lines - len(unique_lines)}")
+    print(f"Unique lines:  {unique_count}")
+    print(f"Duplicates:    {valid_lines - unique_count}")
     print(f"Output:        {output_path}")
 
 

--- a/test_pipeline/config_preprocess/dedup_config.py
+++ b/test_pipeline/config_preprocess/dedup_config.py
@@ -42,10 +42,20 @@ def main():
 
     seen = set()
     total = 0
+    blank_lines = 0
+    skipped_non_config = 0
     with open(input_path, encoding="utf-8") as f:
         for line in f:
             total += 1
-            seen.add(line.rstrip("\n"))
+            line = line.strip()
+            if not line:
+                blank_lines += 1
+                continue
+            # 与引擎入口保持相同边界，预处理产物只能包含 Paddle API 配置。
+            if not line.startswith("paddle."):
+                skipped_non_config += 1
+                continue
+            seen.add(line)
 
     unique_lines = sorted(seen)
 
@@ -53,9 +63,13 @@ def main():
         for line in unique_lines:
             f.write(line + "\n")
 
+    valid_lines = total - blank_lines - skipped_non_config
     print(f"Total lines:   {total}")
+    print(f"Blank lines:   {blank_lines}")
+    print(f"Non-config:    {skipped_non_config}")
+    print(f"Config lines:  {valid_lines}")
     print(f"Unique lines:  {len(unique_lines)}")
-    print(f"Duplicates:    {total - len(unique_lines)}")
+    print(f"Duplicates:    {valid_lines - len(unique_lines)}")
     print(f"Output:        {output_path}")
 
 

--- a/test_pipeline/config_preprocess/extract_api_set.py
+++ b/test_pipeline/config_preprocess/extract_api_set.py
@@ -36,17 +36,18 @@ def extract_apis(input_paths, output_file):
 
     for input_file in input_files:
         try:
-            content = input_file.read_text(encoding="utf-8")
             file_count = 0
 
-            for line in content.splitlines():
-                line = line.strip()
-                if line and "(" in line:
-                    api_name = line.split("(", 1)[0].strip()
-                    if api_name:
-                        api_names.add(api_name)
-                        file_count += 1
-                        total_processed += 1
+            # 按行读取，0-size 配置可能达到数 GB，不能整体 read_text。
+            with input_file.open(encoding="utf-8") as source_file:
+                for line in source_file:
+                    line = line.strip()
+                    if line and "(" in line:
+                        api_name = line.split("(", 1)[0].strip()
+                        if api_name:
+                            api_names.add(api_name)
+                            file_count += 1
+                            total_processed += 1
 
             print(f"Processed {file_count} APIs from {input_file}")
         except Exception as err:

--- a/test_pipeline/config_preprocess/to_0_size_config.py
+++ b/test_pipeline/config_preprocess/to_0_size_config.py
@@ -2,12 +2,14 @@ from __future__ import annotations
 
 import argparse
 import copy
+import heapq
 import math
 import os
+import tempfile
 
 import numpy
 import paddle
-from tester.api_config.parser import analyse_configs
+from tester.api_config.parser import APIConfig
 from tester.input_generation.tensor_config import TensorConfig
 from tqdm import tqdm
 
@@ -21,6 +23,7 @@ def is_0D_tensor(tensor_config):
 
 
 def get_tensor_configs(api_config):
+    # 只展开参数容器，不改变 parser 对嵌套值的既有边界。
     tensor_configs = []
     for arg_config in api_config.args:
         if isinstance(arg_config, TensorConfig):
@@ -40,7 +43,117 @@ def get_tensor_configs(api_config):
     return tensor_configs
 
 
+def iter_api_configs(config_path):
+    """逐行解析配置，避免把全部 APIConfig 对象同时保存在内存。"""
+    with open(config_path, encoding="utf-8") as config_file:
+        for raw_line in config_file:
+            config = raw_line.strip()
+            if config and config.startswith("paddle."):
+                yield APIConfig(config)
+
+
+def _matching_close(text, start, opening, closing):
+    """返回嵌套括号的结束位置，字符串内容中的括号不参与配对。"""
+    # 需要跳过字符串中的括号，否则 callable 或字符串参数会破坏定位。
+    depth = 0
+    quote = None
+    escaped = False
+    for index in range(start, len(text)):
+        char = text[index]
+        if quote is not None:
+            if escaped:
+                escaped = False
+            elif char == "\\":
+                escaped = True
+            elif char == quote:
+                quote = None
+            continue
+        if char in ('"', "'"):
+            quote = char
+        elif char == opening:
+            depth += 1
+        elif char == closing:
+            depth -= 1
+            if depth == 0:
+                return index
+    return None
+
+
+def _find_tensor_shape_spans(config):
+    """记录规范化配置中每个 Tensor shape 列表的字符区间。"""
+    # 偏移区间只覆盖 shape 列表，保留 Tensor 外层语法和 dtype 文本。
+    spans = []
+    search_from = 0
+    marker = "Tensor("
+    while True:
+        tensor_start = config.find(marker, search_from)
+        if tensor_start < 0:
+            return spans
+        shape_start = tensor_start + len(marker)
+        size_prefix = "paddle.Size("
+        if config.startswith(size_prefix, shape_start):
+            shape_start += len(size_prefix)
+        while shape_start < len(config) and config[shape_start].isspace():
+            shape_start += 1
+        if shape_start >= len(config) or config[shape_start] != "[":
+            search_from = tensor_start + len(marker)
+            continue
+        shape_end = _matching_close(config, shape_start, "[", "]")
+        if shape_end is None:
+            return []
+        spans.append((shape_start, shape_end + 1))
+        search_from = shape_end + 1
+
+
+def _selected_positions(tensor_configs):
+    """返回全部 Tensor 维度位置，保持 0-size 覆盖范围不变。"""
+    return [
+        (index, axis)
+        for index, tensor in enumerate(tensor_configs)
+        for axis in range(len(tensor.shape))
+    ]
+
+
+def _replace_shape_spans(config, spans, replacements):
+    """按位置替换 shape，避免为每个候选重新解析 APIConfig。"""
+    # 按原始区间拼接，避免正则替换同形状 Tensor 时误伤其他位置。
+    chunks = []
+    cursor = 0
+    for index, (start, end) in enumerate(spans):
+        chunks.append(config[cursor:start])
+        chunks.append(str(replacements.get(index, config[start:end])))
+        cursor = end
+    chunks.append(config[cursor:])
+    return "".join(chunks)
+
+
+def _object_variants(api_config):
+    """字符串定位失败时的兼容路径；同一配置只深拷贝一次。"""
+    # 仅定位失败时使用对象回退，且整个配置生命周期只复制一次。
+    work_api_config = copy.deepcopy(api_config)
+    work_tensors = get_tensor_configs(work_api_config)
+    for tensor_index, axis in _selected_positions(work_tensors):
+        tensor = work_tensors[tensor_index]
+        old_value = tensor.shape[axis]
+        tensor.shape[axis] = 0
+        try:
+            yield str(work_api_config)
+        finally:
+            tensor.shape[axis] = old_value
+    if all(len(tensor.shape) == len(work_tensors[0].shape) for tensor in work_tensors):
+        for axis in range(len(work_tensors[0].shape)):
+            old_values = [tensor.shape[axis] for tensor in work_tensors]
+            try:
+                for tensor in work_tensors:
+                    tensor.shape[axis] = 0
+                yield str(work_api_config)
+            finally:
+                for tensor, old_value in zip(work_tensors, old_values, strict=True):
+                    tensor.shape[axis] = old_value
+
+
 def to_0_size_config(api_config):
+    # 同一 API/结构最多保留少量重复样本，这是原有稳定性探测协议。
     if api_config.api_name not in apis_map:
         apis_map[api_config.api_name] = {}
 
@@ -54,7 +167,6 @@ def to_0_size_config(api_config):
     if apis_map[api_config.api_name][key] > 5:
         return []
 
-    result = []
     tensor_configs = get_tensor_configs(api_config)
 
     if len(tensor_configs) == 0:
@@ -68,21 +180,35 @@ def to_0_size_config(api_config):
         if shape_len != len(tensor_config.shape):
             shape_equal = False
 
-    for i in range(len(tensor_configs)):
-        for j in range(len(tensor_configs[i].shape)):
-            tmp_api_config = copy.deepcopy(api_config)
-            tmp_tensor_configs = get_tensor_configs(tmp_api_config)
-            tmp_tensor_configs[i].shape[j] = 0
-            result.append(str(tmp_api_config))
+    # 正常路径复用 parser 的规范格式，保证与历史输出兼容。
+    canonical_config = str(api_config)
+    # 运行时 callable 的 repr 不能被 parser 重新执行，此时保留原始可解析文本。
+    runtime_repr_markers = ("<function ", "<method ", "<built-in ", "<slot wrapper ", " at 0x")
+    if any(marker in canonical_config for marker in runtime_repr_markers):
+        canonical_config = api_config.config
+    spans = _find_tensor_shape_spans(canonical_config)
+    if len(spans) != len(tensor_configs):
+        yield from _object_variants(api_config)
+        return
+
+    # 每个变体只复制字符串，不复制整棵 APIConfig 对象树。
+    for tensor_index, axis in _selected_positions(tensor_configs):
+        shape = list(tensor_configs[tensor_index].shape)
+        shape[axis] = 0
+        yield _replace_shape_spans(
+            canonical_config,
+            spans,
+            {tensor_index: shape},
+        )
 
     if shape_equal:
-        for j in range(shape_len):
-            tmp_api_config = copy.deepcopy(api_config)
-            tmp_tensor_configs = get_tensor_configs(tmp_api_config)
-            for i in range(len(tensor_configs)):
-                tmp_tensor_configs[i].shape[j] = 0
-            result.append(str(tmp_api_config))
-    return result
+        for axis in range(shape_len):
+            replacements = {}
+            for index, tensor in enumerate(tensor_configs):
+                shape = list(tensor.shape)
+                shape[axis] = 0
+                replacements[index] = shape
+            yield _replace_shape_spans(canonical_config, spans, replacements)
 
 
 apis_map = {}
@@ -173,6 +299,41 @@ def config_key(api_config):
         result = result + key + "=" + dump_item_str(value) + ", "
 
     return result
+
+
+CHUNK_BYTES = 64 * 1024 * 1024
+
+
+def _flush_chunk(lines, chunk_dir, chunk_index):
+    """将有限大小的去重块排序落盘，避免长配置常驻内存。"""
+    # 块边界按字节计算，避免单条超长配置突破内存预算。
+    if not lines:
+        return None
+    path = os.path.join(chunk_dir, f"chunk_{chunk_index:06d}.txt")
+    with open(path, "w", encoding="utf-8") as output_file:
+        for line in sorted(lines):
+            output_file.write(line + "\n")
+    return path
+
+
+def _merge_chunks(chunk_paths, output_path):
+    """归并已排序分块并再次去重，输出顺序与 dedup_config 保持一致。"""
+    # 归并输入均已排序，因此只需比较相邻行即可完成全局去重。
+    streams = [open(path, encoding="utf-8") for path in chunk_paths]
+    count = 0
+    previous = None
+    try:
+        with open(output_path, "w", encoding="utf-8") as output_file:
+            for line in heapq.merge(*(stream for stream in streams)):
+                if line == previous:
+                    continue
+                output_file.write(line)
+                previous = line
+                count += 1
+    finally:
+        for stream in streams:
+            stream.close()
+    return count
 
 
 def to_big_tensor_config(api_config):
@@ -290,16 +451,31 @@ if __name__ == "__main__":
     if output_dir:
         os.makedirs(output_dir, exist_ok=True)
 
-    config_0_size = set()
-    for input_file in args.inputs:
-        print(f"处理: {input_file}")
-        api_configs = analyse_configs(input_file)
-        config_0_size_chunk = []
-        for api_config in tqdm(api_configs):
-            config_0_size_chunk.extend(set(to_0_size_config(api_config)))
-        config_0_size = config_0_size.union(set(config_0_size_chunk))
+    output_dir = os.path.dirname(args.output) or "."
+    with tempfile.TemporaryDirectory(prefix=".0size_chunks.", dir=output_dir) as chunk_dir:
+        # 临时块位于输出目录，保证大文件处理不依赖系统 /tmp 空间。
+        chunk_paths = []
+        chunk_lines = set()
+        chunk_bytes = 0
+        chunk_index = 0
+        for input_file in args.inputs:
+            print(f"处理: {input_file}")
+            for api_config in tqdm(iter_api_configs(input_file)):
+                # 逐个变体进入有限大小的块集合，避免累计完整输出。
+                for variant in to_0_size_config(api_config):
+                    if variant in chunk_lines:
+                        continue
+                    chunk_lines.add(variant)
+                    chunk_bytes += len(variant) + 1
+                    if chunk_bytes >= CHUNK_BYTES:
+                        path = _flush_chunk(chunk_lines, chunk_dir, chunk_index)
+                        chunk_paths.append(path)
+                        chunk_index += 1
+                        chunk_lines.clear()
+                        chunk_bytes = 0
+        path = _flush_chunk(chunk_lines, chunk_dir, chunk_index)
+        if path is not None:
+            chunk_paths.append(path)
+        unique_count = _merge_chunks(chunk_paths, args.output)
 
-    with open(args.output, "w") as f:
-        f.write("\n".join(config_0_size))
-
-    print(f"输出: {args.output}，共 {len(config_0_size)} 行")
+    print(f"输出: {args.output}，共 {unique_count} 行")

--- a/test_pipeline/run_config.schema.json
+++ b/test_pipeline/run_config.schema.json
@@ -26,8 +26,12 @@
       "additionalProperties": false,
       "properties": {
         "api_config": {"type": ["string", "null"], "description": "单条 case 配置，对应 --api_config。"},
-        "api_config_file": {"type": ["string", "null"], "description": "单个配置文件，对应 --api_config_file。"},
-        "api_config_file_pattern": {"type": ["string", "null"], "description": "多文件 glob，对应 --api_config_file_pattern。"}
+        "api_config_file": {
+          "type": ["string", "array", "null"],
+          "items": {"type": "string"},
+          "minItems": 1,
+          "description": "配置文件、目录或 glob 输入数组，对应 --api_config_file。"
+        }
       }
     },
     "output": {

--- a/test_pipeline/run_config.yaml
+++ b/test_pipeline/run_config.yaml
@@ -16,7 +16,7 @@
 # - engineV4.py / engineV2.py 继续负责 case 执行、pattern 展开、checkpoint 续跑和失败分类。
 #
 # 配置规则：
-# - input.api_config / input.api_config_file / input.api_config_file_pattern 必须且只能配置一个。
+# - input.api_config / input.api_config_file 必须且只能配置一个。
 # - output.log_dir 必填。
 # - engine_args 中未配置或注释掉的字段使用 engine 默认值。
 # - 布尔值会被 run.py 转为 --key=True/False 传给 engine。
@@ -53,10 +53,9 @@ env:
 input:
   # 单条 case 配置，直接传给 engine --api_config。
   api_config: null
-  # 单个配置文件，直接传给 engine --api_config_file。
-  api_config_file: "tester/api_config/5_accuracy/accuracy_1.txt"
-  # 多文件 glob，直接传给 engine --api_config_file_pattern。
-  api_config_file_pattern: null
+  # 配置文件、目录或 glob 输入，可写字符串或字符串数组。
+  api_config_file:
+    - tester/api_config/5_accuracy/accuracy_1.txt
 
 output:
   # 对应 engine --log_dir；run.py 主日志也写到该目录。

--- a/test_pipeline/run_pipeline.sh
+++ b/test_pipeline/run_pipeline.sh
@@ -155,16 +155,11 @@ python "$PROCESSOR_DIR/dedup_config.py" \
     -o "$PADDLEONLY_4096_DIR/$ORIG_MERGED_NAME"
 
 # 转 0size
+# to_0_size_config 已经采用分块排序归并并输出唯一行，直接写最终路径，
+# 避免对可能达到数 GB 的中间文件再做一次全量去重。
 python "$PROCESSOR_DIR/to_0_size_config.py" \
     -i "$PADDLEONLY_4096_DIR/$ORIG_MERGED_NAME" \
-    -o "$OUTPUT_DIR/_tmp_0size.txt"
-
-# 去重 0size
-python "$PROCESSOR_DIR/dedup_config.py" \
-    -i "$OUTPUT_DIR/_tmp_0size.txt" \
     -o "$PADDLEONLY_0SIZE_DIR/0size.txt"
-
-rm -f "$OUTPUT_DIR/_tmp_0size.txt"
 
 # 指定比例时只替换保留集；未指定时完全跳过缩减，保持默认流程结果不变。
 if [ -n "$SLIM_RATIO" ]; then
@@ -177,9 +172,13 @@ if [ -n "$SLIM_RATIO" ]; then
     SLIM_REMOVED_DIR="$SLIM_TMP_DIR/removed"
     # 输入、保留和裁减目录隔离，满足 random_slim 的递归扫描约束。
     mkdir -p "$SLIM_INPUT_DIR"
-    cp "$PADDLEONLY_1M_DIR/1M.txt" "$SLIM_INPUT_DIR/1M.txt"
-    cp "$PADDLEONLY_4096_DIR/$ORIG_MERGED_NAME" "$SLIM_INPUT_DIR/4096.txt"
-    cp "$PADDLEONLY_0SIZE_DIR/0size.txt" "$SLIM_INPUT_DIR/0size.txt"
+    # 同一文件系统优先使用硬链接，避免 slim 模式复制数 GB 的 0-size 文件。
+    ln "$PADDLEONLY_1M_DIR/1M.txt" "$SLIM_INPUT_DIR/1M.txt" 2>/dev/null || \
+        cp "$PADDLEONLY_1M_DIR/1M.txt" "$SLIM_INPUT_DIR/1M.txt"
+    ln "$PADDLEONLY_4096_DIR/$ORIG_MERGED_NAME" "$SLIM_INPUT_DIR/4096.txt" 2>/dev/null || \
+        cp "$PADDLEONLY_4096_DIR/$ORIG_MERGED_NAME" "$SLIM_INPUT_DIR/4096.txt"
+    ln "$PADDLEONLY_0SIZE_DIR/0size.txt" "$SLIM_INPUT_DIR/0size.txt" 2>/dev/null || \
+        cp "$PADDLEONLY_0SIZE_DIR/0size.txt" "$SLIM_INPUT_DIR/0size.txt"
     python "$REPO_DIR/tools/random_slim_api_configs.py" \
         --input-dir "$SLIM_INPUT_DIR" \
         --kept-dir "$SLIM_KEPT_DIR" \
@@ -213,7 +212,7 @@ python "$PROCESSOR_DIR/extract_api_set.py" \
 # ============================================================================
 # 清理中间文件，只保留最终结果
 # ============================================================================
-rm -f "$DERIVED_4096" "$DERIVED_1M" "$OUTPUT_DIR/_tmp_0size.txt"
+rm -f "$DERIVED_4096" "$DERIVED_1M"
 
 echo ""
 echo "======================================================================"

--- a/tester/api_config/parser.py
+++ b/tester/api_config/parser.py
@@ -23,13 +23,34 @@ class APIConfig:
     # 兼容历史配置别名，统一交给 Paddle 原生参数名执行。
     _KWARG_ALIASES = {"paddle.Tensor.sum": {"dim": "axis"}}
 
+    @staticmethod
+    def _memoize_paddle_places(value, memo, visited):
+        value_id = id(value)
+        if value_id in visited:
+            return
+        visited.add(value_id)
+        if isinstance(value, paddle.base.libpaddle.Place):
+            # Place 是不可变运行时句柄，旧版 Paddle 无法 pickle，副本复用其设备语义。
+            memo[value_id] = value
+        elif isinstance(value, dict):
+            for key, item in value.items():
+                APIConfig._memoize_paddle_places(key, memo, visited)
+                APIConfig._memoize_paddle_places(item, memo, visited)
+        elif isinstance(value, (list, tuple, set, frozenset)):
+            for item in value:
+                APIConfig._memoize_paddle_places(item, memo, visited)
+
     def __deepcopy__(self, memo):
         cls = self.__class__
         result = cls.__new__(cls)
         memo[id(self)] = result
-        result.args = copy.deepcopy(self.args)
-        result.kwargs = copy.deepcopy(self.kwargs)
-        result._kwarg_alias_sources = copy.deepcopy(self._kwarg_alias_sources)
+        # 配置参数允许嵌套容器，visited 防止循环引用重复遍历。
+        visited = set()
+        self._memoize_paddle_places(self.args, memo, visited)
+        self._memoize_paddle_places(self.kwargs, memo, visited)
+        result.args = copy.deepcopy(self.args, memo)
+        result.kwargs = copy.deepcopy(self.kwargs, memo)
+        result._kwarg_alias_sources = copy.deepcopy(self._kwarg_alias_sources, memo)
         result.api_name = self.api_name
         # 运行时设备语义随 case 副本传播，不能在稳定性或算子对比路径中退回默认设备。
         result.config = self.config
@@ -501,7 +522,10 @@ def analyse_configs(config_path):
 
     api_configs = []
     for config in configs:
-        # print(config)
+        config = config.strip()
+        # 直接消费配置文件的工具也遵循引擎的输入过滤协议。
+        if not config or not config.startswith("paddle."):
+            continue
         api_config = APIConfig(config)
         api_configs.append(api_config)
     return api_configs

--- a/tester/base.py
+++ b/tester/base.py
@@ -13,6 +13,7 @@ import yaml
 from .api_config.dtype_utils import to_torch_dtype
 from .api_config.parameter_binding import bind_input_parameters, split_tensor_method_arguments
 from .input_generation.generation_rules import input_rules
+from .input_generation.input_copy_policy import requires_inplace_input_copy
 from .input_generation.materialization import (
     clear_tensor_configs,
     materialize_config_tree,
@@ -31,7 +32,6 @@ from .reporting.log_schema import MAX_CSV_CONFIG_LENGTH
 from .runtime.gpu_memory_preflight import (
     GpuMemoryDeferred,
     decide_gpu_memory_preflight,
-    requires_inplace_input_copy,
     should_check_grad,
 )
 

--- a/tester/input_generation/backend.py
+++ b/tester/input_generation/backend.py
@@ -323,6 +323,18 @@ class TorchInputBackend:
         self._generator = self._torch_module.Generator(device=self._device)
         self._generator.manual_seed(seed)
 
+    def reset_input_random_state(self, input_random_state):
+        """重置当前 case 的私有 generator，保持跨 case 随机流独立。"""
+        stream_kind = getattr(input_random_state, "stream_kind", "")
+        if not stream_kind.startswith("output_grad:"):
+            stream_kind = "torch"
+        seed = derive_input_seed(
+            getattr(input_random_state, "seed", 0),
+            getattr(input_random_state, "config_fingerprint", ""),
+            stream_kind,
+        )
+        self._generator.manual_seed(seed)
+
     def _torch(self):
         module = getattr(self, "_torch_module", None)
         if module is not None:
@@ -640,6 +652,23 @@ class PaddleInputBackend:
             stream_kind,
         )
         # Paddle 只有设备级默认 generator；初始化私有状态后立即恢复进程原状态。
+        process_state = self._generator.get_state()
+        try:
+            self._generator.manual_seed(seed)
+            self._random_state = self._generator.get_state()
+        finally:
+            self._generator.set_state(process_state)
+
+    def reset_input_random_state(self, input_random_state):
+        """重置当前 case 的设备 generator 快照，不污染进程级随机状态。"""
+        stream_kind = getattr(input_random_state, "stream_kind", "")
+        if not stream_kind.startswith("output_grad:"):
+            stream_kind = "paddle"
+        seed = derive_input_seed(
+            getattr(input_random_state, "seed", 0),
+            getattr(input_random_state, "config_fingerprint", ""),
+            stream_kind,
+        )
         process_state = self._generator.get_state()
         try:
             self._generator.manual_seed(seed)

--- a/tester/input_generation/backend.py
+++ b/tester/input_generation/backend.py
@@ -74,6 +74,8 @@ class InputBackend(Protocol):
 
     def maximum(self, x, y): ...
 
+    def remainder(self, x, y): ...
+
     def abs(self, value): ...
 
     def sort(self, value): ...
@@ -220,6 +222,10 @@ class NumPyInputBackend:
 
     def maximum(self, x, y):
         return numpy.maximum(x, y)
+
+    def remainder(self, x, y):
+        # 统一取模语义，保证 GPU/CPU 生成器的循环 index 行为一致。
+        return numpy.remainder(x, y)
 
     def abs(self, value):
         return numpy.abs(value)
@@ -506,6 +512,11 @@ class TorchInputBackend:
     def maximum(self, x, y):
         torch = self._torch()
         return torch.maximum(self.asarray(x, copy=False), self.asarray(y, copy=False))
+
+    def remainder(self, x, y):
+        # 使用设备端 remainder，避免将大批量 index 拉回 CPU 计算。
+        torch = self._torch()
+        return torch.remainder(self.asarray(x, copy=False), y)
 
     def abs(self, value):
         torch = self._torch()
@@ -864,6 +875,10 @@ class PaddleInputBackend:
             )
             return paddle.cast(result, result_dtype)
         return paddle.maximum(x_tensor, y_tensor)
+
+    def remainder(self, x, y):
+        # Paddle backend 保持与 NumPy/Torch 相同的非负 index 取模结果。
+        return self._paddle().remainder(self.asarray(x, copy=False), y)
 
     def abs(self, value):
         return self._paddle().abs(self.asarray(value, copy=False))

--- a/tester/input_generation/backend_runtime.py
+++ b/tester/input_generation/backend_runtime.py
@@ -142,6 +142,7 @@ class InputBackendRuntime:
     def __init__(self):
         # backend implementation 不持有 cache；clear 后新一轮 prepare 必须重新探测设备。
         self._prepared = {}
+        self._input_backends = {}
         self._cached_numpy_output_grads = {}
         self._output_grad_stream_counters = {}
 
@@ -159,9 +160,23 @@ class InputBackendRuntime:
             return NumPyInputBackend(input_random_state)
         if policy.resolved == "torch":
             # Torch backend 的 device 由 policy 统一决定。
-            return TorchInputBackend(input_random_state, device=device, prepared=prepared)
+            cache_key = (policy.resolved, device)
+            backend = self._input_backends.get(cache_key)
+            if backend is None:
+                backend = TorchInputBackend(input_random_state, device=device, prepared=prepared)
+                self._input_backends[cache_key] = backend
+            else:
+                backend.reset_input_random_state(input_random_state)
+            return backend
         if policy.resolved == "paddle":
-            return PaddleInputBackend(input_random_state, device=device, prepared=prepared)
+            cache_key = (policy.resolved, device)
+            backend = self._input_backends.get(cache_key)
+            if backend is None:
+                backend = PaddleInputBackend(input_random_state, device=device, prepared=prepared)
+                self._input_backends[cache_key] = backend
+            else:
+                backend.reset_input_random_state(input_random_state)
+            return backend
         raise ValueError(f"unsupported input generation backend: {policy.resolved!r}")
 
     def prepare(self, policy):
@@ -191,6 +206,7 @@ class InputBackendRuntime:
     def clear(self):
         """Drop prepared handles and cached output gradients."""
         self._prepared.clear()
+        self._input_backends.clear()
         self._cached_numpy_output_grads.clear()
         self._output_grad_stream_counters.clear()
 

--- a/tester/input_generation/generation_rules.py
+++ b/tester/input_generation/generation_rules.py
@@ -216,14 +216,29 @@ class _InputValueWriter:
         return read_input_value(self._api_config, tensor_config)
 
     def _write_value(self, input_binding, input_value, update_config):
-        # 暂存值始终由 backend 拷贝持有，隔离规则内部后续的原地修改。
-        stored_input_value = self._input_backend.asarray(input_value, copy=True)
+        # Torch 原生随机结果通常是新分配的；转移其所有权可省掉一次 GPU clone。
+        # Paddle 无可靠视图标记，仍保持复制以隔离规则内的原地修改。
+        copy_value = not self._can_transfer_ownership(input_value)
+        stored_input_value = self._input_backend.asarray(input_value, copy=copy_value)
         self._input_value_by_path[input_binding.path] = InputValue(
             input_binding.path,
             stored_input_value,
             self._input_backend.name,
         )
         self._update_config_by_path[input_binding.path] = update_config
+
+    def _can_transfer_ownership(self, input_value):
+        """判断值是否可由 writer 独占，避免破坏规则的别名隔离。"""
+        backend_name = self._input_backend.name
+        if backend_name != "torch":
+            return False
+        # 同一对象已被其他路径保存时，后续写入必须建立独立 storage。
+        if any(item.generated_value is input_value for item in self._input_value_by_path.values()):
+            return False
+        # 视图共享底层 storage，转移视图会让调用方仍可原地改变已保存输入。
+        if getattr(input_value, "_base", None) is not None:
+            return False
+        return True
 
 
 class InputRuleContext:

--- a/tester/input_generation/generation_rules.py
+++ b/tester/input_generation/generation_rules.py
@@ -2007,6 +2007,14 @@ def generate_repeat_interleave_inputs(rule: InputRuleContext):
 def generate_put_along_axis_inputs(rule: InputRuleContext):
     """输入规则：按输入 shape 与 axis 生成合法 indices 和相容 values。"""
 
+    def generate_unique_indices(dim_size, width, prefix_shape=()):
+        """用随机循环偏移批量生成每个切片内无重复的 index。"""
+        if width == 0:
+            return rule.ops.zeros(prefix_shape + (0,), dtype="int64")
+        offsets = rule.ops.randint(0, dim_size, shape=prefix_shape + (1,))
+        base = rule.ops.arange(width, dtype="int64")
+        return rule.ops.remainder(offsets + base, dim_size)
+
     def generate_random_tensor_input_value(input_binding, shape):
         scalar_spec = InputTensorSpec(
             shape=tuple(shape),
@@ -2029,9 +2037,11 @@ def generate_put_along_axis_inputs(rule: InputRuleContext):
                 if axis < len(current_shape):
                     dim_size = x_shape[axis]
                     if dim_size > 0:
-                        axis_indices = rule.ops.choice(
-                            dim_size, shape=new_shape[axis], replace=False
-                        )
+                        width = new_shape[axis]
+                        if width <= dim_size:
+                            axis_indices = generate_unique_indices(dim_size, width)
+                        else:
+                            axis_indices = rule.ops.choice(dim_size, shape=width, replace=False)
                         axis_indices = rule.ops.cast(axis_indices, "int64")
                         idx_tuple = tuple(
                             [slice(None)] * axis
@@ -2052,8 +2062,11 @@ def generate_put_along_axis_inputs(rule: InputRuleContext):
             return indices
         if 0 <= axis < x_dims:
             dim_size = x_shape[axis]
+            width = current_shape[-1]
+            if width <= dim_size:
+                return generate_unique_indices(dim_size, width, current_shape[:-1])
             for idx in rule.ops.ndindex(tuple(current_shape[:-1])):
-                indices[idx] = rule.ops.choice(dim_size, shape=current_shape[-1], replace=False)
+                indices[idx] = rule.ops.choice(dim_size, shape=width, replace=False)
         return indices
 
     def write_related_input_values(input_binding):

--- a/tester/input_generation/input_copy_policy.py
+++ b/tester/input_generation/input_copy_policy.py
@@ -1,0 +1,15 @@
+"""输入物化阶段的原地修改隔离策略。"""
+
+from __future__ import annotations
+
+
+def requires_inplace_input_copy(api_config):
+    """判断 API 是否可能原地修改输入，因此必须断开框架间 storage。"""
+    # 判定需与 accuracy 的 build_*_input 生命周期保持一致，避免输入别名泄漏。
+    api_name = getattr(api_config, "api_name", "")
+    return (api_name.endswith("_") and not api_name.endswith("__")) or api_name == (
+        "paddle.Tensor.__setitem__"
+    )
+
+
+__all__ = ["requires_inplace_input_copy"]

--- a/tester/input_generation/tensor_config.py
+++ b/tester/input_generation/tensor_config.py
@@ -8,6 +8,7 @@ import paddle
 import yaml
 from tester.api_config.dtype_utils import to_torch_dtype
 
+from .input_copy_policy import requires_inplace_input_copy
 from .values import clear_input_value, read_input_value, read_input_value_backend
 
 
@@ -277,8 +278,12 @@ class TensorConfig:
                 value = paddle.cast(value, dtype=dtype)
             return value
         if backend == "torch" and isinstance(value, torch.Tensor):
-            torch_tensor = value.detach().to(
-                device=self._torch_source_device_for_paddle(api_config)
+            source_device = self._torch_source_device_for_paddle(api_config)
+            # 设备已经一致时避免再次调用 to；DLPack 后续仍负责框架间共享。
+            torch_tensor = (
+                value.detach()
+                if value.device == source_device
+                else value.detach().to(device=source_device)
             )
             paddle_tensor = paddle.utils.dlpack.from_dlpack(
                 torch.utils.dlpack.to_dlpack(torch_tensor)
@@ -437,7 +442,11 @@ class TensorConfig:
         value = read_input_value(api_config, self)
         backend = read_input_value_backend(api_config, self)
         if backend == "torch" and isinstance(value, torch.Tensor):
-            tensor = value.to(device=device, dtype=dtype)
+            # 同设备同 dtype 只需解除生成阶段的梯度关联，避免无意义的 to/copy。
+            if value.device == device and value.dtype == dtype:
+                tensor = value.detach()
+            else:
+                tensor = value.to(device=device, dtype=dtype)
             if requires_grad:
                 tensor = tensor.detach().requires_grad_(True)
             return tensor
@@ -447,11 +456,12 @@ class TensorConfig:
                 paddle_tensor = paddle_tensor._copy_to(paddle.CUDAPlace(device.index or 0), False)
             elif device.type == "cpu":
                 paddle_tensor = paddle_tensor._copy_to(paddle.CPUPlace(), False)
-            tensor = torch.utils.dlpack.from_dlpack(
-                paddle.utils.dlpack.to_dlpack(paddle_tensor)
-            ).to(device=device, dtype=dtype)
-            # DLPack avoids NumPy, then clone so Torch accuracy owns its input storage.
-            tensor = tensor.clone()
+            tensor = torch.utils.dlpack.from_dlpack(paddle.utils.dlpack.to_dlpack(paddle_tensor))
+            if tensor.device != device or tensor.dtype != dtype:
+                tensor = tensor.to(device=device, dtype=dtype)
+            # 原地 API 必须与 Paddle 输入隔离；其他 API 直接共享 DLPack storage。
+            if requires_inplace_input_copy(api_config):
+                tensor = tensor.clone()
             if requires_grad:
                 tensor = tensor.detach().requires_grad_(True)
             return tensor

--- a/tester/input_generation/tensor_config.py
+++ b/tester/input_generation/tensor_config.py
@@ -143,7 +143,8 @@ class TensorConfig:
         memo[id(self)] = result
         result.shape = copy.deepcopy(self.shape)
         result.dtype = copy.deepcopy(self.dtype)
-        result.place = copy.deepcopy(self.place)
+        # Paddle Place 是不可变运行时句柄；旧版本无法 pickle，副本可共享其设备语义。
+        result.place = self.place
         result.is_contiguous = self.is_contiguous
         result.strides = copy.deepcopy(self.strides)
         result.paddle_tensor = None

--- a/tester/reporting/log_report.py
+++ b/tester/reporting/log_report.py
@@ -16,6 +16,13 @@ def _single_line(value):
     return str(value).replace("\r", "\\r").replace("\n", "\\n")
 
 
+def _display_option_value(value):
+    """用稳定的单行格式展示列表参数，避免打印 Python list 语法。"""
+    if isinstance(value, (list, tuple)):
+        return ", ".join(_single_line(item) for item in value)
+    return _single_line(value)
+
+
 def format_duration(seconds):
     """按运行时长选择秒、分钟或小时单位。"""
     if seconds >= 3600:
@@ -211,14 +218,11 @@ def print_run_header(options, paddle_version):
         "custom_device_vs_gpu",
     )
     mode = next(name for name in modes if getattr(options, name))
+    source_option = ("--retest", options.retest)
     if options.api_config:
         source_option = ("--api_config", options.api_config)
     elif options.api_config_file:
         source_option = ("--api_config_file", options.api_config_file)
-    elif getattr(options, "retest", ""):
-        source_option = ("--retest", options.retest)
-    else:
-        source_option = ("--api_config_file_pattern", options.api_config_file_pattern)
 
     timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S.%f")[:-3]
     print(f">>> TEST RUN | {timestamp} | PID {os.getpid()}")
@@ -288,7 +292,9 @@ def print_run_header(options, paddle_version):
     for group_name, group_options in groups:
         print(group_name)
         for name, value in group_options:
-            display_value = str(value).lower() if isinstance(value, bool) else value
+            display_value = (
+                str(value).lower() if isinstance(value, bool) else _display_option_value(value)
+            )
             print(f"  {name}: {display_value}")
 
 

--- a/tester/runtime/config_file_loader.py
+++ b/tester/runtime/config_file_loader.py
@@ -1,0 +1,43 @@
+"""Resolve API configuration file inputs shared by both engine entrypoints."""
+
+from __future__ import annotations
+
+import glob
+import os
+from pathlib import Path
+
+
+def resolve_config_files(inputs: str | list[str]) -> list[str]:
+    """Expand files, directories, and glob patterns into unique paths."""
+    resolved: list[str] = []
+    seen: set[str] = set()
+    # 逗号只用于命令行输入集合，单个路径仍可通过显式文件路径传入。
+    raw_inputs = [inputs] if isinstance(inputs, str) else inputs
+    expanded_inputs = [part.strip() for item in raw_inputs for part in str(item).split(",")]
+    for raw_input in expanded_inputs:
+        value = str(raw_input).strip()
+        if not value:
+            raise ValueError("--api_config_file 不允许为空输入")
+        path = Path(value)
+        if path.is_dir():
+            # 目录只展开当前层 txt，递归范围必须由 ** glob 明确表达。
+            candidates = sorted(path.glob("*.txt"))
+            if not candidates:
+                raise FileNotFoundError(f"目录中没有配置文件: {value}")
+        elif path.is_file():
+            candidates = [path]
+        elif glob.has_magic(value):
+            candidates = [Path(item) for item in glob.glob(value, recursive=True)]
+            candidates = [item for item in sorted(candidates) if item.is_file()]
+            if not candidates:
+                raise FileNotFoundError(f"配置输入没有匹配文件: {value}")
+        else:
+            raise FileNotFoundError(f"No config file found: {value}")
+        for candidate in candidates:
+            normalized = os.path.abspath(os.fspath(candidate))
+            if normalized not in seen:
+                seen.add(normalized)
+                resolved.append(normalized)
+    if not resolved:
+        raise FileNotFoundError("--api_config_file 没有解析出配置文件")
+    return resolved

--- a/tester/runtime/gpu_memory_preflight.py
+++ b/tester/runtime/gpu_memory_preflight.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
+from ..input_generation.input_copy_policy import requires_inplace_input_copy
 from ..input_generation.materialization import (
     build_materialization_plan,
     generated_value_nbytes,
@@ -158,14 +159,6 @@ def _framework_live_input_bytes(config):
     if not _is_gpu_input(config):
         return 0
     return config.nbytes(storage=True)
-
-
-def requires_inplace_input_copy(api_config):
-    # 与 build_*_input 的 API 判断保持同一协议，避免预检和执行路径分叉。
-    api_name = getattr(api_config, "api_name", "")
-    return (api_name.endswith("_") and not api_name.endswith("__")) or api_name == (
-        "paddle.Tensor.__setitem__"
-    )
 
 
 def _framework_materialization(


### PR DESCRIPTION
## 🧭 背景

本分支相对 `upstream/main` 包含运行入口、配置预处理和 GPU 测试链路的连续修复。GPU 批量测试在设备初始化失败时可能反复复活不可用的 slot，导致批次无法完整结束却保留成功退出状态。与此同时，accuracy 和 paddleonly 模式的输入生成会为每个 case 重建 backend，并在框架物化过程中产生重复的 GPU 拷贝；`put_along_axis` 的合法无重复索引也会对每个切片逐个调用随机选择。

## 🔎 问题定位

设备级 CUDA 不可用或设备丢失错误此前没有进入持久化隔离路径，受影响的物理卡仍可能被调度器重新使用。输入生成路径则缺少明确的 storage 所有权策略：原生 Torch 结果会被无条件复制，Paddle/Torch 跨框架转换也会在不需要时 clone，backend 和随机 generator 初始化成本则重复发生在每个 case。

## 🛠️ 实现方案

GPU 调度器新增物理卡 quarantine 状态。识别设备不可用类错误后，隔离受影响卡及其关联 slot；调度、启动和批次收尾逻辑都会尊重该状态，并在业务终态未覆盖全部 case 时返回失败。

输入生成按 backend/device 复用 worker 级 backend，每个 case 重新绑定派生随机种子，保持 case 间随机流隔离。Tensor 物化区分同设备 no-op、跨框架共享和原地修改隔离：可安全转移所有权的 Torch 原生结果不再 clone，原地 API 保留独立 storage；Paddle view 无可靠标记时继续采用保守复制策略。

对于 `put_along_axis` 中请求宽度不超过维度大小的索引，使用设备端随机起点加循环偏移构造无重复索引，减少逐切片随机选择；超出范围或无法满足约束时继续走原有选择路径。

配置入口统一支持配置文件、目录和列表输入，补充 schema、去重、抽取 API 集合及 0-size 配置预处理；相关文档和 V2/V4 脚本同步到统一入口。

## 🔧 主要变更

### 1. GPU 故障隔离

识别 CUDA device unavailable/device lost 初始化错误并隔离物理卡，阻止关联 slot 重新调度；批次结束时检查已完成业务终态数量，避免不完整批次被报告为成功。

### 2. 输入 backend 与 storage 优化

复用 Torch/Paddle 输入 backend 和 generator，按 case 重置随机状态；减少同设备同 dtype 转换、重复 GPU clone 及非必要的 DLPack 转换。原地 API 使用统一策略判断，保持 Paddle/Torch 输入隔离语义。

### 3. 索引生成优化

为 backend 增加统一 remainder 操作，将满足条件的 `put_along_axis` 唯一索引生成改为设备端向量化计算，同时保留动态 shape 和非法范围的兼容路径。

### 4. 配置与入口统一

扩展配置文件加载和校验，统一 CLI、运行脚本及预处理流水线的输入形式，补充配置去重、API 集合提取和 0-size 配置生成能力，并同步 CLI/引擎文档。

## 📁 改动文件

| 类别 | 文件 | 功能说明 |
| --- | --- | --- |
| 调度 | `engineV4.py` | GPU quarantine、slot 调度和批次完整性处理 |
| 输入 backend | `tester/input_generation/backend.py` | backend remainder 操作、随机状态重置 |
| 输入 backend | `tester/input_generation/backend_runtime.py` | worker 级 backend 缓存与生命周期清理 |
| 输入规则 | `tester/input_generation/generation_rules.py` | ownership 策略和 `put_along_axis` 向量化索引 |
| 输入物化 | `tester/input_generation/tensor_config.py` | 同设备 no-op、DLPack 共享和原地复制策略 |
| 复制策略 | `tester/input_generation/input_copy_policy.py` | 统一原地输入复制判定 |
| 预检 | `tester/runtime/gpu_memory_preflight.py` | 复用统一的原地输入复制协议 |
| 测试基类 | `tester/base.py` | 使用统一输入复制判定 |
| 配置加载 | `tester/api_config/parser.py`, `tester/runtime/config_file_loader.py` | 统一配置文件、目录和列表输入 |
| 配置流水线 | `test_pipeline/config_preprocess/`, `test_pipeline/run_pipeline.sh` | 配置去重、API 集合提取和 0-size 生成 |
| 入口文档 | `README.md`, `docs/`, `run.py`, `run-example.sh`, `test_pipeline/V2/`, `test_pipeline/V4/` | 同步 CLI 和脚本入口 |
