### PR TITLE
测试修复：🐛 修复测试运行互斥、错误阶段记录与 CASE 日志恢复

### DIFF
--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -203,13 +203,13 @@ python run.py [-c CONFIG] [OVERRIDES] [ENGINE_OPTIONS]
 
 顶层键为 `name`、`runner`、`env`、`input`、`output`、`retest`、`engine_args`。
 
-- `runner`：`engine`、`foreground`、`dry_run`、`pid_file`。
+- `runner`：`engine`、`foreground`、`dry_run`。
 - `input`：`api_config`、`api_config_file` 二选一。
 - `output`：`log_dir`。
 - `retest`：`enabled`、`rounds`、`error_configs`、`log_dir_template`、`skip_unavailable`。
 - `engine_args`：去掉 `--` 的 engineV4 参数名。
 
-所有字符串都经 `os.path.expandvars` 展开，支持 `${VAR}` 和 `$VAR`；未设置的变量保持原文。
+后台任务的 PID 文件固定为 `output.log_dir/.paddleapitest.pid`，同一输出目录的不同配置或脚本共享互斥状态；对应锁文件为同目录下的 `.paddleapitest.pid.lock`。`run-example.sh` 和 `test_pipeline/V4/*.sh` 使用相同约定。所有字符串都经 `os.path.expandvars` 展开，支持 `${VAR}` 和 `$VAR`；未设置的变量保持原文。
 
 ## 环境变量
 

--- a/engineV4.py
+++ b/engineV4.py
@@ -1019,18 +1019,13 @@ def _init_worker_runtime(
     prepare_runtime=True,
     redirect_output=False,
 ):
-    init_log(options.log_dir)
+    # worker 只初始化日志分片；聚合恢复和状态提交由主进程独占。
+    init_log(options.log_dir, reset_aggregation=False)
 
     if gpu_id is not None:
         os.environ["CUDA_VISIBLE_DEVICES"] = _visible_gpu_ids(gpu_id, comparison_gpu_id)
         workers_on_gpu = (getattr(options, "gpu_workers_per_gpu_map", {}) or {}).get(gpu_id, 1)
         os.environ["PADDLEAPITEST_WORKERS_ON_GPU"] = str(workers_on_gpu)
-        # 多 worker 小 case 时收敛 Torch CPU 线程，避免线程数随进程数成倍过订阅。
-        if int(workers_on_gpu) > 1:
-            os.environ.setdefault(
-                "PADDLEAPITEST_TORCH_NUM_THREADS",
-                str(max(1, 8 // int(workers_on_gpu))),
-            )
     if slot_index is not None and gpu_id is not None:
         # backend 导入和准备阶段即可读取稳定 slot，复活 worker 也遵循同一初始化协议。
         os.environ["PADDLEAPITEST_WORKER_SLOT"] = str(slot_index)
@@ -1271,7 +1266,7 @@ def _sanitizer_worker_loop(
     result_queue,
     options,
 ):
-    init_log(options.log_dir)
+    init_log(options.log_dir, reset_aggregation=False)
     log_worker.redirect_stdio()
 
     sanitizer_cmd = getattr(options, "sanitizer_cmd", None) or shlex.split(

--- a/engineV4.py
+++ b/engineV4.py
@@ -1025,6 +1025,12 @@ def _init_worker_runtime(
         os.environ["CUDA_VISIBLE_DEVICES"] = _visible_gpu_ids(gpu_id, comparison_gpu_id)
         workers_on_gpu = (getattr(options, "gpu_workers_per_gpu_map", {}) or {}).get(gpu_id, 1)
         os.environ["PADDLEAPITEST_WORKERS_ON_GPU"] = str(workers_on_gpu)
+        # 多 worker 小 case 时收敛 Torch CPU 线程，避免线程数随进程数成倍过订阅。
+        if int(workers_on_gpu) > 1:
+            os.environ.setdefault(
+                "PADDLEAPITEST_TORCH_NUM_THREADS",
+                str(max(1, 8 // int(workers_on_gpu))),
+            )
     if slot_index is not None and gpu_id is not None:
         # backend 导入和准备阶段即可读取稳定 slot，复活 worker 也遵循同一初始化协议。
         os.environ["PADDLEAPITEST_WORKER_SLOT"] = str(slot_index)

--- a/run-example.sh
+++ b/run-example.sh
@@ -126,16 +126,30 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SCRIPT_FILE="${BASH_SOURCE[0]##*/}"
 SCRIPT_NAME="${SCRIPT_FILE%.sh}"
 RUN_COMMAND="./${SCRIPT_FILE}"
-PID_FILE="${SCRIPT_DIR}/.${SCRIPT_NAME}.pid"
+mkdir -p "$LOG_DIR" || {
+    echo "[错误] 无法创建日志目录 | 日志 $LOG_DIR"
+    exit 1
+}
+LOG_DIR="$(cd "$LOG_DIR" && pwd -P)"
+# 输出目录锁定任务身份，脚本名不参与互斥。
+PID_FILE="${LOG_DIR}/.paddleapitest.pid"
+LOCK_FILE="${PID_FILE}.lock"
+exec 9>"$LOCK_FILE"
+# 启动、停止和清理共用此锁，防止状态竞态。
 
 # ── 运维命令处理 ──
 case "${1:-}" in
     --stop)
+        flock -x 9
         if [[ -f "$PID_FILE" ]]; then
             pid=$(cat "$PID_FILE")
             if kill -0 "$pid" 2>/dev/null; then
                 # Kill entire process group (main + all workers)
                 kill -- -"$pid" 2>/dev/null || kill "$pid" 2>/dev/null
+                for _ in {1..30}; do
+                    kill -0 "$pid" 2>/dev/null || break
+                    sleep 0.1
+                done
                 echo ">>> 终止任务 | 已终止 | PGID $pid"
             else
                 echo ">>> 终止任务 | 已结束 | PID $pid"
@@ -147,6 +161,7 @@ case "${1:-}" in
         exit 0
         ;;
     --status)
+        flock -x 9
         if [[ -f "$PID_FILE" ]]; then
             pid=$(cat "$PID_FILE")
             if kill -0 "$pid" 2>/dev/null; then
@@ -184,6 +199,7 @@ case "${1:-}" in
 esac
 
 # ── 防重复启动 ──
+flock -x 9
 if [[ -f "$PID_FILE" ]]; then
     old_pid=$(cat "$PID_FILE")
     if kill -0 "$old_pid" 2>/dev/null; then
@@ -283,6 +299,7 @@ mkdir -p "$LOG_DIR" || {
 
 # ── 启动 ──
 if [[ "$FOREGROUND" == "true" ]]; then
+    flock -u 9
     echo "开始    日志目录 $LOG_DIR | Ctrl+C 终止"
     # 忽略 shell 自身的 SIGINT，让 Ctrl+C 只作用于 python 子进程
     trap '' INT
@@ -292,6 +309,7 @@ else
     nohup setsid python "$ENGINE.py" "${ALL_ARGS[@]}" >/dev/null 2>&1 &
     PYTHON_PID=$!
     echo "$PYTHON_PID" > "$PID_FILE"
+    flock -u 9
 
     # 任务自然结束时清理 PID 文件；若已启动新任务，则不误删新 PID。
     (
@@ -299,10 +317,10 @@ else
             sleep 5
         done
 
+        exec 9>"$LOCK_FILE"
+        flock -x 9
         recorded_pid="$(cat "$PID_FILE" 2>/dev/null || true)"
-        if [[ "$recorded_pid" == "$PYTHON_PID" ]]; then
-            rm -f "$PID_FILE"
-        fi
+        [[ "$recorded_pid" == "$PYTHON_PID" ]] && rm -f "$PID_FILE"
     ) >/dev/null 2>&1 &
 
     sleep 1

--- a/run-example.sh
+++ b/run-example.sh
@@ -315,5 +315,6 @@ else
     LOG_FILE="$(ls -t "$LOG_DIR"/log_[0-9]*.log 2>/dev/null | head -1 || true)"
     echo "已启动  PID $PYTHON_PID | 日志 ${LOG_FILE:-$LOG_DIR}"
     echo "管理    状态: ${RUN_COMMAND} --status | 终止: ${RUN_COMMAND} --stop"
-    [[ -n "$LOG_FILE" ]] && echo "跟踪    tail -f $LOG_FILE"
+    # 日志文件可能尚未创建，仍展示固定的跟踪入口供后续使用。
+    echo "跟踪    tail -f $LOG_FILE"
 fi

--- a/run.py
+++ b/run.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import argparse
 import copy
+import fcntl
 import os
 import shlex
 import shutil
@@ -9,6 +10,8 @@ import signal
 import subprocess
 import sys
 import time
+from collections.abc import Iterator
+from contextlib import contextmanager
 from pathlib import Path
 from typing import Any
 
@@ -32,7 +35,7 @@ DEFAULT_RETEST_ERROR_CONFIGS = [
 ]
 
 TOP_LEVEL_KEYS = {"name", "runner", "env", "input", "output", "retest", "engine_args"}
-RUNNER_KEYS = {"engine", "foreground", "dry_run", "pid_file"}
+RUNNER_KEYS = {"engine", "foreground", "dry_run"}
 INPUT_KEYS = {"api_config", "api_config_file"}
 OUTPUT_KEYS = {"log_dir"}
 RETEST_KEYS = {
@@ -124,9 +127,6 @@ def validate_yaml_config(config: dict[str, Any]) -> None:
     for key in ("foreground", "dry_run"):
         if key in runner:
             require_type(f"runner.{key}", runner[key], bool)
-    if "pid_file" in runner:
-        require_type("runner.pid_file", runner["pid_file"], str)
-
     env = ensure_mapping(config, "env")
     for key, value in env.items():
         if not isinstance(key, str):
@@ -263,10 +263,9 @@ def display_path(path: Path) -> str:
         return str(path)
 
 
-def default_pid_file(config_path: Path, config: dict[str, Any]) -> Path:
-    name = str(config.get("name") or config_path.stem)
-    safe_name = "".join(char if char.isalnum() or char in "._-" else "_" for char in name)
-    return PROJECT_ROOT / ".run" / f"{safe_name}.pid"
+def pid_file_for_log_dir(log_dir: Path) -> Path:
+    """将任务身份固定在实际写入的输出目录，而不是调用它的脚本。"""
+    return log_dir / ".paddleapitest.pid"
 
 
 def set_input_config(input_config: dict[str, Any], key: str, value: Any) -> None:
@@ -317,7 +316,7 @@ def apply_overrides(config: dict[str, Any], args: argparse.Namespace) -> None:
         engine_args[key.replace("-", "_")] = parse_engine_value(value)
 
 
-def validate_config(config_path: Path, config: dict[str, Any]) -> tuple[str, Path, Path]:
+def validate_config(config_path: Path, config: dict[str, Any]) -> tuple[str, Path]:
     if not (PROJECT_ROOT / "tester").is_dir():
         raise RuntimeError(f"请在 PaddleAPITest 项目根目录附近执行，未找到 tester/: {PROJECT_ROOT}")
 
@@ -344,13 +343,7 @@ def validate_config(config_path: Path, config: dict[str, Any]) -> tuple[str, Pat
     if not log_dir:
         raise ValueError("output.log_dir 不能为空")
 
-    pid_file_value = runner.get("pid_file")
-    pid_file = (
-        resolve_project_path(pid_file_value)
-        if pid_file_value
-        else default_pid_file(config_path, config)
-    )
-    return str(engine), engine_path, pid_file
+    return str(engine), engine_path
 
 
 def build_engine_command(engine: str, config: dict[str, Any], passthrough: list[str]) -> list[str]:
@@ -472,25 +465,59 @@ def process_running(pid: int) -> bool:
     return True
 
 
-def stop_process(pid_file: Path) -> int:
-    pid = read_pid(pid_file)
-    if pid is None:
-        print(">>> 终止任务 | 无记录")
-        return 0
-    if process_running(pid):
+@contextmanager
+def pid_file_lock(pid_file: Path) -> Iterator[None]:
+    """串行化同一输出目录的 PID 检查、启动、停止与回收。"""
+    pid_file.parent.mkdir(parents=True, exist_ok=True)
+    lock_file = pid_file.with_name(f"{pid_file.name}.lock")
+    with lock_file.open("a", encoding="utf-8") as lock:
+        fcntl.flock(lock.fileno(), fcntl.LOCK_EX)
         try:
-            os.killpg(pid, signal.SIGTERM)
-        except ProcessLookupError:
-            pass
-        except OSError:
+            yield
+        finally:
+            fcntl.flock(lock.fileno(), fcntl.LOCK_UN)
+
+
+def clear_pid_if_matches(pid_file: Path, pid: int) -> None:
+    """只回收自身记录，避免结束的旧任务删除新任务的 PID。"""
+    with pid_file_lock(pid_file):
+        if read_pid(pid_file) == pid:
+            pid_file.unlink(missing_ok=True)
+
+
+def wait_for_process_exit(pid: int, timeout: float = 3.0) -> bool:
+    """停止信号发出后短暂等待旧进程退出，避免新任务与旧任务重叠写目录。"""
+    deadline = time.monotonic() + timeout
+    while process_running(pid) and time.monotonic() < deadline:
+        time.sleep(0.1)
+    return not process_running(pid)
+
+
+def stop_process(pid_file: Path) -> int:
+    with pid_file_lock(pid_file):
+        pid = read_pid(pid_file)
+        if pid is None:
+            print(">>> 终止任务 | 无记录")
+            return 0
+        if process_running(pid):
             try:
-                os.kill(pid, signal.SIGTERM)
+                os.killpg(pid, signal.SIGTERM)
             except ProcessLookupError:
                 pass
-        print(f">>> 终止任务 | 已终止 | PGID {pid}")
-    else:
-        print(f">>> 终止任务 | 已结束 | PID {pid}")
-    pid_file.unlink(missing_ok=True)
+            except OSError:
+                try:
+                    os.kill(pid, signal.SIGTERM)
+                except ProcessLookupError:
+                    pass
+            if not wait_for_process_exit(pid):
+                try:
+                    os.killpg(pid, signal.SIGKILL)
+                except ProcessLookupError:
+                    pass
+            print(f">>> 终止任务 | 已终止 | PGID {pid}")
+        else:
+            print(f">>> 终止任务 | 已结束 | PID {pid}")
+        pid_file.unlink(missing_ok=True)
     return 0
 
 
@@ -507,31 +534,34 @@ def latest_log(log_dir: Path) -> Path | None:
 
 
 def show_status(pid_file: Path, engine: str, log_dir: Path) -> int:
-    pid = read_pid(pid_file)
-    if pid is None:
-        print(">>> 运行状态 | 无记录")
-        print(f"PID文件  {display_path(pid_file)}")
-        return 0
-    if not process_running(pid):
-        print(">>> 运行状态 | 已结束")
-        print(f"进程    PID {pid}")
-        pid_file.unlink(missing_ok=True)
-        return 0
+    with pid_file_lock(pid_file):
+        pid = read_pid(pid_file)
+        if pid is None:
+            print(">>> 运行状态 | 无记录")
+            print(f"PID文件  {display_path(pid_file)}")
+            return 0
+        if not process_running(pid):
+            print(">>> 运行状态 | 已结束")
+            print(f"进程    PID {pid}")
+            pid_file.unlink(missing_ok=True)
+            return 0
 
-    try:
-        children_output = subprocess.check_output(["pgrep", "-P", str(pid)], text=True)
-        children = sum(1 for line in children_output.splitlines() if line.strip())
-    except subprocess.CalledProcessError:
-        children = 0
-    try:
-        elapsed = subprocess.check_output(["ps", "-o", "etime=", "-p", str(pid)], text=True).strip()
-    except subprocess.CalledProcessError:
-        elapsed = "未知"
-    log = latest_log(log_dir)
-    print(">>> 运行状态 | 运行中")
-    print(f"进程    PID {pid} | {engine}.py | Worker {children} | 已运行 {elapsed}")
-    if log:
-        print(f"日志    {display_path(log)}")
+        try:
+            children_output = subprocess.check_output(["pgrep", "-P", str(pid)], text=True)
+            children = sum(1 for line in children_output.splitlines() if line.strip())
+        except subprocess.CalledProcessError:
+            children = 0
+        try:
+            elapsed = subprocess.check_output(
+                ["ps", "-o", "etime=", "-p", str(pid)], text=True
+            ).strip()
+        except subprocess.CalledProcessError:
+            elapsed = "未知"
+        log = latest_log(log_dir)
+        print(">>> 运行状态 | 运行中")
+        print(f"进程    PID {pid} | {engine}.py | Worker {children} | 已运行 {elapsed}")
+        if log:
+            print(f"日志    {display_path(log)}")
     return 0
 
 
@@ -540,22 +570,23 @@ def prepare_log_dir(log_dir: Path) -> Path:
     return log_dir
 
 
-def cleanup_pid_when_done(pid: int, pid_file: Path) -> None:
-    while process_running(pid):
-        time.sleep(5)
-    recorded_pid = read_pid(pid_file)
-    if recorded_pid == pid:
-        pid_file.unlink(missing_ok=True)
-
-
-def run_foreground(command: list[str], env: dict[str, str], log_dir: Path) -> int:
+def run_foreground(
+    command: list[str], env: dict[str, str], log_dir: Path, pid_file: Path, manage_command: str
+) -> int:
     print(f"开始    日志目录 {display_path(log_dir)} | Ctrl+C 终止")
-    process = subprocess.Popen(
-        command,
-        cwd=PROJECT_ROOT,
-        env=env,
-        start_new_session=True,
-    )
+    with pid_file_lock(pid_file):
+        old_pid = read_pid(pid_file)
+        if old_pid and process_running(old_pid):
+            print(f"[警告] 输出目录任务已在运行 | PID {old_pid} | 终止 {manage_command} --stop")
+            return 1
+        pid_file.unlink(missing_ok=True)
+        process = subprocess.Popen(
+            command,
+            cwd=PROJECT_ROOT,
+            env=env,
+            start_new_session=True,
+        )
+        pid_file.write_text(f"{process.pid}\n", encoding="utf-8")
     try:
         return process.wait()
     except KeyboardInterrupt:
@@ -581,6 +612,8 @@ def run_foreground(command: list[str], env: dict[str, str], log_dir: Path) -> in
                 process.wait()
         shutil.rmtree(log_dir / ".tmp", ignore_errors=True)
         return 130 if process.returncode is None or process.returncode < 0 else process.returncode
+    finally:
+        clear_pid_if_matches(pid_file, process.pid)
 
 
 def run_background(
@@ -591,26 +624,26 @@ def run_background(
     engine: str,
     manage_command: str,
 ) -> int:
-    if pid_file.exists():
+    with pid_file_lock(pid_file):
         old_pid = read_pid(pid_file)
         if old_pid and process_running(old_pid):
-            print(f"[警告] 任务已在运行 | PID {old_pid} | 终止 {manage_command} --stop")
+            print(f"[警告] 输出目录任务已在运行 | PID {old_pid} | 终止 {manage_command} --stop")
             return 1
         pid_file.unlink(missing_ok=True)
 
-    pid_file.parent.mkdir(parents=True, exist_ok=True)
-    process = subprocess.Popen(
-        command,
-        cwd=PROJECT_ROOT,
-        env=env,
-        stdout=subprocess.DEVNULL,
-        stderr=subprocess.DEVNULL,
-        start_new_session=True,
-    )
-    pid_file.write_text(f"{process.pid}\n", encoding="utf-8")
+        process = subprocess.Popen(
+            command,
+            cwd=PROJECT_ROOT,
+            env=env,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            start_new_session=True,
+        )
+        pid_file.write_text(f"{process.pid}\n", encoding="utf-8")
 
     cleaner_code = (
-        "import os,sys,time\npid=int(sys.argv[1])\npid_file=sys.argv[2]\n"
+        "import fcntl,os,sys,time\npid=int(sys.argv[1])\npid_file=sys.argv[2]\n"
+        "lock_file=sys.argv[3]\n"
         "while True:\n"
         "    try:\n"
         "        os.kill(pid, 0)\n"
@@ -619,18 +652,27 @@ def run_background(
         "    except PermissionError:\n"
         "        pass\n"
         "    time.sleep(5)\n"
-        "try:\n"
-        "    recorded=open(pid_file).read().strip()\n"
-        "except FileNotFoundError:\n"
-        "    recorded=''\n"
-        "if recorded == str(pid):\n"
+        "with open(lock_file, 'a') as lock:\n"
+        "    fcntl.flock(lock.fileno(), fcntl.LOCK_EX)\n"
         "    try:\n"
-        "        os.remove(pid_file)\n"
+        "        recorded=open(pid_file).read().strip()\n"
         "    except FileNotFoundError:\n"
-        "        pass\n"
+        "        recorded=''\n"
+        "    if recorded == str(pid):\n"
+        "        try:\n"
+        "            os.remove(pid_file)\n"
+        "        except FileNotFoundError:\n"
+        "            pass\n"
     )
     subprocess.Popen(
-        [sys.executable, "-c", cleaner_code, str(process.pid), str(pid_file)],
+        [
+            sys.executable,
+            "-c",
+            cleaner_code,
+            str(process.pid),
+            str(pid_file),
+            str(pid_file.with_name(f"{pid_file.name}.lock")),
+        ],
         stdout=subprocess.DEVNULL,
         stderr=subprocess.DEVNULL,
         start_new_session=True,
@@ -639,7 +681,7 @@ def run_background(
     time.sleep(1)
     if not process_running(process.pid):
         print(f"[错误] 启动失败 | {engine}.py | 日志目录 {display_path(log_dir)}")
-        pid_file.unlink(missing_ok=True)
+        clear_pid_if_matches(pid_file, process.pid)
         return 1
 
     log_file = latest_log(log_dir)
@@ -714,11 +756,12 @@ def run_once(
     force_foreground: bool = False,
     label: str | None = None,
 ) -> int:
-    engine, _engine_path, pid_file = validate_config(config_path, config)
+    engine, _engine_path = validate_config(config_path, config)
     output = ensure_mapping(config, "output")
     runner = ensure_mapping(config, "runner")
     env_config = ensure_mapping(config, "env")
     log_dir = resolve_project_path(output["log_dir"])
+    pid_file = pid_file_for_log_dir(log_dir)
     command = build_engine_command(engine, config, passthrough)
 
     env = os.environ.copy()
@@ -764,9 +807,9 @@ def run_once(
         if arg != "--" and arg.partition("=")[0] not in hidden_options
     ]
     print(f"参数    {' | '.join(display_args)}")
-    if foreground:
-        return run_foreground(command, env, log_dir)
     manage_command = f"python run.py -c {shlex.quote(display_path(config_path))}"
+    if foreground:
+        return run_foreground(command, env, log_dir, pid_file, manage_command)
     return run_background(command, env, log_dir, pid_file, engine, manage_command)
 
 
@@ -845,10 +888,11 @@ def main() -> int:
     config = load_yaml(config_path)
     apply_overrides(config, args)
     validate_yaml_config(config)
-    engine, _engine_path, pid_file = validate_config(config_path, config)
+    engine, _engine_path = validate_config(config_path, config)
 
     output = ensure_mapping(config, "output")
     log_dir = resolve_project_path(output["log_dir"])
+    pid_file = pid_file_for_log_dir(log_dir)
 
     if args.stop:
         return stop_process(pid_file)

--- a/test_pipeline/V4/run_cpu_0size_full.sh
+++ b/test_pipeline/V4/run_cpu_0size_full.sh
@@ -52,7 +52,14 @@ if [[ ! -f "$ENGINE.py" || ! -d "tester" ]]; then
 fi
 SCRIPT_NAME="${BASH_SOURCE[0]##*/}"
 SCRIPT_NAME="${SCRIPT_NAME%.sh}"
-PID_FILE="${SCRIPT_DIR}/.${SCRIPT_NAME}.pid"
+mkdir -p "$LOG_DIR" || exit 1
+LOG_DIR="$(cd "$LOG_DIR" && pwd -P)"
+# 输出目录锁定任务身份，脚本名不参与互斥。
+PID_FILE="${LOG_DIR}/.paddleapitest.pid"
+LOCK_FILE="${PID_FILE}.lock"
+exec 9>"$LOCK_FILE"
+# 启动、停止和清理共用此锁，防止状态竞态。
+flock -x 9
 
 # ── 运维命令处理 ──
 case "${1:-}" in
@@ -62,6 +69,7 @@ case "${1:-}" in
             if kill -0 "$pid" 2>/dev/null; then
                 # Kill entire process group (main + all workers)
                 kill -- -"$pid" 2>/dev/null || kill "$pid" 2>/dev/null
+                for _ in {1..30}; do kill -0 "$pid" 2>/dev/null || break; sleep 0.1; done
                 echo "已终止进程组 PGID=$pid"
             else
                 echo "进程 PID=$pid 已不存在"
@@ -201,6 +209,7 @@ else
     nohup setsid python "$ENGINE.py" "${ALL_ARGS[@]}" >> "$LOG_FILE" 2>&1 &
     PYTHON_PID=$!
     echo "$PYTHON_PID" > "$PID_FILE"
+    flock -u 9
 
     # 任务自然结束时清理 PID 文件；若已启动新任务，则不误删新 PID。
     (
@@ -208,6 +217,7 @@ else
             sleep 5
         done
 
+        flock -x 9
         recorded_pid="$(cat "$PID_FILE" 2>/dev/null || true)"
         if [[ "$recorded_pid" == "$PYTHON_PID" ]]; then
             rm -f "$PID_FILE"

--- a/test_pipeline/V4/run_dsv4_0size_accuracy.sh
+++ b/test_pipeline/V4/run_dsv4_0size_accuracy.sh
@@ -72,7 +72,14 @@ if [[ ! -f "$ENGINE.py" || ! -d "tester" ]]; then
 fi
 SCRIPT_NAME="${BASH_SOURCE[0]##*/}"
 SCRIPT_NAME="${SCRIPT_NAME%.sh}"
-PID_FILE="${SCRIPT_DIR}/.${SCRIPT_NAME}.pid"
+mkdir -p "$LOG_DIR" || exit 1
+LOG_DIR="$(cd "$LOG_DIR" && pwd -P)"
+# 输出目录锁定任务身份，脚本名不参与互斥。
+PID_FILE="${LOG_DIR}/.paddleapitest.pid"
+LOCK_FILE="${PID_FILE}.lock"
+exec 9>"$LOCK_FILE"
+# 启动、停止和清理共用此锁，防止状态竞态。
+flock -x 9
 
 # ── 运维命令处理 ──
 case "${1:-}" in
@@ -82,6 +89,7 @@ case "${1:-}" in
             if kill -0 "$pid" 2>/dev/null; then
                 # Kill entire process group (main + all workers)
                 kill -- -"$pid" 2>/dev/null || kill "$pid" 2>/dev/null
+                for _ in {1..30}; do kill -0 "$pid" 2>/dev/null || break; sleep 0.1; done
                 echo "已终止进程组 PGID=$pid"
             else
                 echo "进程 PID=$pid 已不存在"
@@ -211,6 +219,7 @@ else
     nohup setsid python "$ENGINE.py" "${ALL_ARGS[@]}" >> "$LOG_FILE" 2>&1 &
     PYTHON_PID=$!
     echo "$PYTHON_PID" > "$PID_FILE"
+    flock -u 9
 
     # 任务自然结束时清理 PID 文件；若已启动新任务，则不误删新 PID。
     (
@@ -218,6 +227,7 @@ else
             sleep 5
         done
 
+        flock -x 9
         recorded_pid="$(cat "$PID_FILE" 2>/dev/null || true)"
         if [[ "$recorded_pid" == "$PYTHON_PID" ]]; then
             rm -f "$PID_FILE"

--- a/test_pipeline/V4/run_dsv4_0size_paddleonly.sh
+++ b/test_pipeline/V4/run_dsv4_0size_paddleonly.sh
@@ -72,7 +72,14 @@ if [[ ! -f "$ENGINE.py" || ! -d "tester" ]]; then
 fi
 SCRIPT_NAME="${BASH_SOURCE[0]##*/}"
 SCRIPT_NAME="${SCRIPT_NAME%.sh}"
-PID_FILE="${SCRIPT_DIR}/.${SCRIPT_NAME}.pid"
+mkdir -p "$LOG_DIR" || exit 1
+LOG_DIR="$(cd "$LOG_DIR" && pwd -P)"
+# 输出目录锁定任务身份，脚本名不参与互斥。
+PID_FILE="${LOG_DIR}/.paddleapitest.pid"
+LOCK_FILE="${PID_FILE}.lock"
+exec 9>"$LOCK_FILE"
+# 启动、停止和清理共用此锁，防止状态竞态。
+flock -x 9
 
 # ── 运维命令处理 ──
 case "${1:-}" in
@@ -82,6 +89,7 @@ case "${1:-}" in
             if kill -0 "$pid" 2>/dev/null; then
                 # Kill entire process group (main + all workers)
                 kill -- -"$pid" 2>/dev/null || kill "$pid" 2>/dev/null
+                for _ in {1..30}; do kill -0 "$pid" 2>/dev/null || break; sleep 0.1; done
                 echo "已终止进程组 PGID=$pid"
             else
                 echo "进程 PID=$pid 已不存在"
@@ -211,6 +219,7 @@ else
     nohup setsid python "$ENGINE.py" "${ALL_ARGS[@]}" >> "$LOG_FILE" 2>&1 &
     PYTHON_PID=$!
     echo "$PYTHON_PID" > "$PID_FILE"
+    flock -u 9
 
     # 任务自然结束时清理 PID 文件；若已启动新任务，则不误删新 PID。
     (
@@ -218,6 +227,7 @@ else
             sleep 5
         done
 
+        flock -x 9
         recorded_pid="$(cat "$PID_FILE" 2>/dev/null || true)"
         if [[ "$recorded_pid" == "$PYTHON_PID" ]]; then
             rm -f "$PID_FILE"

--- a/test_pipeline/V4/run_dsv4_1M_accuracy.sh
+++ b/test_pipeline/V4/run_dsv4_1M_accuracy.sh
@@ -72,7 +72,14 @@ if [[ ! -f "$ENGINE.py" || ! -d "tester" ]]; then
 fi
 SCRIPT_NAME="${BASH_SOURCE[0]##*/}"
 SCRIPT_NAME="${SCRIPT_NAME%.sh}"
-PID_FILE="${SCRIPT_DIR}/.${SCRIPT_NAME}.pid"
+mkdir -p "$LOG_DIR" || exit 1
+LOG_DIR="$(cd "$LOG_DIR" && pwd -P)"
+# 输出目录锁定任务身份，脚本名不参与互斥。
+PID_FILE="${LOG_DIR}/.paddleapitest.pid"
+LOCK_FILE="${PID_FILE}.lock"
+exec 9>"$LOCK_FILE"
+# 启动、停止和清理共用此锁，防止状态竞态。
+flock -x 9
 
 # ── 运维命令处理 ──
 case "${1:-}" in
@@ -82,6 +89,7 @@ case "${1:-}" in
             if kill -0 "$pid" 2>/dev/null; then
                 # Kill entire process group (main + all workers)
                 kill -- -"$pid" 2>/dev/null || kill "$pid" 2>/dev/null
+                for _ in {1..30}; do kill -0 "$pid" 2>/dev/null || break; sleep 0.1; done
                 echo "已终止进程组 PGID=$pid"
             else
                 echo "进程 PID=$pid 已不存在"
@@ -211,6 +219,7 @@ else
     nohup setsid python "$ENGINE.py" "${ALL_ARGS[@]}" >> "$LOG_FILE" 2>&1 &
     PYTHON_PID=$!
     echo "$PYTHON_PID" > "$PID_FILE"
+    flock -u 9
 
     # 任务自然结束时清理 PID 文件；若已启动新任务，则不误删新 PID。
     (
@@ -218,6 +227,7 @@ else
             sleep 5
         done
 
+        flock -x 9
         recorded_pid="$(cat "$PID_FILE" 2>/dev/null || true)"
         if [[ "$recorded_pid" == "$PYTHON_PID" ]]; then
             rm -f "$PID_FILE"

--- a/test_pipeline/V4/run_dsv4_1M_paddleonly.sh
+++ b/test_pipeline/V4/run_dsv4_1M_paddleonly.sh
@@ -72,7 +72,14 @@ if [[ ! -f "$ENGINE.py" || ! -d "tester" ]]; then
 fi
 SCRIPT_NAME="${BASH_SOURCE[0]##*/}"
 SCRIPT_NAME="${SCRIPT_NAME%.sh}"
-PID_FILE="${SCRIPT_DIR}/.${SCRIPT_NAME}.pid"
+mkdir -p "$LOG_DIR" || exit 1
+LOG_DIR="$(cd "$LOG_DIR" && pwd -P)"
+# 输出目录锁定任务身份，脚本名不参与互斥。
+PID_FILE="${LOG_DIR}/.paddleapitest.pid"
+LOCK_FILE="${PID_FILE}.lock"
+exec 9>"$LOCK_FILE"
+# 启动、停止和清理共用此锁，防止状态竞态。
+flock -x 9
 
 # ── 运维命令处理 ──
 case "${1:-}" in
@@ -82,6 +89,7 @@ case "${1:-}" in
             if kill -0 "$pid" 2>/dev/null; then
                 # Kill entire process group (main + all workers)
                 kill -- -"$pid" 2>/dev/null || kill "$pid" 2>/dev/null
+                for _ in {1..30}; do kill -0 "$pid" 2>/dev/null || break; sleep 0.1; done
                 echo "已终止进程组 PGID=$pid"
             else
                 echo "进程 PID=$pid 已不存在"
@@ -211,6 +219,7 @@ else
     nohup setsid python "$ENGINE.py" "${ALL_ARGS[@]}" >> "$LOG_FILE" 2>&1 &
     PYTHON_PID=$!
     echo "$PYTHON_PID" > "$PID_FILE"
+    flock -u 9
 
     # 任务自然结束时清理 PID 文件；若已启动新任务，则不误删新 PID。
     (
@@ -218,6 +227,7 @@ else
             sleep 5
         done
 
+        flock -x 9
         recorded_pid="$(cat "$PID_FILE" 2>/dev/null || true)"
         if [[ "$recorded_pid" == "$PYTHON_PID" ]]; then
             rm -f "$PID_FILE"

--- a/test_pipeline/V4/run_dsv4_v2_accuracy_manual_threshold.sh
+++ b/test_pipeline/V4/run_dsv4_v2_accuracy_manual_threshold.sh
@@ -75,7 +75,14 @@ if [[ ! -f "$ENGINE.py" || ! -d "tester" ]]; then
 fi
 SCRIPT_NAME="${BASH_SOURCE[0]##*/}"
 SCRIPT_NAME="${SCRIPT_NAME%.sh}"
-PID_FILE="${SCRIPT_DIR}/.${SCRIPT_NAME}.pid"
+mkdir -p "$LOG_DIR" || exit 1
+LOG_DIR="$(cd "$LOG_DIR" && pwd -P)"
+# 输出目录锁定任务身份，脚本名不参与互斥。
+PID_FILE="${LOG_DIR}/.paddleapitest.pid"
+LOCK_FILE="${PID_FILE}.lock"
+exec 9>"$LOCK_FILE"
+# 启动、停止和清理共用此锁，防止状态竞态。
+flock -x 9
 
 # ── 运维命令处理 ──
 case "${1:-}" in
@@ -85,6 +92,7 @@ case "${1:-}" in
             if kill -0 "$pid" 2>/dev/null; then
                 # Kill entire process group (main + all workers)
                 kill -- -"$pid" 2>/dev/null || kill "$pid" 2>/dev/null
+                for _ in {1..30}; do kill -0 "$pid" 2>/dev/null || break; sleep 0.1; done
                 echo "已终止进程组 PGID=$pid"
             else
                 echo "进程 PID=$pid 已不存在"
@@ -214,6 +222,7 @@ else
     nohup setsid python "$ENGINE.py" "${ALL_ARGS[@]}" >> "$LOG_FILE" 2>&1 &
     PYTHON_PID=$!
     echo "$PYTHON_PID" > "$PID_FILE"
+    flock -u 9
 
     # 任务自然结束时清理 PID 文件；若已启动新任务，则不误删新 PID。
     (
@@ -221,6 +230,7 @@ else
             sleep 5
         done
 
+        flock -x 9
         recorded_pid="$(cat "$PID_FILE" 2>/dev/null || true)"
         if [[ "$recorded_pid" == "$PYTHON_PID" ]]; then
             rm -f "$PID_FILE"

--- a/test_pipeline/V4/run_gpu_0size_full.sh
+++ b/test_pipeline/V4/run_gpu_0size_full.sh
@@ -52,7 +52,14 @@ if [[ ! -f "$ENGINE.py" || ! -d "tester" ]]; then
 fi
 SCRIPT_NAME="${BASH_SOURCE[0]##*/}"
 SCRIPT_NAME="${SCRIPT_NAME%.sh}"
-PID_FILE="${SCRIPT_DIR}/.${SCRIPT_NAME}.pid"
+mkdir -p "$LOG_DIR" || exit 1
+LOG_DIR="$(cd "$LOG_DIR" && pwd -P)"
+# 输出目录锁定任务身份，脚本名不参与互斥。
+PID_FILE="${LOG_DIR}/.paddleapitest.pid"
+LOCK_FILE="${PID_FILE}.lock"
+exec 9>"$LOCK_FILE"
+# 启动、停止和清理共用此锁，防止状态竞态。
+flock -x 9
 
 # ── 运维命令处理 ──
 case "${1:-}" in
@@ -62,6 +69,7 @@ case "${1:-}" in
             if kill -0 "$pid" 2>/dev/null; then
                 # Kill entire process group (main + all workers)
                 kill -- -"$pid" 2>/dev/null || kill "$pid" 2>/dev/null
+                for _ in {1..30}; do kill -0 "$pid" 2>/dev/null || break; sleep 0.1; done
                 echo "已终止进程组 PGID=$pid"
             else
                 echo "进程 PID=$pid 已不存在"
@@ -201,6 +209,7 @@ else
     nohup setsid python "$ENGINE.py" "${ALL_ARGS[@]}" >> "$LOG_FILE" 2>&1 &
     PYTHON_PID=$!
     echo "$PYTHON_PID" > "$PID_FILE"
+    flock -u 9
 
     # 任务自然结束时清理 PID 文件；若已启动新任务，则不误删新 PID。
     (
@@ -208,6 +217,7 @@ else
             sleep 5
         done
 
+        flock -x 9
         recorded_pid="$(cat "$PID_FILE" 2>/dev/null || true)"
         if [[ "$recorded_pid" == "$PYTHON_PID" ]]; then
             rm -f "$PID_FILE"

--- a/test_pipeline/V4/run_gpu_accuracy_full.sh
+++ b/test_pipeline/V4/run_gpu_accuracy_full.sh
@@ -64,7 +64,14 @@ if [[ ! -f "$ENGINE.py" || ! -d "tester" ]]; then
 fi
 SCRIPT_NAME="${BASH_SOURCE[0]##*/}"
 SCRIPT_NAME="${SCRIPT_NAME%.sh}"
-PID_FILE="${SCRIPT_DIR}/.${SCRIPT_NAME}.pid"
+mkdir -p "$LOG_DIR" || exit 1
+LOG_DIR="$(cd "$LOG_DIR" && pwd -P)"
+# 输出目录锁定任务身份，脚本名不参与互斥。
+PID_FILE="${LOG_DIR}/.paddleapitest.pid"
+LOCK_FILE="${PID_FILE}.lock"
+exec 9>"$LOCK_FILE"
+# 启动、停止和清理共用此锁，防止状态竞态。
+flock -x 9
 
 # ── 运维命令处理 ──
 case "${1:-}" in
@@ -74,6 +81,7 @@ case "${1:-}" in
             if kill -0 "$pid" 2>/dev/null; then
                 # Kill entire process group (main + all workers)
                 kill -- -"$pid" 2>/dev/null || kill "$pid" 2>/dev/null
+                for _ in {1..30}; do kill -0 "$pid" 2>/dev/null || break; sleep 0.1; done
                 echo "已终止进程组 PGID=$pid"
             else
                 echo "进程 PID=$pid 已不存在"
@@ -202,6 +210,7 @@ else
     nohup setsid python "$ENGINE.py" "${ALL_ARGS[@]}" >> "$LOG_FILE" 2>&1 &
     PYTHON_PID=$!
     echo "$PYTHON_PID" > "$PID_FILE"
+    flock -u 9
 
     # 任务自然结束时清理 PID 文件；若已启动新任务，则不误删新 PID。
     (
@@ -209,6 +218,7 @@ else
             sleep 5
         done
 
+        flock -x 9
         recorded_pid="$(cat "$PID_FILE" 2>/dev/null || true)"
         if [[ "$recorded_pid" == "$PYTHON_PID" ]]; then
             rm -f "$PID_FILE"

--- a/test_pipeline/V4/run_gpu_bigtensor_full.sh
+++ b/test_pipeline/V4/run_gpu_bigtensor_full.sh
@@ -50,7 +50,14 @@ if [[ ! -f "$ENGINE.py" || ! -d "tester" ]]; then
 fi
 SCRIPT_NAME="${BASH_SOURCE[0]##*/}"
 SCRIPT_NAME="${SCRIPT_NAME%.sh}"
-PID_FILE="${SCRIPT_DIR}/.${SCRIPT_NAME}.pid"
+mkdir -p "$LOG_DIR" || exit 1
+LOG_DIR="$(cd "$LOG_DIR" && pwd -P)"
+# 输出目录锁定任务身份，脚本名不参与互斥。
+PID_FILE="${LOG_DIR}/.paddleapitest.pid"
+LOCK_FILE="${PID_FILE}.lock"
+exec 9>"$LOCK_FILE"
+# 启动、停止和清理共用此锁，防止状态竞态。
+flock -x 9
 
 # ── 运维命令处理 ──
 case "${1:-}" in
@@ -60,6 +67,7 @@ case "${1:-}" in
             if kill -0 "$pid" 2>/dev/null; then
                 # Kill entire process group (main + all workers)
                 kill -- -"$pid" 2>/dev/null || kill "$pid" 2>/dev/null
+                for _ in {1..30}; do kill -0 "$pid" 2>/dev/null || break; sleep 0.1; done
                 echo "已终止进程组 PGID=$pid"
             else
                 echo "进程 PID=$pid 已不存在"
@@ -183,6 +191,7 @@ else
     nohup setsid python "$ENGINE.py" "${ALL_ARGS[@]}" >> "$LOG_FILE" 2>&1 &
     PYTHON_PID=$!
     echo "$PYTHON_PID" > "$PID_FILE"
+    flock -u 9
 
     # 任务自然结束时清理 PID 文件；若已启动新任务，则不误删新 PID。
     (
@@ -190,6 +199,7 @@ else
             sleep 5
         done
 
+        flock -x 9
         recorded_pid="$(cat "$PID_FILE" 2>/dev/null || true)"
         if [[ "$recorded_pid" == "$PYTHON_PID" ]]; then
             rm -f "$PID_FILE"

--- a/test_pipeline/V4/run_v2_0size_accuracy.sh
+++ b/test_pipeline/V4/run_v2_0size_accuracy.sh
@@ -72,7 +72,14 @@ if [[ ! -f "$ENGINE.py" || ! -d "tester" ]]; then
 fi
 SCRIPT_NAME="${BASH_SOURCE[0]##*/}"
 SCRIPT_NAME="${SCRIPT_NAME%.sh}"
-PID_FILE="${SCRIPT_DIR}/.${SCRIPT_NAME}.pid"
+mkdir -p "$LOG_DIR" || exit 1
+LOG_DIR="$(cd "$LOG_DIR" && pwd -P)"
+# 输出目录锁定任务身份，脚本名不参与互斥。
+PID_FILE="${LOG_DIR}/.paddleapitest.pid"
+LOCK_FILE="${PID_FILE}.lock"
+exec 9>"$LOCK_FILE"
+# 启动、停止和清理共用此锁，防止状态竞态。
+flock -x 9
 
 # ── 运维命令处理 ──
 case "${1:-}" in
@@ -82,6 +89,7 @@ case "${1:-}" in
             if kill -0 "$pid" 2>/dev/null; then
                 # Kill entire process group (main + all workers)
                 kill -- -"$pid" 2>/dev/null || kill "$pid" 2>/dev/null
+                for _ in {1..30}; do kill -0 "$pid" 2>/dev/null || break; sleep 0.1; done
                 echo "已终止进程组 PGID=$pid"
             else
                 echo "进程 PID=$pid 已不存在"
@@ -211,6 +219,7 @@ else
     nohup setsid python "$ENGINE.py" "${ALL_ARGS[@]}" >> "$LOG_FILE" 2>&1 &
     PYTHON_PID=$!
     echo "$PYTHON_PID" > "$PID_FILE"
+    flock -u 9
 
     # 任务自然结束时清理 PID 文件；若已启动新任务，则不误删新 PID。
     (
@@ -218,6 +227,7 @@ else
             sleep 5
         done
 
+        flock -x 9
         recorded_pid="$(cat "$PID_FILE" 2>/dev/null || true)"
         if [[ "$recorded_pid" == "$PYTHON_PID" ]]; then
             rm -f "$PID_FILE"

--- a/test_pipeline/V4/run_v2_0size_paddleonly.sh
+++ b/test_pipeline/V4/run_v2_0size_paddleonly.sh
@@ -72,7 +72,14 @@ if [[ ! -f "$ENGINE.py" || ! -d "tester" ]]; then
 fi
 SCRIPT_NAME="${BASH_SOURCE[0]##*/}"
 SCRIPT_NAME="${SCRIPT_NAME%.sh}"
-PID_FILE="${SCRIPT_DIR}/.${SCRIPT_NAME}.pid"
+mkdir -p "$LOG_DIR" || exit 1
+LOG_DIR="$(cd "$LOG_DIR" && pwd -P)"
+# 输出目录锁定任务身份，脚本名不参与互斥。
+PID_FILE="${LOG_DIR}/.paddleapitest.pid"
+LOCK_FILE="${PID_FILE}.lock"
+exec 9>"$LOCK_FILE"
+# 启动、停止和清理共用此锁，防止状态竞态。
+flock -x 9
 
 # ── 运维命令处理 ──
 case "${1:-}" in
@@ -82,6 +89,7 @@ case "${1:-}" in
             if kill -0 "$pid" 2>/dev/null; then
                 # Kill entire process group (main + all workers)
                 kill -- -"$pid" 2>/dev/null || kill "$pid" 2>/dev/null
+                for _ in {1..30}; do kill -0 "$pid" 2>/dev/null || break; sleep 0.1; done
                 echo "已终止进程组 PGID=$pid"
             else
                 echo "进程 PID=$pid 已不存在"
@@ -211,6 +219,7 @@ else
     nohup setsid python "$ENGINE.py" "${ALL_ARGS[@]}" >> "$LOG_FILE" 2>&1 &
     PYTHON_PID=$!
     echo "$PYTHON_PID" > "$PID_FILE"
+    flock -u 9
 
     # 任务自然结束时清理 PID 文件；若已启动新任务，则不误删新 PID。
     (
@@ -218,6 +227,7 @@ else
             sleep 5
         done
 
+        flock -x 9
         recorded_pid="$(cat "$PID_FILE" 2>/dev/null || true)"
         if [[ "$recorded_pid" == "$PYTHON_PID" ]]; then
             rm -f "$PID_FILE"

--- a/test_pipeline/V4/run_v2_1M_accuracy.sh
+++ b/test_pipeline/V4/run_v2_1M_accuracy.sh
@@ -72,7 +72,14 @@ if [[ ! -f "$ENGINE.py" || ! -d "tester" ]]; then
 fi
 SCRIPT_NAME="${BASH_SOURCE[0]##*/}"
 SCRIPT_NAME="${SCRIPT_NAME%.sh}"
-PID_FILE="${SCRIPT_DIR}/.${SCRIPT_NAME}.pid"
+mkdir -p "$LOG_DIR" || exit 1
+LOG_DIR="$(cd "$LOG_DIR" && pwd -P)"
+# 输出目录锁定任务身份，脚本名不参与互斥。
+PID_FILE="${LOG_DIR}/.paddleapitest.pid"
+LOCK_FILE="${PID_FILE}.lock"
+exec 9>"$LOCK_FILE"
+# 启动、停止和清理共用此锁，防止状态竞态。
+flock -x 9
 
 # ── 运维命令处理 ──
 case "${1:-}" in
@@ -82,6 +89,7 @@ case "${1:-}" in
             if kill -0 "$pid" 2>/dev/null; then
                 # Kill entire process group (main + all workers)
                 kill -- -"$pid" 2>/dev/null || kill "$pid" 2>/dev/null
+                for _ in {1..30}; do kill -0 "$pid" 2>/dev/null || break; sleep 0.1; done
                 echo "已终止进程组 PGID=$pid"
             else
                 echo "进程 PID=$pid 已不存在"
@@ -211,6 +219,7 @@ else
     nohup setsid python "$ENGINE.py" "${ALL_ARGS[@]}" >> "$LOG_FILE" 2>&1 &
     PYTHON_PID=$!
     echo "$PYTHON_PID" > "$PID_FILE"
+    flock -u 9
 
     # 任务自然结束时清理 PID 文件；若已启动新任务，则不误删新 PID。
     (
@@ -218,6 +227,7 @@ else
             sleep 5
         done
 
+        flock -x 9
         recorded_pid="$(cat "$PID_FILE" 2>/dev/null || true)"
         if [[ "$recorded_pid" == "$PYTHON_PID" ]]; then
             rm -f "$PID_FILE"

--- a/test_pipeline/V4/run_v2_1M_paddleonly.sh
+++ b/test_pipeline/V4/run_v2_1M_paddleonly.sh
@@ -72,7 +72,14 @@ if [[ ! -f "$ENGINE.py" || ! -d "tester" ]]; then
 fi
 SCRIPT_NAME="${BASH_SOURCE[0]##*/}"
 SCRIPT_NAME="${SCRIPT_NAME%.sh}"
-PID_FILE="${SCRIPT_DIR}/.${SCRIPT_NAME}.pid"
+mkdir -p "$LOG_DIR" || exit 1
+LOG_DIR="$(cd "$LOG_DIR" && pwd -P)"
+# 输出目录锁定任务身份，脚本名不参与互斥。
+PID_FILE="${LOG_DIR}/.paddleapitest.pid"
+LOCK_FILE="${PID_FILE}.lock"
+exec 9>"$LOCK_FILE"
+# 启动、停止和清理共用此锁，防止状态竞态。
+flock -x 9
 
 # ── 运维命令处理 ──
 case "${1:-}" in
@@ -82,6 +89,7 @@ case "${1:-}" in
             if kill -0 "$pid" 2>/dev/null; then
                 # Kill entire process group (main + all workers)
                 kill -- -"$pid" 2>/dev/null || kill "$pid" 2>/dev/null
+                for _ in {1..30}; do kill -0 "$pid" 2>/dev/null || break; sleep 0.1; done
                 echo "已终止进程组 PGID=$pid"
             else
                 echo "进程 PID=$pid 已不存在"
@@ -211,6 +219,7 @@ else
     nohup setsid python "$ENGINE.py" "${ALL_ARGS[@]}" >> "$LOG_FILE" 2>&1 &
     PYTHON_PID=$!
     echo "$PYTHON_PID" > "$PID_FILE"
+    flock -u 9
 
     # 任务自然结束时清理 PID 文件；若已启动新任务，则不误删新 PID。
     (
@@ -218,6 +227,7 @@ else
             sleep 5
         done
 
+        flock -x 9
         recorded_pid="$(cat "$PID_FILE" 2>/dev/null || true)"
         if [[ "$recorded_pid" == "$PYTHON_PID" ]]; then
             rm -f "$PID_FILE"

--- a/test_pipeline/run_config.schema.json
+++ b/test_pipeline/run_config.schema.json
@@ -5,15 +5,14 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
-    "name": {"type": "string", "description": "任务名称，用于默认 PID 文件名。"},
+    "name": {"type": "string", "description": "任务显示名称。"},
     "runner": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
         "engine": {"type": "string", "enum": ["engineV4", "engineV2"], "default": "engineV4"},
         "foreground": {"type": "boolean", "default": false},
-        "dry_run": {"type": "boolean", "default": false},
-        "pid_file": {"type": "string", "description": "可选；省略时 run.py 使用 .run/<name>.pid。"}
+        "dry_run": {"type": "boolean", "default": false}
       }
     },
     "env": {

--- a/test_pipeline/run_config.yaml
+++ b/test_pipeline/run_config.yaml
@@ -35,7 +35,6 @@ runner:
   foreground: false
   # true=只打印最终命令，不执行。也可用命令行 --dry-run 临时覆盖。
   dry_run: false
-  # pid_file: ".run/run_config.pid"
 
 # 可选：需要导出的环境变量。值建议写成字符串，避免 YAML 布尔值转换带来歧义。
 # Paddle Flags 在启动 Paddle 前生效，用于控制 Paddle 运行时行为：

--- a/tester/accuracy.py
+++ b/tester/accuracy.py
@@ -233,16 +233,14 @@ class APITestAccuracy(APITestBase):
         self,
         err,
         default_log_type,
-        phase,
+        stage,
         *,
-        allow_ignore_paddle=False,
         force_log_type=None,
     ):
         log_type, fatal = self.report_runtime_error(
             err,
             default_log_type,
-            phase,
-            allow_ignore_paddle=allow_ignore_paddle,
+            stage,
             force_log_type=force_log_type,
         )
         self.dump_finalize(log_type or default_log_type)
@@ -251,11 +249,12 @@ class APITestAccuracy(APITestBase):
         return log_type, fatal
 
     def _report_comparison_error(self, err, tensor_index=0, tensor_count=1):
-        phase = "backward" if self.is_backward else "forward"
+        # 比较阶段不携带 Paddle 或 Torch 前缀，避免混淆执行端与比较端。
+        stage = self.STAGE_COMPARE_BACKWARD if self.is_backward else self.STAGE_COMPARE_FORWARD
         log_type, fatal = self.report_runtime_error(
             err,
             "paddle_accuracy",
-            phase,
+            stage,
             tensor_position=f"{tensor_index + 1}/{tensor_count}",
         )
         self.dump_finalize(log_type or "paddle_accuracy")
@@ -271,14 +270,15 @@ class APITestAccuracy(APITestBase):
         tensor_position=None,
         **details,
     ):
-        phase = "backward" if self.is_backward else "forward"
+        # 比较输出沿用同一阶段协议，错误和精度结果保持一致。
+        stage = self.STAGE_COMPARE_BACKWARD if self.is_backward else self.STAGE_COMPARE_FORWARD
         detail_text = " | ".join(
             f"{key.replace('_', ' ')} {value}" for key, value in details.items()
         )
         self.report_case_result(
             "paddle_accuracy",
             reason.replace("_", " "),
-            phase=phase,
+            stage=stage,
             tensor_position=tensor_position,
             error=detail_text or None,
         )
@@ -395,7 +395,7 @@ class APITestAccuracy(APITestBase):
                 return False
             self.dump_event("numpy_input_done")
         except Exception as err:
-            log_type, fatal = self.report_runtime_error(err, "config_input", "input")
+            log_type, fatal = self.report_runtime_error(err, "config_input", self.STAGE_INPUT)
             self.dump_finalize(log_type or "config_input")
             if fatal:
                 raise
@@ -408,7 +408,9 @@ class APITestAccuracy(APITestBase):
             torch.set_default_device(device)
             self.dump_event("torch_input_start")
             if not self.build_torch_input():
-                self.report_case_result("torch_error", "build_torch_input failed")
+                self.report_case_result(
+                    "torch_error", "build_torch_input failed", stage=self.STAGE_INPUT
+                )
                 self.dump_finalize("torch_error")
                 return False, None, None, False
             self.dump_save(
@@ -468,7 +470,10 @@ class APITestAccuracy(APITestBase):
             #     torch_output = self.torch_args[0] if len(self.torch_args) > 0 else next(iter(self.torch_kwargs.values()))
 
         except Exception as err:
-            _, fatal = self._report_runtime_error_and_finalize(err, "torch_error", "forward")
+            # Torch 前向和同步分开记录，异步错误仍能保留方向。
+            _, fatal = self._report_runtime_error_and_finalize(
+                err, "torch_error", self.STAGE_TORCH_FORWARD
+            )
             if fatal:
                 raise
             return False, None, None, False
@@ -477,10 +482,11 @@ class APITestAccuracy(APITestBase):
         try:
             self.check_torch_operator_cuda_error()
         except Exception as err:
+            # Torch 反向错误必须在梯度阶段终止当前 case。
             _, fatal = self._report_runtime_error_and_finalize(
                 err,
                 "torch_error",
-                "forward cuda check",
+                self.STAGE_TORCH_FORWARD_SYNC,
                 force_log_type="torch_error",
             )
             if fatal:
@@ -526,11 +532,14 @@ class APITestAccuracy(APITestBase):
                 self._report_runtime_error_and_finalize(
                     err,
                     "config_input",
-                    "backward",
+                    self.STAGE_TORCH_BACKWARD,
                     force_log_type="config_input",
                 )
                 return False, None, None, False
-            _, fatal = self._report_runtime_error_and_finalize(err, "torch_error", "backward")
+            # Paddle 前向错误与 Torch 错误使用相同格式。
+            _, fatal = self._report_runtime_error_and_finalize(
+                err, "torch_error", self.STAGE_TORCH_BACKWARD
+            )
             if fatal:
                 raise
             return False, None, None, False
@@ -540,7 +549,7 @@ class APITestAccuracy(APITestBase):
             self._report_runtime_error_and_finalize(
                 err,
                 "torch_error",
-                "backward cuda check",
+                self.STAGE_TORCH_BACKWARD_SYNC,
                 force_log_type="torch_error",
             )
             raise
@@ -606,7 +615,9 @@ class APITestAccuracy(APITestBase):
         # Paddle 侧必须在 Torch 结果清理后开始，避免两套 runtime 同时持有峰值数据。
         try:
             if not self.build_paddle_input():
-                self.report_case_result("paddle_error", "build_paddle_input failed")
+                self.report_case_result(
+                    "paddle_error", "build_paddle_input failed", stage=self.STAGE_INPUT
+                )
                 self.clear_output_grad_cache()
                 self.dump_finalize("paddle_error")
                 return False, None
@@ -646,7 +657,9 @@ class APITestAccuracy(APITestBase):
                 )
         except Exception as err:
             _, fatal = self._report_runtime_error_and_finalize(
-                err, "paddle_error", "forward", allow_ignore_paddle=True
+                err,
+                "paddle_error",
+                self.STAGE_PADDLE_FORWARD,
             )
             if fatal:
                 raise
@@ -657,7 +670,9 @@ class APITestAccuracy(APITestBase):
             self.dump_event("paddle_forward_done")
             self.check_paddle_kernel_cuda_error()
         except Exception as err:
-            self._report_runtime_error_and_finalize(err, "paddle_cuda", "forward")
+            self._report_runtime_error_and_finalize(
+                err, "paddle_cuda", self.STAGE_PADDLE_FORWARD_SYNC
+            )
             raise
         return True, paddle_output
 
@@ -683,7 +698,7 @@ class APITestAccuracy(APITestBase):
                 )
             del inputs_list, result_outputs, result_outputs_grads
         except GpuMemoryGuardSkip as err:
-            self.report_case_result("oom", phase="memory_guard", message=str(err))
+            self.report_case_result("oom", stage=self.STAGE_PADDLE_BACKWARD, message=str(err))
             self.clear_runtime_inputs("paddle")
             self.clear_output_grad_cache()
             self.dump_finalize("oom", memory_guard=str(err))
@@ -693,12 +708,14 @@ class APITestAccuracy(APITestBase):
                 self._report_runtime_error_and_finalize(
                     err,
                     "config_input",
-                    "backward",
+                    self.STAGE_PADDLE_BACKWARD,
                     force_log_type="config_input",
                 )
                 return False, None
             _, fatal = self._report_runtime_error_and_finalize(
-                err, "paddle_error", "backward", allow_ignore_paddle=True
+                err,
+                "paddle_error",
+                self.STAGE_PADDLE_BACKWARD,
             )
             if fatal:
                 raise
@@ -707,7 +724,9 @@ class APITestAccuracy(APITestBase):
         try:
             self.check_paddle_kernel_cuda_error()
         except Exception as err:
-            self._report_runtime_error_and_finalize(err, "paddle_cuda", "backward cuda check")
+            self._report_runtime_error_and_finalize(
+                err, "paddle_cuda", self.STAGE_PADDLE_BACKWARD_SYNC
+            )
             raise
         return True, paddle_out_grads
 
@@ -716,7 +735,7 @@ class APITestAccuracy(APITestBase):
         try:
             dual_gpu_completed = bool(self._test_accuracy())
         except GpuMemoryGuardSkip as err:
-            self.report_case_result("oom", phase="memory_guard", message=str(err))
+            self.report_case_result("oom", stage=self.STAGE_MEMORY_PREFLIGHT, message=str(err))
             self.dump_finalize("oom", memory_guard=str(err))
         finally:
             # _test_accuracy 返回后局部结果引用已经销毁，此时才能可靠清理 allocator cache。
@@ -776,7 +795,9 @@ class APITestAccuracy(APITestBase):
                 self.api_config, paddle_output, torch_output
             )
         except Exception as err:
-            _, fatal = self._report_runtime_error_and_finalize(err, "paddle_accuracy", "forward")
+            _, fatal = self._report_runtime_error_and_finalize(
+                err, "paddle_accuracy", self.STAGE_COMPARE_FORWARD
+            )
             if fatal:
                 raise
             return
@@ -824,7 +845,7 @@ class APITestAccuracy(APITestBase):
                 )
             except Exception as err:
                 _, fatal = self._report_runtime_error_and_finalize(
-                    err, "paddle_accuracy", "backward"
+                    err, "paddle_accuracy", self.STAGE_COMPARE_BACKWARD
                 )
                 if fatal:
                     raise

--- a/tester/accuracy_stable.py
+++ b/tester/accuracy_stable.py
@@ -787,7 +787,8 @@ class APITestAccuracyStable(APITestBase):
                 self.report_case_result("config_input", "generate_input_values failed")
                 return
         except Exception as err:
-            _, fatal = self.report_runtime_error(err, "config_input", "input")
+            # stable 模式的配置错误仍归入统一输入阶段。
+            _, fatal = self.report_runtime_error(err, "config_input", self.STAGE_INPUT)
             if fatal:
                 raise
             return
@@ -797,7 +798,7 @@ class APITestAccuracyStable(APITestBase):
             # 后续两轮只从不可变 CPU 副本重建，GPU 生成源在此结束生命周期。
             self.clear_generated_input_values()
         except Exception as err:
-            _, fatal = self.report_runtime_error(err, "config_input", "input cache")
+            _, fatal = self.report_runtime_error(err, "config_input", self.STAGE_INPUT)
             if fatal:
                 raise
             return
@@ -815,7 +816,8 @@ class APITestAccuracyStable(APITestBase):
                 ):
                     return
         except GpuMemoryGuardSkip as err:
-            self.report_case_result("oom", phase="memory_guard", message=str(err))
+            # 资源预检查失败不进入任何框架执行阶段。
+            self.report_case_result("oom", stage=self.STAGE_MEMORY_PREFLIGHT, message=str(err))
             return
 
         summary_failed = False
@@ -833,7 +835,8 @@ class APITestAccuracyStable(APITestBase):
             log_worker.write_stable_passes(self.api_config.config)
         except GpuMemoryGuardSkip as err:
             summary_failed = True
-            self.report_case_result("oom", phase="memory_guard", message=str(err))
+            # 同一资源错误协议也用于稳定模式的重复迭代。
+            self.report_case_result("oom", stage=self.STAGE_MEMORY_PREFLIGHT, message=str(err))
             return
         except Exception:
             summary_failed = True
@@ -858,6 +861,7 @@ class APITestAccuracyStable(APITestBase):
                 self.report_case_result(
                     "torch_error",
                     "build_torch_input failed",
+                    stage=self.STAGE_INPUT,
                     affected_comps=self._TORCH_AFFECTED_COMPS[iter_idx],
                 )
                 return None, None, None
@@ -887,7 +891,8 @@ class APITestAccuracyStable(APITestBase):
             _, fatal = self.report_runtime_error(
                 err,
                 "torch_error",
-                "forward",
+                # Torch 稳定性检查沿用普通 accuracy 的前向阶段。
+                self.STAGE_TORCH_FORWARD,
                 affected_comps=self._TORCH_AFFECTED_COMPS[iter_idx],
             )
             if fatal:
@@ -901,7 +906,7 @@ class APITestAccuracyStable(APITestBase):
             _, fatal = self.report_runtime_error(
                 err,
                 "torch_error",
-                "forward cuda check",
+                self.STAGE_TORCH_FORWARD_SYNC,
                 force_log_type="torch_error",
                 affected_comps=self._TORCH_AFFECTED_COMPS[iter_idx],
             )
@@ -932,7 +937,8 @@ class APITestAccuracyStable(APITestBase):
                     self.report_runtime_error(
                         err,
                         "config_input",
-                        "backward",
+                        # 梯度迭代中的 Torch 错误统一归入反向阶段。
+                        self.STAGE_TORCH_BACKWARD,
                         force_log_type="config_input",
                         affected_comps=self._TORCH_AFFECTED_COMPS[iter_idx],
                     )
@@ -941,7 +947,7 @@ class APITestAccuracyStable(APITestBase):
                     self.report_runtime_error(
                         err,
                         "oom",
-                        "backward",
+                        self.STAGE_TORCH_BACKWARD,
                         force_log_type="oom",
                         affected_comps=self._TORCH_AFFECTED_COMPS[iter_idx],
                     )
@@ -950,7 +956,7 @@ class APITestAccuracyStable(APITestBase):
                     self.report_runtime_error(
                         err,
                         "torch_error",
-                        "backward",
+                        self.STAGE_TORCH_BACKWARD,
                         force_log_type="torch_error",
                         affected_comps=self._TORCH_AFFECTED_COMPS[iter_idx],
                     )
@@ -958,7 +964,7 @@ class APITestAccuracyStable(APITestBase):
                 _, fatal = self.report_runtime_error(
                     err,
                     "torch_error",
-                    "backward",
+                    self.STAGE_TORCH_BACKWARD,
                     affected_comps=self._TORCH_AFFECTED_COMPS[iter_idx],
                 )
                 if fatal:
@@ -971,7 +977,7 @@ class APITestAccuracyStable(APITestBase):
                 self.report_runtime_error(
                     err,
                     "torch_error",
-                    "backward cuda check",
+                    self.STAGE_TORCH_BACKWARD_SYNC,
                     force_log_type="torch_error",
                     affected_comps=self._TORCH_AFFECTED_COMPS[iter_idx],
                 )
@@ -988,6 +994,7 @@ class APITestAccuracyStable(APITestBase):
                 self.report_case_result(
                     "paddle_error",
                     "build_paddle_input failed",
+                    stage=self.STAGE_INPUT,
                     affected_comps=self._PADDLE_AFFECTED_COMPS[iter_idx],
                 )
                 return None, None
@@ -1037,8 +1044,8 @@ class APITestAccuracyStable(APITestBase):
             _, fatal = self.report_runtime_error(
                 err,
                 "paddle_error",
-                "forward",
-                allow_ignore_paddle=True,
+                # Paddle 稳定性检查不再使用 dynamic/static 自由文本。
+                self.STAGE_PADDLE_FORWARD,
                 affected_comps=self._PADDLE_AFFECTED_COMPS[iter_idx],
             )
             if fatal:
@@ -1051,7 +1058,7 @@ class APITestAccuracyStable(APITestBase):
             self.report_runtime_error(
                 err,
                 "paddle_cuda",
-                "forward cuda check",
+                self.STAGE_PADDLE_FORWARD_SYNC,
                 force_log_type="paddle_cuda",
                 affected_comps=self._PADDLE_AFFECTED_COMPS[iter_idx],
             )
@@ -1078,17 +1085,9 @@ class APITestAccuracyStable(APITestBase):
                     self.report_runtime_error(
                         err,
                         "config_input",
-                        "backward",
+                        # Paddle 梯度迭代与普通反向阶段保持同一标签。
+                        self.STAGE_PADDLE_BACKWARD,
                         force_log_type="config_input",
-                        affected_comps=self._PADDLE_AFFECTED_COMPS[iter_idx],
-                    )
-                    return None, None
-                if self.should_ignore_paddle_error(err_str):
-                    self.report_runtime_error(
-                        err,
-                        "paddle_error",
-                        "backward",
-                        allow_ignore_paddle=True,
                         affected_comps=self._PADDLE_AFFECTED_COMPS[iter_idx],
                     )
                     return None, None
@@ -1096,7 +1095,7 @@ class APITestAccuracyStable(APITestBase):
                     self.report_runtime_error(
                         err,
                         "paddle_cuda",
-                        "backward",
+                        self.STAGE_PADDLE_BACKWARD,
                         force_log_type="paddle_cuda",
                         affected_comps=self._PADDLE_AFFECTED_COMPS[iter_idx],
                     )
@@ -1105,7 +1104,7 @@ class APITestAccuracyStable(APITestBase):
                     self.report_runtime_error(
                         err,
                         "oom",
-                        "backward",
+                        self.STAGE_PADDLE_BACKWARD,
                         force_log_type="oom",
                         affected_comps=self._PADDLE_AFFECTED_COMPS[iter_idx],
                     )
@@ -1113,7 +1112,7 @@ class APITestAccuracyStable(APITestBase):
                 self.report_runtime_error(
                     err,
                     "paddle_error",
-                    "backward",
+                    self.STAGE_PADDLE_BACKWARD,
                     affected_comps=self._PADDLE_AFFECTED_COMPS[iter_idx],
                 )
                 return None, None
@@ -1124,7 +1123,7 @@ class APITestAccuracyStable(APITestBase):
                 self.report_runtime_error(
                     err,
                     "paddle_cuda",
-                    "backward cuda check",
+                    self.STAGE_PADDLE_BACKWARD_SYNC,
                     force_log_type="paddle_cuda",
                     affected_comps=self._PADDLE_AFFECTED_COMPS[iter_idx],
                 )
@@ -1145,7 +1144,7 @@ class APITestAccuracyStable(APITestBase):
         log_type, fatal = self.report_runtime_error(
             err,
             "paddle_accuracy",
-            comp,
+            self.STAGE_COMPARE_BACKWARD if comp.endswith("B") else self.STAGE_COMPARE_FORWARD,
             tensor_position=tensor_position,
             affected_comps=(comp,),
         )

--- a/tester/api_config/parameter_binding.py
+++ b/tester/api_config/parameter_binding.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import collections
+import functools
 import inspect
 from dataclasses import dataclass
 from pathlib import Path
@@ -176,13 +177,32 @@ def resolve_input_api(api_name):
     return resolved_api
 
 
+def _inspect_input_signature(api):
+    try:
+        return inspect.signature(api)
+    except (TypeError, ValueError):
+        return None
+
+
+@functools.lru_cache(maxsize=512)
+def _inspect_input_signature_cached(api):
+    """缓存 worker 内稳定 callable 的反射元数据。"""
+    return _inspect_input_signature(api)
+
+
+def _inspect_input_signature_with_cache(api):
+    try:
+        # callable 进入键后，运行时重绑定会自然触发新一轮反射。
+        return _inspect_input_signature_cached(api)
+    except TypeError:
+        # 不可哈希 callable 保留原语义，不因缓存支持范围而失败。
+        return _inspect_input_signature(api)
+
+
 def resolve_input_signature(api_name, api=None):
     # 可反射 API 使用真实签名；无签名 C-op 只接受明确的公共别名。
     api = api or resolve_input_api(api_name)
-    try:
-        signature = inspect.signature(api)
-    except (TypeError, ValueError):
-        signature = None
+    signature = _inspect_input_signature_with_cache(api)
     source = "signature"
     # api 参数由执行侧传入时可避免重复解析，但解析规则保持一致。
     if signature is None:
@@ -192,10 +212,8 @@ def resolve_input_signature(api_name, api=None):
                 None, "unresolved", "API has no inspectable signature or public alias"
             )
         public_api = resolve_input_api(public_api_name)
-        try:
-            signature = inspect.signature(public_api)
-        except (TypeError, ValueError):
-            signature = None
+        # 别名仍逐次解析当前 callable，避免 monkeypatch 或运行时重绑定命中旧签名。
+        signature = _inspect_input_signature_with_cache(public_api)
         if signature is None:
             return InputSignatureResult(
                 None, "unresolved", f"public alias has no signature: {public_api_name}"

--- a/tester/api_config/parameter_binding.py
+++ b/tester/api_config/parameter_binding.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import collections
-import functools
 import inspect
 from dataclasses import dataclass
 from pathlib import Path
@@ -177,32 +176,13 @@ def resolve_input_api(api_name):
     return resolved_api
 
 
-def _inspect_input_signature(api):
-    try:
-        return inspect.signature(api)
-    except (TypeError, ValueError):
-        return None
-
-
-@functools.lru_cache(maxsize=512)
-def _inspect_input_signature_cached(api):
-    """缓存 worker 内稳定 callable 的反射元数据。"""
-    return _inspect_input_signature(api)
-
-
-def _inspect_input_signature_with_cache(api):
-    try:
-        # callable 进入键后，运行时重绑定会自然触发新一轮反射。
-        return _inspect_input_signature_cached(api)
-    except TypeError:
-        # 不可哈希 callable 保留原语义，不因缓存支持范围而失败。
-        return _inspect_input_signature(api)
-
-
 def resolve_input_signature(api_name, api=None):
     # 可反射 API 使用真实签名；无签名 C-op 只接受明确的公共别名。
     api = api or resolve_input_api(api_name)
-    signature = _inspect_input_signature_with_cache(api)
+    try:
+        signature = inspect.signature(api)
+    except (TypeError, ValueError):
+        signature = None
     source = "signature"
     # api 参数由执行侧传入时可避免重复解析，但解析规则保持一致。
     if signature is None:
@@ -212,8 +192,10 @@ def resolve_input_signature(api_name, api=None):
                 None, "unresolved", "API has no inspectable signature or public alias"
             )
         public_api = resolve_input_api(public_api_name)
-        # 别名仍逐次解析当前 callable，避免 monkeypatch 或运行时重绑定命中旧签名。
-        signature = _inspect_input_signature_with_cache(public_api)
+        try:
+            signature = inspect.signature(public_api)
+        except (TypeError, ValueError):
+            signature = None
         if signature is None:
             return InputSignatureResult(
                 None, "unresolved", f"public alias has no signature: {public_api_name}"

--- a/tester/base.py
+++ b/tester/base.py
@@ -1251,6 +1251,12 @@ class APITestBase:
         max_rel_diff = -1.0
         max_rel_index = 0
         exact_compare = atol == 0.0 and rtol == 0.0
+        exact_integral_compare = exact_compare and not (
+            actual_dtype.is_floating_point
+            or actual_dtype.is_complex
+            or expected_dtype.is_floating_point
+            or expected_dtype.is_complex
+        )
         for start, actual_chunk, expected_chunk in chunks:
             if actual_chunk.dtype != expected_chunk.dtype:
                 # Match TensorLikePair._equalize_attributes without promoting
@@ -1271,6 +1277,11 @@ class APITestBase:
                 compare_dtype = torch.promote_types(actual_promote_dtype, expected_promote_dtype)
                 actual_chunk = actual_chunk.to(compare_dtype)
                 expected_chunk = expected_chunk.to(compare_dtype)
+
+            # 整数通过路径只需要融合 reduction；失败后仍走原诊断以保留 mismatch 详情。
+            if exact_integral_compare and torch.equal(actual_chunk, expected_chunk):
+                # 整数相等已由单个 reduction 完成，失败时再计算详细 mismatch。
+                continue
 
             if exact_compare:
                 equal = actual_chunk == expected_chunk
@@ -1653,6 +1664,59 @@ class APITestBase:
 
         # DLPack 只负责跨框架表示转换，转换后的 Tensor 还要统一搬到比较设备。
         # 因此 CPU kernel 与 GPU compare 的组合不会因源 Tensor 在 CPU 而退回 CPU compare。
+
+        if comparison_device.type == "cuda" and (is_cpu_tensor(actual) or is_cpu_tensor(expected)):
+            estimated_temp_bytes = self._comparison_temporary_bytes(actual, expected)
+            working_bytes = self._resolve_comparison_workspace(
+                actual,
+                estimated_temp_bytes,
+                dual_gpu,
+                comparison_device_id=comparison_device_id,
+            )
+            cpu_result_bytes = sum(
+                int(value.numel()) * _tensor_element_size(value)
+                for value in (actual, expected)
+                if is_cpu_tensor(value)
+            )
+            try:
+                free_bytes, _ = torch.cuda.mem_get_info(comparison_device_id)
+            except Exception:
+                free_bytes = 0
+            # 只有完整 CPU 结果无法和 workspace 同时驻留时，才逐 slab 搬运。
+            if cpu_result_bytes and free_bytes < cpu_result_bytes + working_bytes:
+                # 显存不足时只搬运当前 logical slab，禁止完整 CPU 结果制造峰值。
+                if tuple(actual.shape) != tuple(expected.shape):
+                    raise AssertionError(
+                        f"shape mismatch: {actual_name} {tuple(actual.shape)}, "
+                        f"{expected_name} {tuple(expected.shape)}"
+                    )
+                if is_check_dtype:
+                    actual_dtype = self._framework_tensor_torch_dtype(actual)
+                    expected_dtype = self._framework_tensor_torch_dtype(expected)
+                    if actual_dtype != expected_dtype:
+                        raise AssertionError(
+                            f"dtype mismatch: {actual_name} {actual_dtype}, "
+                            f"{expected_name} {expected_dtype}"
+                        )
+
+                def stream_error_msg(msg):
+                    return (
+                        f"Not equal to tolerance rtol={rtol}, atol={atol}\n"
+                        f"{msg}\n{actual_name}: shape={tuple(actual.shape)}\n"
+                        f"{expected_name}: shape={tuple(expected.shape)}"
+                    )
+
+                self._torch_assert_accuracy_in_logical_slabs(
+                    actual,
+                    expected,
+                    atol,
+                    rtol,
+                    stream_error_msg,
+                    working_bytes,
+                    comparison_device,
+                    is_check_dtype,
+                )
+                return
 
         if not actual.is_contiguous() or not expected.is_contiguous():
             actual_shape = tuple(actual.shape)

--- a/tester/base.py
+++ b/tester/base.py
@@ -28,7 +28,22 @@ from .input_generation.tensor_config import (
 from .reporting import log_worker
 from .reporting.dump_writer import DEFAULT_DUMP_DIR, DumpContext, dump_enabled
 from .reporting.log_comparison import log_accuracy_tolerance
-from .reporting.log_schema import MAX_CSV_CONFIG_LENGTH
+from .reporting.log_schema import (
+    COMPARE_BACKWARD_STAGE,
+    COMPARE_FORWARD_STAGE,
+    INPUT_STAGE,
+    MAX_CSV_CONFIG_LENGTH,
+    MEMORY_PREFLIGHT_STAGE,
+    PADDLE_BACKWARD_STAGE,
+    PADDLE_BACKWARD_SYNC_STAGE,
+    PADDLE_FORWARD_STAGE,
+    PADDLE_FORWARD_SYNC_STAGE,
+    TORCH_BACKWARD_STAGE,
+    TORCH_BACKWARD_SYNC_STAGE,
+    TORCH_FORWARD_STAGE,
+    TORCH_FORWARD_SYNC_STAGE,
+    Stage,
+)
 from .runtime.gpu_memory_preflight import (
     GpuMemoryDeferred,
     decide_gpu_memory_preflight,
@@ -45,8 +60,6 @@ not_check_dtype = frozenset(config.get("not_check_dtype", []))
 rand_apis = frozenset(config.get("rand_apis", []))
 stochastic_behavior_apis = frozenset(config.get("stochastic_behavior_apis", []))
 
-paddle_error_dismiss = {}  # disabled: covered by the unified runtime error reporter
-# paddle_error_dismiss = config.get("paddle_error_dismiss", {})
 special_accuracy_atol_rtol = config.get("special_accuracy_atol_rtol", {})
 
 with (_TESTER_DIR / "api_config" / "torch_error_skip.txt").open(encoding="utf-8") as f:
@@ -309,6 +322,20 @@ def classify_runtime_error(error_msg):
 
 
 class APITestBase:
+    # tester 只引用这一组阶段常量，避免各模式重新拼接框架与执行阶段。
+    STAGE_INPUT = INPUT_STAGE
+    STAGE_PADDLE_FORWARD = PADDLE_FORWARD_STAGE
+    STAGE_PADDLE_BACKWARD = PADDLE_BACKWARD_STAGE
+    STAGE_PADDLE_FORWARD_SYNC = PADDLE_FORWARD_SYNC_STAGE
+    STAGE_PADDLE_BACKWARD_SYNC = PADDLE_BACKWARD_SYNC_STAGE
+    STAGE_TORCH_FORWARD = TORCH_FORWARD_STAGE
+    STAGE_TORCH_BACKWARD = TORCH_BACKWARD_STAGE
+    STAGE_TORCH_FORWARD_SYNC = TORCH_FORWARD_SYNC_STAGE
+    STAGE_TORCH_BACKWARD_SYNC = TORCH_BACKWARD_SYNC_STAGE
+    STAGE_COMPARE_FORWARD = COMPARE_FORWARD_STAGE
+    STAGE_COMPARE_BACKWARD = COMPARE_BACKWARD_STAGE
+    STAGE_MEMORY_PREFLIGHT = MEMORY_PREFLIGHT_STAGE
+
     def __init__(self, api_config, use_torch=True, runtime_config=None):
         # case 只能消费主进程冻结后的策略，不能在 worker 内根据环境重新选择 backend。
         if runtime_config is None:
@@ -408,8 +435,7 @@ class APITestBase:
         self,
         err,
         default_log_type,
-        phase,
-        allow_ignore_paddle=False,
+        stage: Stage,
         *,
         tensor_position=None,
         force_log_type=None,
@@ -421,20 +447,17 @@ class APITestBase:
         from classify_runtime_error().
         """
         err_msg = str(err)
-        if phase:
-            self.dump_error(f"{phase}_error", err)
+        # dump 事件保留阶段派生名，inorder 日志使用统一直接文本。
+        if stage:
+            self.dump_error(f"{stage.lower().replace(' ', '_')}_error", err)
         log_type, fatal = classify_runtime_error(err_msg)
-        if log_type is None and allow_ignore_paddle and self.should_ignore_paddle_error(err_msg):
-            log_type = "pass"
-            self.report_case_result(log_type, affected_comps=affected_comps)
-            return log_type, False
         if force_log_type is not None:
             log_type = force_log_type
         if log_type is None:
             log_type = default_log_type
         self.report_case_result(
             log_type,
-            phase=phase,
+            stage=stage,
             error=err_msg,
             tensor_position=tensor_position,
             affected_comps=affected_comps,
@@ -446,7 +469,7 @@ class APITestBase:
         log_type,
         message=None,
         *,
-        phase=None,
+        stage: Stage | None = None,
         error=None,
         tensor_position=None,
         affected_comps=None,
@@ -456,7 +479,7 @@ class APITestBase:
         log_worker.emit_case_result(
             log_type,
             self.api_config.config,
-            phase=phase,
+            stage=stage,
             message=message,
             error=error,
             tensor_position=tensor_position,
@@ -491,7 +514,11 @@ class APITestBase:
             if decision.should_skip:
                 message = decision.message()
                 self.record_memory_governance_metric("memory_preflight_oom")
-                self.report_case_result("oom", phase="preflight", message=message)
+                self.report_case_result(
+                    "oom",
+                    stage=self.STAGE_MEMORY_PREFLIGHT,
+                    message=message,
+                )
                 self.dump_finalize("oom", memory_preflight=message)
                 return False
             compute_stages = tuple(
@@ -614,7 +641,7 @@ class APITestBase:
     def report_compare_error(
         self,
         err,
-        phase,
+        stage: Stage,
         default_log_type="paddle_accuracy",
         *,
         tensor_position=None,
@@ -622,7 +649,7 @@ class APITestBase:
         log_type, fatal = self.report_runtime_error(
             err,
             default_log_type,
-            phase,
+            stage,
             tensor_position=tensor_position,
         )
         if fatal:
@@ -2260,16 +2287,6 @@ class APITestBase:
     def is_forward_only(self):
         api = self.api_config.api_name[self.api_config.api_name.rindex(".") + 1 :]
         return api in forward_only_apis
-
-    def should_ignore_paddle_error(self, error_msg):
-        dismiss_errors = paddle_error_dismiss.get(self.api_config.api_name, None)
-        if dismiss_errors is None:
-            return False
-        if isinstance(dismiss_errors, str):
-            return dismiss_errors in error_msg
-        elif isinstance(dismiss_errors, (list, tuple)):
-            return any(error in error_msg for error in dismiss_errors)
-        return False
 
     def should_check_dtype(self):
         return self.api_config.api_name not in not_check_dtype

--- a/tester/base.py
+++ b/tester/base.py
@@ -365,20 +365,8 @@ class APITestBase:
         self.comparison_workspace_cache = {}
         if use_torch:
             # worker 数增大时按卡分摊 Torch 线程，单 worker 保持原有 8 线程默认值。
-            try:
-                workers_on_gpu = max(1, int(os.environ.get("PADDLEAPITEST_WORKERS_ON_GPU", "1")))
-            except (TypeError, ValueError):
-                workers_on_gpu = 1
-            default_torch_threads = max(1, 8 // workers_on_gpu)
-            raw_torch_threads = os.environ.get(
-                "PADDLEAPITEST_TORCH_NUM_THREADS", str(default_torch_threads)
-            )
-            try:
-                torch_threads = int(raw_torch_threads)
-            except (TypeError, ValueError):
-                # 外部环境变量可能来自调度系统，非法值仍按当前 worker 数回退。
-                torch_threads = default_torch_threads
-            torch.set_num_threads(max(1, torch_threads))
+            workers_on_gpu = max(1, int(os.environ.get("PADDLEAPITEST_WORKERS_ON_GPU", "1")))
+            torch.set_num_threads(max(1, 8 // workers_on_gpu))
             torch.set_printoptions(threshold=100, linewidth=120)
 
     def torch_operator_device(self):
@@ -1251,12 +1239,6 @@ class APITestBase:
         max_rel_diff = -1.0
         max_rel_index = 0
         exact_compare = atol == 0.0 and rtol == 0.0
-        exact_integral_compare = exact_compare and not (
-            actual_dtype.is_floating_point
-            or actual_dtype.is_complex
-            or expected_dtype.is_floating_point
-            or expected_dtype.is_complex
-        )
         for start, actual_chunk, expected_chunk in chunks:
             if actual_chunk.dtype != expected_chunk.dtype:
                 # Match TensorLikePair._equalize_attributes without promoting
@@ -1277,11 +1259,6 @@ class APITestBase:
                 compare_dtype = torch.promote_types(actual_promote_dtype, expected_promote_dtype)
                 actual_chunk = actual_chunk.to(compare_dtype)
                 expected_chunk = expected_chunk.to(compare_dtype)
-
-            # 整数通过路径只需要融合 reduction；失败后仍走原诊断以保留 mismatch 详情。
-            if exact_integral_compare and torch.equal(actual_chunk, expected_chunk):
-                # 整数相等已由单个 reduction 完成，失败时再计算详细 mismatch。
-                continue
 
             if exact_compare:
                 equal = actual_chunk == expected_chunk
@@ -1664,59 +1641,6 @@ class APITestBase:
 
         # DLPack 只负责跨框架表示转换，转换后的 Tensor 还要统一搬到比较设备。
         # 因此 CPU kernel 与 GPU compare 的组合不会因源 Tensor 在 CPU 而退回 CPU compare。
-
-        if comparison_device.type == "cuda" and (is_cpu_tensor(actual) or is_cpu_tensor(expected)):
-            estimated_temp_bytes = self._comparison_temporary_bytes(actual, expected)
-            working_bytes = self._resolve_comparison_workspace(
-                actual,
-                estimated_temp_bytes,
-                dual_gpu,
-                comparison_device_id=comparison_device_id,
-            )
-            cpu_result_bytes = sum(
-                int(value.numel()) * _tensor_element_size(value)
-                for value in (actual, expected)
-                if is_cpu_tensor(value)
-            )
-            try:
-                free_bytes, _ = torch.cuda.mem_get_info(comparison_device_id)
-            except Exception:
-                free_bytes = 0
-            # 只有完整 CPU 结果无法和 workspace 同时驻留时，才逐 slab 搬运。
-            if cpu_result_bytes and free_bytes < cpu_result_bytes + working_bytes:
-                # 显存不足时只搬运当前 logical slab，禁止完整 CPU 结果制造峰值。
-                if tuple(actual.shape) != tuple(expected.shape):
-                    raise AssertionError(
-                        f"shape mismatch: {actual_name} {tuple(actual.shape)}, "
-                        f"{expected_name} {tuple(expected.shape)}"
-                    )
-                if is_check_dtype:
-                    actual_dtype = self._framework_tensor_torch_dtype(actual)
-                    expected_dtype = self._framework_tensor_torch_dtype(expected)
-                    if actual_dtype != expected_dtype:
-                        raise AssertionError(
-                            f"dtype mismatch: {actual_name} {actual_dtype}, "
-                            f"{expected_name} {expected_dtype}"
-                        )
-
-                def stream_error_msg(msg):
-                    return (
-                        f"Not equal to tolerance rtol={rtol}, atol={atol}\n"
-                        f"{msg}\n{actual_name}: shape={tuple(actual.shape)}\n"
-                        f"{expected_name}: shape={tuple(expected.shape)}"
-                    )
-
-                self._torch_assert_accuracy_in_logical_slabs(
-                    actual,
-                    expected,
-                    atol,
-                    rtol,
-                    stream_error_msg,
-                    working_bytes,
-                    comparison_device,
-                    is_check_dtype,
-                )
-                return
 
         if not actual.is_contiguous() or not expected.is_contiguous():
             actual_shape = tuple(actual.shape)

--- a/tester/base.py
+++ b/tester/base.py
@@ -364,7 +364,21 @@ class APITestBase:
         # 同一 case 的结果树共享设备快照，避免每个叶子重复查询 CUDA allocator。
         self.comparison_workspace_cache = {}
         if use_torch:
-            torch.set_num_threads(8)
+            # worker 数增大时按卡分摊 Torch 线程，单 worker 保持原有 8 线程默认值。
+            try:
+                workers_on_gpu = max(1, int(os.environ.get("PADDLEAPITEST_WORKERS_ON_GPU", "1")))
+            except (TypeError, ValueError):
+                workers_on_gpu = 1
+            default_torch_threads = max(1, 8 // workers_on_gpu)
+            raw_torch_threads = os.environ.get(
+                "PADDLEAPITEST_TORCH_NUM_THREADS", str(default_torch_threads)
+            )
+            try:
+                torch_threads = int(raw_torch_threads)
+            except (TypeError, ValueError):
+                # 外部环境变量可能来自调度系统，非法值仍按当前 worker 数回退。
+                torch_threads = default_torch_threads
+            torch.set_num_threads(max(1, torch_threads))
             torch.set_printoptions(threshold=100, linewidth=120)
 
     def torch_operator_device(self):

--- a/tester/input_generation/backend.py
+++ b/tester/input_generation/backend.py
@@ -47,7 +47,7 @@ def _direct_float_dtype(dtype, shape):
     if not _large_shape(shape):
         return None
     storage_dtype = resolve_input_dtype(dtype) if dtype is not None else None
-    return storage_dtype if storage_dtype in {"float16", "bfloat16"} else None
+    return storage_dtype if storage_dtype == "float16" else None
 
 
 def _direct_int32(dtype, shape, low, high):
@@ -753,7 +753,7 @@ class PaddleInputBackend:
     def random(self, shape=None, dtype=None):
         paddle = self._paddle()
         direct_dtype = _direct_float_dtype(dtype, shape)
-        # 默认随机原语先生成稳定 float32 storage，再按逻辑 dtype 转换。
+        # 小配置保持稳定 float32 stream，大 float16 避免高精度临时值。
         value = self._run_random(
             lambda: paddle.rand(
                 self._paddle_shape(shape),
@@ -797,14 +797,15 @@ class PaddleInputBackend:
 
     def randn(self, *shape, dtype=None):
         paddle = self._paddle()
+        direct_dtype = _direct_float_dtype(dtype, shape)
         value = self._run_random(
             lambda: paddle.randn(
                 self._paddle_shape(shape),
-                dtype="float32",
+                dtype=direct_dtype or "float32",
                 device=self.device,
             )
         )
-        return self.cast(value, dtype) if dtype is not None else value
+        return self.cast(value, dtype) if dtype is not None and not direct_dtype else value
 
     def choice(self, values, shape=None, replace=True, p=None):
         paddle = self._paddle()

--- a/tester/input_generation/backend.py
+++ b/tester/input_generation/backend.py
@@ -15,6 +15,9 @@ from .value_generators import (
     resolve_input_dtype,
 )
 
+# 大 Tensor 才切换目标 storage dtype，避免改变小配置既有随机序列。
+DIRECT_DTYPE_NUMEL_THRESHOLD = 1 << 20
+
 
 def _normalize_shape(shape, *, scalar_empty):
     """统一 NumPy 与原生 backend 对标量 shape 的边界表示。"""
@@ -30,6 +33,29 @@ def _choice_shape(shape, *, scalar_empty):
     scalar = shape is None
     normalized = _normalize_shape(shape, scalar_empty=scalar_empty)
     return scalar, normalized, 1 if scalar else int(numpy.prod(normalized))
+
+
+def _large_shape(shape):
+    """判断是否值得避免高精度临时 Tensor。"""
+    _, _, numel = _choice_shape(shape, scalar_empty=False)
+    return numel >= DIRECT_DTYPE_NUMEL_THRESHOLD
+
+
+def _direct_float_dtype(dtype, shape):
+    """返回大 Tensor 可直接生成的浮点 storage dtype。"""
+    # 低精度直生只对超过阈值的随机输入生效，避免改变小配置的随机序列。
+    if not _large_shape(shape):
+        return None
+    storage_dtype = resolve_input_dtype(dtype) if dtype is not None else None
+    return storage_dtype if storage_dtype in {"float16", "bfloat16"} else None
+
+
+def _direct_int32(dtype, shape, low, high):
+    """仅在边界可表达时使用 int32 原生随机算子。"""
+    # randint 边界必须能由 int32 表达，避免生成后 cast 造成索引回绕。
+    if not _large_shape(shape) or resolve_input_dtype(dtype) != "int32":
+        return False
+    return -(1 << 31) <= int(low) < int(high) <= (1 << 31)
 
 
 @runtime_checkable
@@ -367,52 +393,60 @@ class TorchInputBackend:
     def random(self, shape=None, dtype=None):
         torch = self._torch()
         torch_shape = self._torch_shape(shape)
+        direct_dtype = _direct_float_dtype(dtype, shape)
         value = torch.rand(
             torch_shape,
-            dtype=torch.float32,
+            dtype=self._torch_dtype(direct_dtype) if direct_dtype else torch.float32,
             device=self._device,
             generator=self._generator,
         )
-        return self.cast(value, dtype) if dtype is not None else value
+        return self.cast(value, dtype) if dtype is not None and not direct_dtype else value
 
     def uniform(self, low=0.0, high=1.0, shape=None, dtype=None):
         torch = self._torch()
         torch_shape = self._torch_shape(shape)
+        direct_dtype = _direct_float_dtype(dtype, shape)
         value = torch.empty(
             torch_shape,
-            dtype=self._resolve_torch_float_dtype(dtype),
+            dtype=(
+                self._torch_dtype(direct_dtype)
+                if direct_dtype
+                else self._resolve_torch_float_dtype(dtype)
+            ),
             device=self._device,
         ).uniform_(
             float(low),
             float(high),
             generator=self._generator,
         )
-        return self.cast(value, dtype) if dtype is not None else value
+        return self.cast(value, dtype) if dtype is not None and not direct_dtype else value
 
     def randint(self, low, high=None, shape=None, dtype=None):
         torch = self._torch()
         torch_shape = self._torch_shape(shape)
         if high is None:
             low, high = 0, low
+        direct_int32 = _direct_int32(dtype, shape, low, high)
         value = torch.randint(
             int(low),
             int(high),
             torch_shape,
-            dtype=torch.int64,
+            dtype=torch.int32 if direct_int32 else torch.int64,
             device=self._device,
             generator=self._generator,
         )
-        return self.cast(value, dtype) if dtype is not None else value
+        return self.cast(value, dtype) if dtype is not None and not direct_int32 else value
 
     def randn(self, *shape, dtype=None):
         torch = self._torch()
+        direct_dtype = _direct_float_dtype(dtype, shape)
         value = torch.randn(
             tuple(shape),
-            dtype=torch.float32,
+            dtype=self._torch_dtype(direct_dtype) if direct_dtype else torch.float32,
             device=self._device,
             generator=self._generator,
         )
-        return self.cast(value, dtype) if dtype is not None else value
+        return self.cast(value, dtype) if dtype is not None and not direct_dtype else value
 
     def choice(self, values, shape=None, replace=True, p=None):
         torch = self._torch()
@@ -718,45 +752,48 @@ class PaddleInputBackend:
 
     def random(self, shape=None, dtype=None):
         paddle = self._paddle()
+        direct_dtype = _direct_float_dtype(dtype, shape)
         # 默认随机原语先生成稳定 float32 storage，再按逻辑 dtype 转换。
         value = self._run_random(
             lambda: paddle.rand(
                 self._paddle_shape(shape),
-                dtype="float32",
+                dtype=direct_dtype or "float32",
                 device=self.device,
             )
         )
-        return self.cast(value, dtype) if dtype is not None else value
+        return self.cast(value, dtype) if dtype is not None and not direct_dtype else value
 
     def uniform(self, low=0.0, high=1.0, shape=None, dtype=None):
         paddle = self._paddle()
+        direct_dtype = _direct_float_dtype(dtype, shape)
         # seed=0 表示消费刚挂载的设备 generator，而不是创建算子私有固定 seed。
         value = self._run_random(
             lambda: paddle.uniform(
                 self._paddle_shape(shape),
-                dtype=self._resolve_paddle_float_dtype(dtype),
+                dtype=direct_dtype or self._resolve_paddle_float_dtype(dtype),
                 min=float(low),
                 max=float(high),
                 seed=0,
                 device=self.device,
             )
         )
-        return self.cast(value, dtype) if dtype is not None else value
+        return self.cast(value, dtype) if dtype is not None and not direct_dtype else value
 
     def randint(self, low, high=None, shape=None, dtype=None):
         if high is None:
             low, high = 0, low
         paddle = self._paddle()
+        direct_int32 = _direct_int32(dtype, shape, low, high)
         value = self._run_random(
             lambda: paddle.randint(
                 int(low),
                 int(high),
                 self._paddle_shape(shape),
-                dtype="int64",
+                dtype="int32" if direct_int32 else "int64",
                 device=self.device,
             )
         )
-        return self.cast(value, dtype) if dtype is not None else value
+        return self.cast(value, dtype) if dtype is not None and not direct_int32 else value
 
     def randn(self, *shape, dtype=None):
         paddle = self._paddle()

--- a/tester/input_generation/generation_rules.py
+++ b/tester/input_generation/generation_rules.py
@@ -2683,7 +2683,8 @@ def generate_take_along_axis_inputs(rule: InputRuleContext):
     """输入规则：按目标 axis 尺寸限制 take_along_axis 索引。"""
 
     def generate_indices_input_value(input_binding):
-        arr_shape = rule.arg("arr").shape
+        # 函数参数名为 arr，Tensor method 的接收者绑定后统一为 x。
+        arr_shape = rule.arg("arr", rule.arg("x")).shape
         axis = rule.arg("axis")
         generate_axis_input_value = axis if axis >= 0 else axis + len(arr_shape)
         dim_size = arr_shape[generate_axis_input_value]

--- a/tester/paddle_cinn_vs_dygraph.py
+++ b/tester/paddle_cinn_vs_dygraph.py
@@ -31,13 +31,15 @@ class APITestCINNVSDygraph(APITestBase):
                 self.report_case_result("config_input", "generate_input_values failed")
                 return
         except Exception as err:
-            log_type, fatal = self.report_runtime_error(err, "config_input", "input")
+            log_type, fatal = self.report_runtime_error(err, "config_input", self.STAGE_INPUT)
             if fatal:
                 raise
             return
 
         if not self.build_paddle_input():
-            self.report_case_result("paddle_error", "build_paddle_input failed")
+            self.report_case_result(
+                "paddle_error", "build_paddle_input failed", stage=self.STAGE_INPUT
+            )
             return
 
         try:
@@ -68,8 +70,7 @@ class APITestCINNVSDygraph(APITestBase):
             _, fatal = self.report_runtime_error(
                 err,
                 "paddle_error",
-                "dynamic forward",
-                allow_ignore_paddle=True,
+                self.STAGE_PADDLE_FORWARD,
             )
             if fatal:
                 raise
@@ -78,7 +79,7 @@ class APITestCINNVSDygraph(APITestBase):
         try:
             self.check_operator_cuda_error()
         except Exception as err:
-            self.report_runtime_error(err, "paddle_cuda", "dynamic forward cuda check")
+            self.report_runtime_error(err, "paddle_cuda", self.STAGE_PADDLE_FORWARD_SYNC)
             raise
 
         need_check_grad = self.test_backward and self.need_check_grad()
@@ -107,15 +108,14 @@ class APITestCINNVSDygraph(APITestBase):
                     self.report_runtime_error(
                         err,
                         "config_input",
-                        "dynamic backward",
+                        self.STAGE_PADDLE_BACKWARD,
                         force_log_type="config_input",
                     )
                     return
                 _, fatal = self.report_runtime_error(
                     err,
                     "paddle_error",
-                    "dynamic backward",
-                    allow_ignore_paddle=True,
+                    self.STAGE_PADDLE_BACKWARD,
                 )
                 if fatal:
                     raise
@@ -124,7 +124,7 @@ class APITestCINNVSDygraph(APITestBase):
             try:
                 self.check_operator_cuda_error()
             except Exception as err:
-                self.report_runtime_error(err, "paddle_cuda", "dynamic backward cuda check")
+                self.report_runtime_error(err, "paddle_cuda", self.STAGE_PADDLE_BACKWARD_SYNC)
                 raise
 
         try:
@@ -207,15 +207,14 @@ class APITestCINNVSDygraph(APITestBase):
                 self.report_runtime_error(
                     err,
                     "config_input",
-                    "static",
+                    self.STAGE_PADDLE_BACKWARD if need_check_grad else self.STAGE_PADDLE_FORWARD,
                     force_log_type="config_input",
                 )
                 return
             _, fatal = self.report_runtime_error(
                 err,
                 "paddle_error",
-                "static",
-                allow_ignore_paddle=True,
+                self.STAGE_PADDLE_BACKWARD if need_check_grad else self.STAGE_PADDLE_FORWARD,
             )
             if fatal:
                 raise
@@ -224,7 +223,13 @@ class APITestCINNVSDygraph(APITestBase):
         try:
             self.check_operator_cuda_error()
         except Exception as err:
-            self.report_runtime_error(err, "paddle_cuda", "static cuda check")
+            self.report_runtime_error(
+                err,
+                "paddle_cuda",
+                self.STAGE_PADDLE_BACKWARD_SYNC
+                if need_check_grad
+                else self.STAGE_PADDLE_FORWARD_SYNC,
+            )
             raise
 
         if not self.compare(dynamic_fwd_output, static_fwd_output):
@@ -237,28 +242,28 @@ class APITestCINNVSDygraph(APITestBase):
         self.report_case_result("pass")
 
     def compare(self, dygraph_output, static_output, is_backward=False):
-        backward_str = "backward " if is_backward else ""
+        stage = self.STAGE_COMPARE_BACKWARD if is_backward else self.STAGE_COMPARE_FORWARD
         self.is_backward = is_backward
         if isinstance(dygraph_output, paddle.Tensor):
             if not isinstance(static_output, paddle.Tensor):
                 self.report_case_result(
                     "config_parse",
                     "match error",
-                    phase=backward_str.strip() or None,
+                    stage=stage,
                     error=f"type not match, dygraph: {type(dygraph_output)}, static: {type(static_output)}",
                 )
                 return False
             try:
                 self.paddle_assert_accuracy(dygraph_output, static_output)
             except Exception as err:
-                self.report_compare_error(err, backward_str.strip())
+                self.report_compare_error(err, stage)
                 return False
         elif isinstance(dygraph_output, (list, tuple)):
             if not isinstance(static_output, (list, tuple)):
                 self.report_case_result(
                     "config_parse",
                     "match error",
-                    phase=backward_str.strip() or None,
+                    stage=stage,
                     error=f"type not match, dygraph: {type(dygraph_output)}, static: {type(static_output)}",
                 )
                 return False
@@ -268,7 +273,7 @@ class APITestCINNVSDygraph(APITestBase):
                 self.report_case_result(
                     "config_parse",
                     "match error",
-                    phase=backward_str.strip() or None,
+                    stage=stage,
                     error=f"length not match, dygraph: {len(dygraph_output)}, static: {len(static_output)}",
                 )
                 return False
@@ -283,7 +288,7 @@ class APITestCINNVSDygraph(APITestBase):
                     self.report_case_result(
                         "config_parse",
                         "match error",
-                        phase=backward_str.strip() or None,
+                        stage=stage,
                         tensor_position=f"{i + 1}/{len(dygraph_output)}",
                         error=f"type not match, dygraph: {type(dygraph_item)}, static: {type(static_item)}",
                     )
@@ -291,9 +296,11 @@ class APITestCINNVSDygraph(APITestBase):
                 try:
                     self.paddle_assert_accuracy(dygraph_item, static_item)
                 except Exception as err:
-                    position = f"tensor {i + 1}/{len(dygraph_output)}"
-                    phase = f"{backward_str.strip()} | {position}" if backward_str else position
-                    self.report_compare_error(err, phase)
+                    self.report_compare_error(
+                        err,
+                        stage,
+                        tensor_position=f"{i + 1}/{len(dygraph_output)}",
+                    )
                     return False
         elif dygraph_output is None and static_output is None:
             pass
@@ -301,7 +308,7 @@ class APITestCINNVSDygraph(APITestBase):
             self.report_case_result(
                 "config_parse",
                 "match error",
-                phase=backward_str.strip() or None,
+                stage=stage,
                 error=f"type not match, dygraph: {type(dygraph_output)}, static: {type(static_output)}",
             )
             return False

--- a/tester/paddle_device_vs_cpu.py
+++ b/tester/paddle_device_vs_cpu.py
@@ -55,12 +55,15 @@ class APITestCustomDeviceVSCPU(APITestBase):
                 print(f"build_paddle_input failed on {device_type}", flush=True)
                 return None, None
 
-            # Forward
-            if self.test_amp:
-                with paddle.amp.auto_cast():
+            try:
+                if self.test_amp:
+                    with paddle.amp.auto_cast():
+                        output = self.paddle_api(*tuple(self.paddle_args), **self.paddle_kwargs)
+                else:
                     output = self.paddle_api(*tuple(self.paddle_args), **self.paddle_kwargs)
-            else:
-                output = self.paddle_api(*tuple(self.paddle_args), **self.paddle_kwargs)
+            except Exception as err:
+                self.report_runtime_error(err, "paddle_error", self.STAGE_PADDLE_FORWARD)
+                return None, None
 
             # Backward
             out_grads = None
@@ -79,12 +82,8 @@ class APITestCustomDeviceVSCPU(APITestBase):
                             allow_unused=True,
                         )
                     except Exception as grad_err:
-                        print(
-                            f"[{device_type} backward error]",
-                            self.api_config.config,
-                            "\n",
-                            str(grad_err),
-                            flush=True,
+                        self.report_runtime_error(
+                            grad_err, "paddle_error", self.STAGE_PADDLE_BACKWARD
                         )
                         out_grads = None
                 else:
@@ -96,13 +95,7 @@ class APITestCustomDeviceVSCPU(APITestBase):
             return output, out_grads
 
         except Exception as err:
-            print(
-                f"[{device_type} error]",
-                self.api_config.config,
-                "\n",
-                str(err),
-                flush=True,
-            )
+            self.report_runtime_error(err, "paddle_error", self.STAGE_INPUT)
             return None, None
 
     def _compare_single_tensor(self, cpu_tensor, custom_tensor, tensor_name=""):
@@ -127,8 +120,12 @@ class APITestCustomDeviceVSCPU(APITestBase):
             return True
 
         except Exception as err:
-            phase = f"compare {tensor_name}" if tensor_name else "compare"
-            self.report_compare_error(err, phase)
+            stage = (
+                self.STAGE_COMPARE_BACKWARD
+                if "gradient" in tensor_name
+                else self.STAGE_COMPARE_FORWARD
+            )
+            self.report_compare_error(err, stage)
             return False
 
     def compare_outputs(self, cpu_output, custom_output):
@@ -250,7 +247,7 @@ class APITestCustomDeviceVSCPU(APITestBase):
                 self.report_case_result("config_input", "generate_input_values failed")
                 return
         except Exception as err:
-            log_type, fatal = self.report_runtime_error(err, "config_input", "input")
+            log_type, fatal = self.report_runtime_error(err, "config_input", self.STAGE_INPUT)
             if fatal:
                 raise
             return
@@ -258,13 +255,17 @@ class APITestCustomDeviceVSCPU(APITestBase):
         # 5. Run API on CPU (including forward and backward)
         cpu_output, cpu_grads = self.run_on_device("cpu", 0)
         if cpu_output is None:
-            self.report_case_result("paddle_error", "cpu execution failed")
+            self.report_case_result(
+                "paddle_error", "cpu execution failed", stage=self.STAGE_PADDLE_FORWARD
+            )
             return
 
         # 6. Run API on target device (including forward and backward)
         tgt_output, tgt_grads = self.run_on_device(target_device, device_id)
         if tgt_output is None:
-            self.report_case_result("paddle_error", f"{target_device} execution failed")
+            self.report_case_result(
+                "paddle_error", f"{target_device} execution failed", stage=self.STAGE_PADDLE_FORWARD
+            )
             return
 
         # 7. Compare forward results
@@ -277,7 +278,11 @@ class APITestCustomDeviceVSCPU(APITestBase):
             print("[Backward test begin]")
 
             if cpu_grads is None:
-                self.report_case_result("paddle_error", "cpu backward execution failed")
+                self.report_case_result(
+                    "paddle_error",
+                    "cpu backward execution failed",
+                    stage=self.STAGE_PADDLE_BACKWARD,
+                )
                 backward_pass = False
             elif tgt_grads is None:
                 self.report_case_result(

--- a/tester/paddle_device_vs_gpu.py
+++ b/tester/paddle_device_vs_gpu.py
@@ -161,7 +161,9 @@ class APITestPaddleDeviceVSGPU(APITestCustomDeviceVSCPU):
                 return None, None
 
             if not self.build_paddle_input():
-                self.report_case_result("paddle_error", "build_paddle_input failed")
+                self.report_case_result(
+                    "paddle_error", "build_paddle_input failed", stage=self.STAGE_INPUT
+                )
                 return None, None
 
             paddle_output = self.paddle_api(*tuple(self.paddle_args), **self.paddle_kwargs)
@@ -183,7 +185,10 @@ class APITestPaddleDeviceVSGPU(APITestCustomDeviceVSCPU):
             return paddle_output, paddle_grads
 
         except Exception as e:
-            _, fatal = self.report_runtime_error(e, "paddle_error", f"paddle {paddle_device_type}")
+            stage = (
+                self.STAGE_PADDLE_BACKWARD if self.need_check_grad() else self.STAGE_PADDLE_FORWARD
+            )
+            _, fatal = self.report_runtime_error(e, "paddle_error", stage)
             if fatal:
                 raise
             return None, None
@@ -254,7 +259,7 @@ class APITestPaddleDeviceVSGPU(APITestCustomDeviceVSCPU):
                     flush=True,
                 )
             except Exception as e:
-                self.report_compare_error(e, "download forward")
+                self.report_compare_error(e, self.STAGE_COMPARE_FORWARD)
                 return False
 
             # 对比Backward梯度（如果存在且Forward通过）
@@ -298,7 +303,7 @@ class APITestPaddleDeviceVSGPU(APITestCustomDeviceVSCPU):
                         flush=True,
                     )
                 except Exception as e:
-                    self.report_compare_error(e, "download backward")
+                    self.report_compare_error(e, self.STAGE_COMPARE_BACKWARD)
                     return False
 
             print(
@@ -309,7 +314,7 @@ class APITestPaddleDeviceVSGPU(APITestCustomDeviceVSCPU):
             return True
 
         except Exception as e:
-            self.report_compare_error(e, "download compare")
+            self.report_compare_error(e, self.STAGE_COMPARE_FORWARD)
             return False
 
     def test(self):

--- a/tester/paddle_gpu_performance.py
+++ b/tester/paddle_gpu_performance.py
@@ -31,14 +31,16 @@ class APITestPaddleGPUPerformance(APITestBase):
                 self.report_case_result("config_input", "generate_input_values failed")
                 return
         except Exception as err:
-            log_type, fatal = self.report_runtime_error(err, "config_input", "input")
+            log_type, fatal = self.report_runtime_error(err, "config_input", self.STAGE_INPUT)
             if fatal:
                 raise
             return
 
         try:
             if not self.build_paddle_input():
-                self.report_case_result("paddle_error", "build_paddle_input failed")
+                self.report_case_result(
+                    "paddle_error", "build_paddle_input failed", stage=self.STAGE_INPUT
+                )
                 return
             numel = tensor_config_tree_numel(self.api_config.args, self.api_config.kwargs)
             test_loop = 2147483647 * 20 // numel
@@ -103,15 +105,7 @@ class APITestPaddleGPUPerformance(APITestBase):
                 "\t",
                 "failed",
             )
-            if self.should_ignore_paddle_error(str(err)):
-                self.report_runtime_error(
-                    err,
-                    "paddle_error",
-                    "forward",
-                    allow_ignore_paddle=True,
-                )
-                return
-            _, fatal = self.report_runtime_error(err, "paddle_error", "forward")
+            _, fatal = self.report_runtime_error(err, "paddle_error", self.STAGE_PADDLE_FORWARD)
             if fatal:
                 raise err
             return
@@ -165,15 +159,7 @@ class APITestPaddleGPUPerformance(APITestBase):
                 "\t",
                 "failed",
             )
-            if self.should_ignore_paddle_error(str(err)):
-                self.report_runtime_error(
-                    err,
-                    "paddle_error",
-                    "backward",
-                    allow_ignore_paddle=True,
-                )
-                return
-            _, fatal = self.report_runtime_error(err, "paddle_error", "backward")
+            _, fatal = self.report_runtime_error(err, "paddle_error", self.STAGE_PADDLE_BACKWARD)
             if fatal:
                 raise err
             return

--- a/tester/paddle_only.py
+++ b/tester/paddle_only.py
@@ -221,15 +221,12 @@ class APITestPaddleOnly(APITestBase):
         self,
         err,
         default_log_type,
-        phase,
-        *,
-        allow_ignore_paddle=False,
+        stage,
     ):
         log_type, fatal = self.report_runtime_error(
             err,
             default_log_type,
-            phase,
-            allow_ignore_paddle=allow_ignore_paddle,
+            stage,
         )
         self._finalize_paddle_only(log_type or default_log_type)
         return log_type, fatal
@@ -257,17 +254,27 @@ class APITestPaddleOnly(APITestBase):
                 return
             self.dump_event("numpy_input_done")
         except Exception as err:
-            _, fatal = self._report_paddle_only_error(err, "config_input", "input")
+            _, fatal = self._report_paddle_only_error(
+                err,
+                "config_input",
+                self.STAGE_INPUT,
+            )
             if fatal:
                 raise
             return
 
+        # 豁免范围在阶段边界内恢复，避免吞掉后续阶段的数值检查。
+        exemption_scope = self._nonfinite_exemption_scope()
+        # 输入失败必须单独归类，否则会被误报为前向执行失败。
         try:
-            exemption_scope = self._nonfinite_exemption_scope()
             with self._nan_inf_check_disabled(exemption_scope == "all"):
                 self.dump_event("paddle_input_start")
                 if not self.build_paddle_input():
-                    self.report_case_result("paddle_error", "build_paddle_input failed")
+                    self.report_case_result(
+                        "paddle_error",
+                        "build_paddle_input failed",
+                        stage=self.STAGE_INPUT,
+                    )
                     self._finalize_paddle_only("paddle_error")
                     return
                 self.clear_generated_input_values()
@@ -277,32 +284,62 @@ class APITestPaddleOnly(APITestBase):
                     framework="paddle",
                 )
                 self.dump_event("paddle_input_done")
+        except Exception as err:
+            _, fatal = self._report_paddle_only_error(
+                err,
+                "paddle_error",
+                self.STAGE_INPUT,
+            )
+            if fatal:
+                raise
+            return
 
-                with self._nan_inf_check_disabled(exemption_scope in {"all", "forward"}):
-                    paddle_output = self._run_paddle_forward()
+        # 前向异常不应与反向梯度异常共享同一个错误阶段。
+        try:
+            with self._nan_inf_check_disabled(exemption_scope in {"all", "forward"}):
+                paddle_output = self._run_paddle_forward()
+        except Exception as err:
+            _, fatal = self._report_paddle_only_error(
+                err,
+                "paddle_error",
+                self.STAGE_PADDLE_FORWARD,
+            )
+            if fatal:
+                raise
+            return
+
+        # 反向阶段单独处理显存保护异常和框架异常。
+        try:
+            with self._nan_inf_check_disabled(exemption_scope == "all"):
                 self._run_paddle_backward(paddle_output)
         except GpuMemoryGuardSkip as err:
-            self.report_case_result("oom", phase="memory_guard", message=str(err))
+            self.report_case_result(
+                "oom",
+                stage=self.STAGE_PADDLE_BACKWARD,
+                message=str(err),
+            )
             self._finalize_paddle_only("oom")
             return
         except Exception as err:
             _, fatal = self._report_paddle_only_error(
                 err,
                 "paddle_error",
-                "paddle_only",
-                allow_ignore_paddle=True,
+                self.STAGE_PADDLE_BACKWARD,
             )
             if fatal:
                 raise
             return
 
+        # 同步错误保留所属方向，便于定位异步 CUDA 错误。
         try:
             self.check_operator_cuda_error()
         except Exception as err:
             _, fatal = self._report_paddle_only_error(
                 err,
                 "paddle_cuda",
-                "paddle_only cuda check",
+                self.STAGE_PADDLE_BACKWARD_SYNC
+                if self.need_check_grad()
+                else self.STAGE_PADDLE_FORWARD_SYNC,
             )
             if fatal:
                 raise

--- a/tester/paddle_torch_gpu_performance.py
+++ b/tester/paddle_torch_gpu_performance.py
@@ -674,14 +674,16 @@ class APITestPaddleTorchGPUPerformance(APITestBase):
                 self.report_case_result("config_input", "generate_input_values failed")
                 return
         except Exception as err:
-            log_type, fatal = self.report_runtime_error(err, "config_input", "input")
+            log_type, fatal = self.report_runtime_error(err, "config_input", self.STAGE_INPUT)
             if fatal:
                 raise
             return
 
         try:
             if not self.build_paddle_input():
-                self.report_case_result("paddle_error", "build_paddle_input failed")
+                self.report_case_result(
+                    "paddle_error", "build_paddle_input failed", stage=self.STAGE_INPUT
+                )
                 return
 
             if self.test_amp:
@@ -720,8 +722,7 @@ class APITestPaddleTorchGPUPerformance(APITestBase):
             _, fatal = self.report_runtime_error(
                 err,
                 "paddle_error",
-                "paddle forward",
-                allow_ignore_paddle=True,
+                self.STAGE_PADDLE_FORWARD,
             )
             if fatal:
                 raise err
@@ -766,8 +767,7 @@ class APITestPaddleTorchGPUPerformance(APITestBase):
             _, fatal = self.report_runtime_error(
                 err,
                 "paddle_error",
-                "paddle backward",
-                allow_ignore_paddle=True,
+                self.STAGE_PADDLE_BACKWARD,
             )
             if fatal:
                 raise err
@@ -782,7 +782,9 @@ class APITestPaddleTorchGPUPerformance(APITestBase):
             device = torch.device("cuda:0")
             torch.set_default_device(device)
             if not self.build_torch_input():
-                self.report_case_result("torch_error", "build_torch_input failed")
+                self.report_case_result(
+                    "torch_error", "build_torch_input failed", stage=self.STAGE_INPUT
+                )
                 return
 
             bound_arguments = bind_paddle_arguments(
@@ -838,7 +840,7 @@ class APITestPaddleTorchGPUPerformance(APITestBase):
                 torch_backward_sync,
                 combined,
             )
-            _, fatal = self.report_runtime_error(err, "torch_error", "torch forward")
+            _, fatal = self.report_runtime_error(err, "torch_error", self.STAGE_TORCH_FORWARD)
             if fatal:
                 raise err
             return
@@ -891,7 +893,7 @@ class APITestPaddleTorchGPUPerformance(APITestBase):
                 torch_backward_sync,
                 combined,
             )
-            _, fatal = self.report_runtime_error(err, "torch_error", "torch backward")
+            _, fatal = self.report_runtime_error(err, "torch_error", self.STAGE_TORCH_BACKWARD)
             if fatal:
                 raise err
             return

--- a/tester/reporting/__init__.py
+++ b/tester/reporting/__init__.py
@@ -8,11 +8,13 @@ from . import log_runtime as _runtime
 from . import log_worker as _worker
 
 
-def init_log(log_dir):
+def init_log(log_dir, *, reset_aggregation=True):
     """初始化日志路径及进程内状态。"""
     _runtime._configure_log(log_dir)
     _worker._reset_worker_state()
-    _aggregation._reset_aggregation_state()
+    if reset_aggregation:
+        # 聚合状态只属于主进程，worker 仅写自己的日志分片。
+        _aggregation._reset_aggregation_state()
 
 
 __all__ = ("init_log",)

--- a/tester/reporting/log_aggregation.py
+++ b/tester/reporting/log_aggregation.py
@@ -76,10 +76,27 @@ def _ensure_inorder_build():
         return build_path
 
     out_path = runtime.TEST_LOG_PATH / "log_inorder.log"
+    expected_size = None
+    state_path = _inorder_state_path()
+    if state_path.exists():
+        # cleanup 重试只能重建 state 已确认的 build 前缀，不能复制目标文件尾部。
+        state = json.loads(state_path.read_text(encoding="utf-8"))
+        expected_size = int(state["build_offset"])
     if out_path.exists():
         with out_path.open("rb") as source, build_path.open("wb") as target:
-            while chunk := source.read(4 * 1024 * 1024):
+            remaining = expected_size
+            while remaining is None or remaining:
+                chunk_size = 4 * 1024 * 1024
+                if remaining is not None:
+                    chunk_size = min(chunk_size, remaining)
+                chunk = source.read(chunk_size)
+                if not chunk:
+                    if remaining:
+                        raise ValueError("published log ended before inorder state")
+                    break
                 target.write(chunk)
+                if remaining is not None:
+                    remaining -= len(chunk)
             runtime.sync_file(target)
     else:
         with build_path.open("wb") as target:
@@ -95,7 +112,21 @@ def _load_inorder_state():
     state_path = _inorder_state_path()
     build_path = _inorder_build_path()
     if not state_path.exists():
-        _ensure_inorder_build()
+        # 无 state 时，已发布日志长度是唯一可信的 build 基线。
+        out_path = runtime.TEST_LOG_PATH / "log_inorder.log"
+        baseline_size = out_path.stat().st_size if out_path.exists() else 0
+        if not build_path.exists():
+            _ensure_inorder_build()
+        elif build_path.stat().st_size < baseline_size:
+            raise RuntimeError("inorder build is shorter than published log")
+        else:
+            with build_path.open("r+b") as build_file:
+                build_file.truncate(baseline_size)
+                runtime.sync_file(build_file)
+            runtime.sync_directory(build_path.parent)
+            _inorder_build_offset = baseline_size
+        # 首次追加前先建立基线，build 写入后崩溃才能回退到明确 offset。
+        _write_inorder_state()
         return
 
     try:
@@ -290,18 +321,26 @@ def _find_last_complete_case_end(file_path, start_offset):
 
 def _publish_inorder_build():
     """将已 fsync 的 build 原子发布为最终日志。"""
-    # rename 后即使随后被杀，目标文件也是完整 build，而非半截 append。
+    # build 保留到 source 清理成功，cleanup 重试始终复用同一份内容。
     build_path = _ensure_inorder_build()
     out_path = runtime.TEST_LOG_PATH / "log_inorder.log"
+    publish_path = out_path.with_name(f".{out_path.name}.publish.tmp")
     try:
         with build_path.open("ab") as build_file:
             runtime.sync_file(build_file)
-        os.replace(build_path, out_path)
+        with build_path.open("rb") as source, publish_path.open("wb") as target:
+            # 发布副本独立于 build，原子替换后仍可继续 cleanup 重试。
+            while chunk := source.read(4 * 1024 * 1024):
+                target.write(chunk)
+            runtime.sync_file(target)
+        os.replace(publish_path, out_path)
         runtime.sync_directory(out_path.parent)
         return True
     except Exception as err:
         print(f"Error publishing {build_path} to {out_path}: {err}", flush=True)
         return False
+    finally:
+        publish_path.unlink(missing_ok=True)
 
 
 def _cleanup_inorder_sources():

--- a/tester/reporting/log_aggregation.py
+++ b/tester/reporting/log_aggregation.py
@@ -19,9 +19,9 @@ from .log_schema import (
 _result_offsets = {}
 _inorder_offsets = {}
 _inorder_completed_offsets = {}
-_inorder_build_offset = 0
 _INORDER_STATE_FILENAME = ".inorder_state.json"
 _INORDER_BUILD_FILENAME = ".log_inorder.build"
+_COPY_BUFFER_SIZE = 4 * 1024 * 1024
 _CSV_SPECS = (
     ("tol", TOL_HEADER, ("API", "dtype", "config", "mode")),
     ("stable", STABLE_HEADER, ("API", "dtype", "config", "comp")),
@@ -29,11 +29,9 @@ _CSV_SPECS = (
 
 
 def _reset_aggregation_state():
-    global _inorder_build_offset
     _result_offsets.clear()
     _inorder_offsets.clear()
     _inorder_completed_offsets.clear()
-    _inorder_build_offset = 0
     _load_inorder_state()
 
 
@@ -51,8 +49,7 @@ def _write_inorder_state():
     state_path = _inorder_state_path()
     temp_path = state_path.with_name(f".{state_path.name}.tmp")
     state = {
-        "version": 1,
-        "build_offset": _inorder_build_offset,
+        "build_offset": _inorder_build_path().stat().st_size,
         "sources": {file_path.name: offset for file_path, offset in _inorder_offsets.items()},
     }
     try:
@@ -66,102 +63,63 @@ def _write_inorder_state():
         temp_path.unlink(missing_ok=True)
 
 
-def _ensure_inorder_build():
-    """恢复或创建聚合 build，旧的最终日志只在首次迁移时复制一次。"""
-    # build 是可回退的工作副本，正式日志只在最终发布阶段替换。
-    global _inorder_build_offset
-    build_path = _inorder_build_path()
-    if build_path.exists():
-        _inorder_build_offset = build_path.stat().st_size
-        return build_path
+def _copy_file_prefix(source_path, target_path, size):
+    """复制指定长度并持久化，供 build 恢复和最终发布共用。"""
+    remaining = size
+    with source_path.open("rb") as source, target_path.open("wb") as target:
+        while remaining:
+            chunk = source.read(min(_COPY_BUFFER_SIZE, remaining))
+            if not chunk:
+                raise ValueError(f"{source_path} ended before {size} bytes")
+            target.write(chunk)
+            remaining -= len(chunk)
+        runtime.sync_file(target)
+    runtime.sync_directory(target_path.parent)
 
-    out_path = runtime.TEST_LOG_PATH / "log_inorder.log"
-    expected_size = None
-    state_path = _inorder_state_path()
-    if state_path.exists():
-        # cleanup 重试只能重建 state 已确认的 build 前缀，不能复制目标文件尾部。
-        state = json.loads(state_path.read_text(encoding="utf-8"))
-        expected_size = int(state["build_offset"])
-    if out_path.exists():
-        with out_path.open("rb") as source, build_path.open("wb") as target:
-            remaining = expected_size
-            while remaining is None or remaining:
-                chunk_size = 4 * 1024 * 1024
-                if remaining is not None:
-                    chunk_size = min(chunk_size, remaining)
-                chunk = source.read(chunk_size)
-                if not chunk:
-                    if remaining:
-                        raise ValueError("published log ended before inorder state")
-                    break
-                target.write(chunk)
-                if remaining is not None:
-                    remaining -= len(chunk)
-            runtime.sync_file(target)
-    else:
-        with build_path.open("wb") as target:
-            runtime.sync_file(target)
-    runtime.sync_directory(build_path.parent)
-    _inorder_build_offset = build_path.stat().st_size
+
+def _prepare_inorder_build(expected_size):
+    """将 build 恢复到 state 指定的安全长度。"""
+    build_path = _inorder_build_path()
+    if not build_path.exists():
+        out_path = runtime.TEST_LOG_PATH / "log_inorder.log"
+        if expected_size:
+            if not out_path.exists():
+                raise FileNotFoundError(f"missing recoverable {build_path}")
+            _copy_file_prefix(out_path, build_path, expected_size)
+        else:
+            with build_path.open("wb") as target:
+                runtime.sync_file(target)
+            runtime.sync_directory(build_path.parent)
+
+    actual_size = build_path.stat().st_size
+    if actual_size < expected_size:
+        raise ValueError(f"inorder build is shorter than state: {actual_size} < {expected_size}")
+    if actual_size > expected_size:
+        # build 写入后、state 更新前退出时，超出安全点的尾部必须回退。
+        with build_path.open("r+b") as build_file:
+            build_file.truncate(expected_size)
+            runtime.sync_file(build_file)
     return build_path
 
 
 def _load_inorder_state():
     """加载上次聚合提交点，并截断未提交的 build 尾部。"""
-    global _inorder_build_offset
     state_path = _inorder_state_path()
-    build_path = _inorder_build_path()
-    if not state_path.exists():
-        # 无 state 时，已发布日志长度是唯一可信的 build 基线。
-        out_path = runtime.TEST_LOG_PATH / "log_inorder.log"
-        baseline_size = out_path.stat().st_size if out_path.exists() else 0
-        if not build_path.exists():
-            _ensure_inorder_build()
-        elif build_path.stat().st_size < baseline_size:
-            raise RuntimeError("inorder build is shorter than published log")
-        else:
-            with build_path.open("r+b") as build_file:
-                build_file.truncate(baseline_size)
-                runtime.sync_file(build_file)
-            runtime.sync_directory(build_path.parent)
-            _inorder_build_offset = baseline_size
-        # 首次追加前先建立基线，build 写入后崩溃才能回退到明确 offset。
-        _write_inorder_state()
-        return
-
     try:
-        state = json.loads(state_path.read_text(encoding="utf-8"))
-        if state.get("version") != 1:
-            raise ValueError(f"unsupported inorder state version: {state.get('version')}")
-        expected_size = int(state["build_offset"])
-        if not build_path.exists():
+        if state_path.exists():
+            state = json.loads(state_path.read_text(encoding="utf-8"))
+            expected_size = int(state["build_offset"])
+            for name, offset in state.get("sources", {}).items():
+                _inorder_offsets[runtime.TMP_LOG_PATH / name] = int(offset)
+        else:
+            # 无 state 时，已发布日志长度是唯一可信的 build 基线。
             out_path = runtime.TEST_LOG_PATH / "log_inorder.log"
-            if not out_path.exists() or out_path.stat().st_size < expected_size:
-                raise FileNotFoundError(f"missing recoverable {build_path}")
-            with out_path.open("rb") as source, build_path.open("wb") as target:
-                remaining = expected_size
-                while remaining:
-                    chunk = source.read(min(4 * 1024 * 1024, remaining))
-                    if not chunk:
-                        raise ValueError("published log ended before inorder state")
-                    target.write(chunk)
-                    remaining -= len(chunk)
-                runtime.sync_file(target)
-            runtime.sync_directory(build_path.parent)
-        actual_size = build_path.stat().st_size
-        if actual_size < expected_size:
-            raise ValueError(
-                f"inorder build is shorter than state: {actual_size} < {expected_size}"
-            )
-        if actual_size > expected_size:
-            # 进程可能在写 build 后、写 state 前退出，尾部必须回退。
-            with build_path.open("r+b") as build_file:
-                build_file.truncate(expected_size)
-                runtime.sync_file(build_file)
-        _inorder_build_offset = expected_size
-        for name, offset in state.get("sources", {}).items():
-            _inorder_offsets[runtime.TMP_LOG_PATH / name] = int(offset)
-    except (OSError, TypeError, ValueError, json.JSONDecodeError) as err:
+            expected_size = out_path.stat().st_size if out_path.exists() else 0
+        _prepare_inorder_build(expected_size)
+        if not state_path.exists():
+            # 首次追加前建立基线，崩溃后才能按旧 offset 回退。
+            _write_inorder_state()
+    except (OSError, TypeError, ValueError) as err:
         raise RuntimeError(f"failed to recover inorder aggregation state: {err}") from err
 
 
@@ -185,7 +143,7 @@ def _read_pending_result_bytes(file_path):
     return data, offset, file_size
 
 
-def _save_result_offsets(pending_offsets, cleanup):
+def _save_result_offsets(pending_offsets):
     """保存读取偏移；source 清理由整轮聚合成功后统一执行。"""
     _result_offsets.update(pending_offsets)
 
@@ -224,10 +182,9 @@ def mark_inorder_case_complete(pid, completed_offset):
 
 def _flush_completed_inorder_logs():
     """按 worker 增量复制完整 case，并持久化 source offset。"""
-    global _inorder_build_offset
     if not _inorder_completed_offsets:
         return True
-    out_file = _ensure_inorder_build()
+    out_file = _inorder_build_path()
     try:
         with out_file.open("ab") as out_f:
             for file_path, end_offset in list(_inorder_completed_offsets.items()):
@@ -239,7 +196,6 @@ def _flush_completed_inorder_logs():
                 runtime.sync_file(out_f)
                 _inorder_offsets[file_path] = end_offset
                 _inorder_completed_offsets.pop(file_path, None)
-            _inorder_build_offset = out_f.tell()
         _write_inorder_state()
         return True
     except Exception as err:
@@ -266,7 +222,7 @@ def _aggregate_text_logs(log_files, out_file, cleanup):
             with out_file.open("a") as f:
                 f.writelines(f"{line}\n" for line in sorted(all_lines))
                 runtime.sync_file(f)
-        _save_result_offsets(pending_offsets, cleanup)
+        _save_result_offsets(pending_offsets)
     except Exception as err:
         print(f"Error writing to {out_file}: {err}", flush=True)
         return False
@@ -286,8 +242,7 @@ def _aggregate_result_logs(cleanup, tmp_exists):
 def _aggregate_inorder_logs(cleanup, tmp_exists):
     """恢复完整 case，发布 build 后再清理 worker 临时日志。"""
     if not tmp_exists:
-        _ensure_inorder_build()
-        return True
+        return _publish_inorder_build() if cleanup else True
     if not _flush_completed_inorder_logs():
         return False
     log_files = sorted(runtime.TMP_LOG_PATH.glob("log_*.log"))
@@ -322,17 +277,12 @@ def _find_last_complete_case_end(file_path, start_offset):
 def _publish_inorder_build():
     """将已 fsync 的 build 原子发布为最终日志。"""
     # build 保留到 source 清理成功，cleanup 重试始终复用同一份内容。
-    build_path = _ensure_inorder_build()
+    build_path = _inorder_build_path()
     out_path = runtime.TEST_LOG_PATH / "log_inorder.log"
     publish_path = out_path.with_name(f".{out_path.name}.publish.tmp")
     try:
-        with build_path.open("ab") as build_file:
-            runtime.sync_file(build_file)
-        with build_path.open("rb") as source, publish_path.open("wb") as target:
-            # 发布副本独立于 build，原子替换后仍可继续 cleanup 重试。
-            while chunk := source.read(4 * 1024 * 1024):
-                target.write(chunk)
-            runtime.sync_file(target)
+        # 发布副本独立于 build，原子替换后仍可继续 cleanup 重试。
+        _copy_file_prefix(build_path, publish_path, build_path.stat().st_size)
         os.replace(publish_path, out_path)
         runtime.sync_directory(out_path.parent)
         return True
@@ -344,14 +294,10 @@ def _publish_inorder_build():
 
 
 def _cleanup_inorder_sources():
-    """最终日志发布成功后，删除或截断已消费的 worker source。"""
+    """最终日志发布成功后删除 worker source 和聚合状态。"""
     # source 删除是最后一步；之前任意失败都必须保留它用于恢复。
     for file_path in sorted(runtime.TMP_LOG_PATH.glob("log_*.log")):
         try:
-            committed_offset = _inorder_offsets.get(file_path, 0)
-            with file_path.open("r+b") as source:
-                source.truncate(committed_offset)
-                runtime.sync_file(source)
             file_path.unlink(missing_ok=True)
             _inorder_offsets.pop(file_path, None)
         except FileNotFoundError:
@@ -423,7 +369,7 @@ def _aggregate_csv_logs(log_files, out_file, header, cleanup):
             with out_file.open("a", newline="") as out_f:
                 out_f.write(buffer.getvalue())
                 runtime.sync_file(out_f)
-        _save_result_offsets(pending_offsets, cleanup)
+        _save_result_offsets(pending_offsets)
     except Exception as err:
         print(f"Error aggregating CSV into {out_file}: {err}", flush=True)
         return False
@@ -518,10 +464,6 @@ def _aggregate_comp_logs(cleanup, tmp_exists):
         for prefix in LOG_PREFIXES.values():
             log_files = list(dim_dir.glob(f"{prefix}_*.txt"))
             results.append(_aggregate_text_logs(log_files, out_dim_dir / f"{prefix}.txt", cleanup))
-        if cleanup and not any(dim_dir.iterdir()):
-            dim_dir.rmdir()
-    if cleanup and comp_tmp_dir.exists() and not any(comp_tmp_dir.iterdir()):
-        comp_tmp_dir.rmdir()
     return has_comp, all(results)
 
 

--- a/tester/reporting/log_aggregation.py
+++ b/tester/reporting/log_aggregation.py
@@ -6,6 +6,8 @@ import csv
 import io
 import json
 import os
+import tempfile
+from pathlib import Path
 
 from . import log_runtime as runtime
 from .log_schema import (
@@ -47,20 +49,30 @@ def _write_inorder_state():
     """持久化 source offset，保证删除 .tmp 前可以恢复聚合进度。"""
     # state 必须在 source 清理前落盘，主进程重启才能避免重复或丢失。
     state_path = _inorder_state_path()
-    temp_path = state_path.with_name(f".{state_path.name}.tmp")
     state = {
         "build_offset": _inorder_build_path().stat().st_size,
         "sources": {file_path.name: offset for file_path, offset in _inorder_offsets.items()},
     }
+    temp_path = None
     try:
-        with temp_path.open("w", encoding="utf-8") as state_file:
+        # 多个启动进程可能同时恢复状态，唯一临时文件避免彼此替换或清理。
+        with tempfile.NamedTemporaryFile(
+            "w",
+            encoding="utf-8",
+            dir=state_path.parent,
+            prefix=f".{state_path.name}.",
+            suffix=".tmp",
+            delete=False,
+        ) as state_file:
+            temp_path = Path(state_file.name)
             json.dump(state, state_file, sort_keys=True)
             state_file.write("\n")
             runtime.sync_file(state_file)
         os.replace(temp_path, state_path)
         runtime.sync_directory(state_path.parent)
     finally:
-        temp_path.unlink(missing_ok=True)
+        if temp_path is not None:
+            temp_path.unlink(missing_ok=True)
 
 
 def _copy_file_prefix(source_path, target_path, size):

--- a/tester/reporting/log_aggregation.py
+++ b/tester/reporting/log_aggregation.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import csv
 import io
+import json
 import os
 
 from . import log_runtime as runtime
@@ -18,6 +19,9 @@ from .log_schema import (
 _result_offsets = {}
 _inorder_offsets = {}
 _inorder_completed_offsets = {}
+_inorder_build_offset = 0
+_INORDER_STATE_FILENAME = ".inorder_state.json"
+_INORDER_BUILD_FILENAME = ".log_inorder.build"
 _CSV_SPECS = (
     ("tol", TOL_HEADER, ("API", "dtype", "config", "mode")),
     ("stable", STABLE_HEADER, ("API", "dtype", "config", "comp")),
@@ -25,9 +29,109 @@ _CSV_SPECS = (
 
 
 def _reset_aggregation_state():
+    global _inorder_build_offset
     _result_offsets.clear()
     _inorder_offsets.clear()
     _inorder_completed_offsets.clear()
+    _inorder_build_offset = 0
+    _load_inorder_state()
+
+
+def _inorder_state_path():
+    return runtime.TEST_LOG_PATH / _INORDER_STATE_FILENAME
+
+
+def _inorder_build_path():
+    return runtime.TEST_LOG_PATH / _INORDER_BUILD_FILENAME
+
+
+def _write_inorder_state():
+    """持久化 source offset，保证删除 .tmp 前可以恢复聚合进度。"""
+    # state 必须在 source 清理前落盘，主进程重启才能避免重复或丢失。
+    state_path = _inorder_state_path()
+    temp_path = state_path.with_name(f".{state_path.name}.tmp")
+    state = {
+        "version": 1,
+        "build_offset": _inorder_build_offset,
+        "sources": {file_path.name: offset for file_path, offset in _inorder_offsets.items()},
+    }
+    try:
+        with temp_path.open("w", encoding="utf-8") as state_file:
+            json.dump(state, state_file, sort_keys=True)
+            state_file.write("\n")
+            runtime.sync_file(state_file)
+        os.replace(temp_path, state_path)
+        runtime.sync_directory(state_path.parent)
+    finally:
+        temp_path.unlink(missing_ok=True)
+
+
+def _ensure_inorder_build():
+    """恢复或创建聚合 build，旧的最终日志只在首次迁移时复制一次。"""
+    # build 是可回退的工作副本，正式日志只在最终发布阶段替换。
+    global _inorder_build_offset
+    build_path = _inorder_build_path()
+    if build_path.exists():
+        _inorder_build_offset = build_path.stat().st_size
+        return build_path
+
+    out_path = runtime.TEST_LOG_PATH / "log_inorder.log"
+    if out_path.exists():
+        with out_path.open("rb") as source, build_path.open("wb") as target:
+            while chunk := source.read(4 * 1024 * 1024):
+                target.write(chunk)
+            runtime.sync_file(target)
+    else:
+        with build_path.open("wb") as target:
+            runtime.sync_file(target)
+    runtime.sync_directory(build_path.parent)
+    _inorder_build_offset = build_path.stat().st_size
+    return build_path
+
+
+def _load_inorder_state():
+    """加载上次聚合提交点，并截断未提交的 build 尾部。"""
+    global _inorder_build_offset
+    state_path = _inorder_state_path()
+    build_path = _inorder_build_path()
+    if not state_path.exists():
+        _ensure_inorder_build()
+        return
+
+    try:
+        state = json.loads(state_path.read_text(encoding="utf-8"))
+        if state.get("version") != 1:
+            raise ValueError(f"unsupported inorder state version: {state.get('version')}")
+        expected_size = int(state["build_offset"])
+        if not build_path.exists():
+            out_path = runtime.TEST_LOG_PATH / "log_inorder.log"
+            if not out_path.exists() or out_path.stat().st_size < expected_size:
+                raise FileNotFoundError(f"missing recoverable {build_path}")
+            with out_path.open("rb") as source, build_path.open("wb") as target:
+                remaining = expected_size
+                while remaining:
+                    chunk = source.read(min(4 * 1024 * 1024, remaining))
+                    if not chunk:
+                        raise ValueError("published log ended before inorder state")
+                    target.write(chunk)
+                    remaining -= len(chunk)
+                runtime.sync_file(target)
+            runtime.sync_directory(build_path.parent)
+        actual_size = build_path.stat().st_size
+        if actual_size < expected_size:
+            raise ValueError(
+                f"inorder build is shorter than state: {actual_size} < {expected_size}"
+            )
+        if actual_size > expected_size:
+            # 进程可能在写 build 后、写 state 前退出，尾部必须回退。
+            with build_path.open("r+b") as build_file:
+                build_file.truncate(expected_size)
+                runtime.sync_file(build_file)
+        _inorder_build_offset = expected_size
+        for name, offset in state.get("sources", {}).items():
+            _inorder_offsets[runtime.TMP_LOG_PATH / name] = int(offset)
+    except (OSError, TypeError, ValueError, json.JSONDecodeError) as err:
+        raise RuntimeError(f"failed to recover inorder aggregation state: {err}") from err
 
 
 def _read_pending_result_bytes(file_path):
@@ -51,13 +155,8 @@ def _read_pending_result_bytes(file_path):
 
 
 def _save_result_offsets(pending_offsets, cleanup):
-    """保存读取偏移，并按需删除已消费的临时文件。"""
+    """保存读取偏移；source 清理由整轮聚合成功后统一执行。"""
     _result_offsets.update(pending_offsets)
-    if not cleanup:
-        return
-    for file_path in pending_offsets:
-        file_path.unlink(missing_ok=True)
-        _result_offsets.pop(file_path, None)
 
 
 def _copy_inorder_range(file_path, out_f, start_offset, end_offset):
@@ -93,20 +192,24 @@ def mark_inorder_case_complete(pid, completed_offset):
 
 
 def _flush_completed_inorder_logs():
-    """按 worker 一次读取所有已完成 case，并在成功后推进聚合 offset。"""
+    """按 worker 增量复制完整 case，并持久化 source offset。"""
+    global _inorder_build_offset
     if not _inorder_completed_offsets:
         return True
-    out_file = runtime.TEST_LOG_PATH / "log_inorder.log"
+    out_file = _ensure_inorder_build()
     try:
         with out_file.open("ab") as out_f:
             for file_path, end_offset in list(_inorder_completed_offsets.items()):
                 start_offset = _inorder_offsets.get(file_path, 0)
                 if end_offset < start_offset:
                     start_offset = 0
+                end_offset = min(end_offset, file_path.stat().st_size)
                 _copy_inorder_range(file_path, out_f, start_offset, end_offset)
-                out_f.flush()
+                runtime.sync_file(out_f)
                 _inorder_offsets[file_path] = end_offset
                 _inorder_completed_offsets.pop(file_path, None)
+            _inorder_build_offset = out_f.tell()
+        _write_inorder_state()
         return True
     except Exception as err:
         print(f"Error flushing case blocks to {out_file}: {err}", flush=True)
@@ -131,6 +234,7 @@ def _aggregate_text_logs(log_files, out_file, cleanup):
         elif all_lines:
             with out_file.open("a") as f:
                 f.writelines(f"{line}\n" for line in sorted(all_lines))
+                runtime.sync_file(f)
         _save_result_offsets(pending_offsets, cleanup)
     except Exception as err:
         print(f"Error writing to {out_file}: {err}", flush=True)
@@ -149,39 +253,78 @@ def _aggregate_result_logs(cleanup, tmp_exists):
 
 
 def _aggregate_inorder_logs(cleanup, tmp_exists):
-    """刷出安全 block，并聚合已停止 worker 的剩余输出。"""
+    """恢复完整 case，发布 build 后再清理 worker 临时日志。"""
     if not tmp_exists:
+        _ensure_inorder_build()
         return True
     if not _flush_completed_inorder_logs():
         return False
     log_files = sorted(runtime.TMP_LOG_PATH.glob("log_*.log"))
     if not log_files:
+        return _publish_inorder_build() if cleanup else True
+    if not cleanup:
         return True
 
-    out_file = runtime.TEST_LOG_PATH / "log_inorder.log"
-    try:
-        with out_file.open("ab") as out_f:
-            for file_path in log_files:
-                try:
-                    start_offset = _inorder_offsets.get(file_path, 0)
-                    end_offset = file_path.stat().st_size
-                    if end_offset < start_offset:
-                        start_offset = 0
-                    _copy_inorder_range(file_path, out_f, start_offset, end_offset)
-                    out_f.flush()
-                    if cleanup:
-                        _inorder_offsets[file_path] = end_offset
-                        file_path.unlink()
-                        _inorder_offsets.pop(file_path, None)
-                        _inorder_completed_offsets.pop(file_path, None)
-                    else:
-                        _inorder_offsets[file_path] = end_offset
-                except Exception as err:
-                    print(f"Error reading {file_path}: {err}", flush=True)
-                    return False
-    except Exception as err:
-        print(f"Error writing to {out_file}: {err}", flush=True)
+    # 主进程重启时，完整 end 之后的内容可以恢复；未闭合尾部不进入 build。
+    for file_path in log_files:
+        start_offset = _inorder_offsets.get(file_path, 0)
+        end_offset = _find_last_complete_case_end(file_path, start_offset)
+        if end_offset > start_offset:
+            _inorder_completed_offsets[file_path] = end_offset
+    if not _flush_completed_inorder_logs():
         return False
+    return _publish_inorder_build()
+
+
+def _find_last_complete_case_end(file_path, start_offset):
+    """扫描 source 尾部，只把完整结束标记之前的字节视为可恢复。"""
+    # 正常增量路径不扫描历史文件，避免每批次退化为全量解析。
+    last_complete = start_offset
+    with file_path.open("rb") as source:
+        source.seek(start_offset)
+        while line := source.readline():
+            if line.startswith(b"<<< CASE "):
+                last_complete = source.tell()
+    return last_complete
+
+
+def _publish_inorder_build():
+    """将已 fsync 的 build 原子发布为最终日志。"""
+    # rename 后即使随后被杀，目标文件也是完整 build，而非半截 append。
+    build_path = _ensure_inorder_build()
+    out_path = runtime.TEST_LOG_PATH / "log_inorder.log"
+    try:
+        with build_path.open("ab") as build_file:
+            runtime.sync_file(build_file)
+        os.replace(build_path, out_path)
+        runtime.sync_directory(out_path.parent)
+        return True
+    except Exception as err:
+        print(f"Error publishing {build_path} to {out_path}: {err}", flush=True)
+        return False
+
+
+def _cleanup_inorder_sources():
+    """最终日志发布成功后，删除或截断已消费的 worker source。"""
+    # source 删除是最后一步；之前任意失败都必须保留它用于恢复。
+    for file_path in sorted(runtime.TMP_LOG_PATH.glob("log_*.log")):
+        try:
+            committed_offset = _inorder_offsets.get(file_path, 0)
+            with file_path.open("r+b") as source:
+                source.truncate(committed_offset)
+                runtime.sync_file(source)
+            file_path.unlink(missing_ok=True)
+            _inorder_offsets.pop(file_path, None)
+        except FileNotFoundError:
+            _inorder_offsets.pop(file_path, None)
+        except Exception as err:
+            print(f"Error cleaning {file_path}: {err}", flush=True)
+            return False
+    _inorder_completed_offsets.clear()
+    _inorder_state_path().unlink(missing_ok=True)
+    _inorder_build_path().unlink(missing_ok=True)
+    runtime.sync_directory(runtime.TEST_LOG_PATH)
+    _inorder_offsets.clear()
     return True
 
 
@@ -212,7 +355,27 @@ def _aggregate_csv_logs(log_files, out_file, header, cleanup):
                 if row:
                     pending_rows.append(row)
 
-        if pending_rows:
+        if cleanup:
+            # cleanup 可能重复执行，已有 CSV 行必须幂等保留而不是再次追加。
+            existing_rows = []
+            if out_file.exists():
+                with out_file.open(newline="") as source:
+                    reader = csv.reader(source)
+                    existing_header = next(reader, None)
+                    if existing_header not in (None, header):
+                        raise ValueError(f"unexpected CSV header in {out_file}: {existing_header}")
+                    existing_rows = [row for row in reader if row]
+            rows = list(dict.fromkeys(tuple(row) for row in existing_rows + pending_rows))
+            temp_file = out_file.with_name(f".{out_file.name}.aggregate.tmp")
+            with temp_file.open("w", newline="") as target:
+                writer = csv.writer(target)
+                writer.writerow(header)
+                writer.writerows(rows)
+                runtime.sync_file(target)
+            os.replace(temp_file, out_file)
+            runtime.sync_directory(out_file.parent)
+            temp_file.unlink(missing_ok=True)
+        elif pending_rows:
             buffer = io.StringIO(newline="")
             writer = csv.writer(buffer)
             if not out_file.exists() or out_file.stat().st_size == 0:
@@ -220,6 +383,7 @@ def _aggregate_csv_logs(log_files, out_file, header, cleanup):
             writer.writerows(pending_rows)
             with out_file.open("a", newline="") as out_f:
                 out_f.write(buffer.getvalue())
+                runtime.sync_file(out_f)
         _save_result_offsets(pending_offsets, cleanup)
     except Exception as err:
         print(f"Error aggregating CSV into {out_file}: {err}", flush=True)
@@ -320,6 +484,37 @@ def _aggregate_comp_logs(cleanup, tmp_exists):
     if cleanup and comp_tmp_dir.exists() and not any(comp_tmp_dir.iterdir()):
         comp_tmp_dir.rmdir()
     return has_comp, all(results)
+
+
+def _cleanup_result_sources():
+    """所有派生结果发布成功后，统一清除 worker 结果 source。"""
+    # 文本、CSV、comp 输出全部成功后，才允许清理任何结果 source。
+    source_files = []
+    for prefix in LOG_PREFIXES.values():
+        source_files.extend(runtime.TMP_LOG_PATH.glob(f"{prefix}_*.txt"))
+    source_files.extend(runtime.TMP_LOG_PATH.glob("tol_*.csv"))
+    source_files.extend(runtime.TMP_LOG_PATH.glob("stable_*.csv"))
+    source_files.extend(runtime.TMP_LOG_PATH.glob("comp/**/*.txt"))
+    source_files.extend(runtime.TMP_LOG_PATH.glob("comp/**/*.csv"))
+    try:
+        for file_path in source_files:
+            file_path.unlink(missing_ok=True)
+        for directory in (
+            sorted(
+                (path for path in (runtime.TMP_LOG_PATH / "comp").rglob("*") if path.is_dir()),
+                reverse=True,
+            )
+            if (runtime.TMP_LOG_PATH / "comp").exists()
+            else ()
+        ):
+            if not any(directory.iterdir()):
+                directory.rmdir()
+        for file_path in source_files:
+            _result_offsets.pop(file_path, None)
+        return True
+    except Exception as err:
+        print(f"Error cleaning result sources: {err}", flush=True)
+        return False
 
 
 def _find_duplicate_classifications(log_dir):
@@ -448,18 +643,22 @@ def _aggregate_logs(*, final, cleanup):
         has_comp, comp_success = _aggregate_comp_logs(cleanup_tmp, tmp_exists)
         results.append(comp_success)
     all_success = all(results)
-
+    if final:
+        final_results = [
+            _sort_csv(runtime.TEST_LOG_PATH / f"{name}.csv", columns)
+            for name, _, columns in _CSV_SPECS
+        ]
+        if has_comp:
+            final_results.append(_sync_comp_main_summary())
+        all_success = all(final_results) and all_success
+    if cleanup_tmp and all_success:
+        # 只有所有派生输出都成功后，source 才允许被删除。
+        all_success = _cleanup_result_sources() and _cleanup_inorder_sources()
     if not final:
         if cleanup_tmp and all_success:
             _remove_empty_tmp_dir()
         return all_success
 
-    final_results = [
-        _sort_csv(runtime.TEST_LOG_PATH / f"{name}.csv", columns) for name, _, columns in _CSV_SPECS
-    ]
-    if has_comp:
-        final_results.append(_sync_comp_main_summary())
-    all_success = all(final_results) and all_success
     if all_success:
         _remove_empty_tmp_dir()
     log_counts = _count_result_logs()

--- a/tester/reporting/log_aggregation.py
+++ b/tester/reporting/log_aggregation.py
@@ -6,8 +6,6 @@ import csv
 import io
 import json
 import os
-import tempfile
-from pathlib import Path
 
 from . import log_runtime as runtime
 from .log_schema import (
@@ -49,30 +47,20 @@ def _write_inorder_state():
     """持久化 source offset，保证删除 .tmp 前可以恢复聚合进度。"""
     # state 必须在 source 清理前落盘，主进程重启才能避免重复或丢失。
     state_path = _inorder_state_path()
+    temp_path = state_path.with_name(f".{state_path.name}.tmp")
     state = {
         "build_offset": _inorder_build_path().stat().st_size,
         "sources": {file_path.name: offset for file_path, offset in _inorder_offsets.items()},
     }
-    temp_path = None
     try:
-        # 多个启动进程可能同时恢复状态，唯一临时文件避免彼此替换或清理。
-        with tempfile.NamedTemporaryFile(
-            "w",
-            encoding="utf-8",
-            dir=state_path.parent,
-            prefix=f".{state_path.name}.",
-            suffix=".tmp",
-            delete=False,
-        ) as state_file:
-            temp_path = Path(state_file.name)
+        with temp_path.open("w", encoding="utf-8") as state_file:
             json.dump(state, state_file, sort_keys=True)
             state_file.write("\n")
             runtime.sync_file(state_file)
         os.replace(temp_path, state_path)
         runtime.sync_directory(state_path.parent)
     finally:
-        if temp_path is not None:
-            temp_path.unlink(missing_ok=True)
+        temp_path.unlink(missing_ok=True)
 
 
 def _copy_file_prefix(source_path, target_path, size):

--- a/tester/reporting/log_comparison.py
+++ b/tester/reporting/log_comparison.py
@@ -48,12 +48,13 @@ def log_accuracy_tolerance(
     tensor_count,
 ):
     """记录从 assert-close 失败消息中解析出的容差。"""
-    mode = "backward" if is_backward else "forward"
+    stage = "Compare backward" if is_backward else "Compare forward"
     print(
-        f"[tolerance] {mode} | tensor {tensor_index + 1}/{tensor_count} | {config}\n{error_msg}",
+        f"[tolerance] {stage} | tensor {tensor_index + 1}/{tensor_count} | {config}\n{error_msg}",
         flush=True,
     )
     max_abs_diff, max_rel_diff = _get_diff(error_msg, _TOL_ABS_PATTERN, _TOL_REL_PATTERN)
+    mode = "backward" if is_backward else "forward"
     row = [api, config, dtype, mode, str(max_abs_diff), str(max_rel_diff)]
     runtime.append_csv_row(
         runtime.RESULT_LOG_PATH / f"tol{runtime.RESULT_LOG_SUFFIX}.csv",
@@ -71,12 +72,12 @@ def _format_comp_line(
     **details,
 ):
     """构造稳定、单行且便于 grep 的 accuracy_stable 比较标记。"""
-    phase = "backward" if comp.endswith("B") else "forward"
+    stage = "Compare backward" if comp.endswith("B") else "Compare forward"
     base_comp = comp.removesuffix("B")
     actual_kind, actual_run, expected_kind, expected_run = base_comp
     actual_source = f"{_FRAMEWORK_NAMES[actual_kind]}#{actual_run}"
     expected_source = f"{_FRAMEWORK_NAMES[expected_kind]}#{expected_run}"
-    fields = [f"> COMP {comp}", result, phase]
+    fields = [f"> COMP {comp}", result, stage]
     if tensor_index is not None and tensor_count is not None:
         fields.append(f"tensor {tensor_index + 1}/{tensor_count}")
     fields.append(f"{actual_source} vs {expected_source}")

--- a/tester/reporting/log_runtime.py
+++ b/tester/reporting/log_runtime.py
@@ -134,9 +134,32 @@ def close_process_files():
     _process_file_handlers.clear()
     for handler in handlers:
         try:
+            sync_file(handler)
             handler.close()
         except Exception as err:
             print(f"Error closing process file: {err}", flush=True)
+
+
+def sync_file(file_obj):
+    """持久化已写入的日志，避免进程被杀时只剩用户态缓冲。"""
+    file_obj.flush()
+    os.fsync(file_obj.fileno())
+
+
+def sync_directory(directory):
+    """持久化目录项变更，保证原子替换后的文件名可恢复。"""
+    directory_fd = os.open(directory, os.O_RDONLY)
+    try:
+        os.fsync(directory_fd)
+    finally:
+        os.close(directory_fd)
+
+
+def sync_process_files():
+    """在 worker 报告终态前持久化该进程打开的结果分片。"""
+    # 终态消息发送前必须先落盘，否则主进程恢复时可能看不到结果行。
+    for handler in tuple(_process_file_handlers.values()):
+        sync_file(handler)
 
 
 def _get_process_file(file_path):
@@ -206,7 +229,9 @@ def write_lines_atomic(file_path, lines):
     try:
         with temp_file.open("w") as target:
             target.writelines(lines)
+            sync_file(target)
         os.replace(temp_file, file_path)
+        sync_directory(file_path.parent)
     finally:
         temp_file.unlink(missing_ok=True)
 

--- a/tester/reporting/log_runtime.py
+++ b/tester/reporting/log_runtime.py
@@ -135,9 +135,13 @@ def close_process_files():
     for handler in handlers:
         try:
             sync_file(handler)
-            handler.close()
         except Exception as err:
-            print(f"Error closing process file: {err}", flush=True)
+            print(f"Error syncing process file: {err}", flush=True)
+        finally:
+            try:
+                handler.close()
+            except Exception as err:
+                print(f"Error closing process file: {err}", flush=True)
 
 
 def sync_file(file_obj):

--- a/tester/reporting/log_schema.py
+++ b/tester/reporting/log_schema.py
@@ -4,6 +4,46 @@ from __future__ import annotations
 
 from typing import Literal
 
+Stage = Literal[
+    "Input",
+    "Paddle forward",
+    "Paddle backward",
+    "Paddle forward sync",
+    "Paddle backward sync",
+    "Torch forward",
+    "Torch backward",
+    "Torch forward sync",
+    "Torch backward sync",
+    "Compare forward",
+    "Compare backward",
+    "Memory preflight",
+]
+
+# 输入阶段覆盖参数解析和框架输入物化。
+INPUT_STAGE: Stage = "Input"
+# Paddle 前向阶段只表示算子执行本身。
+PADDLE_FORWARD_STAGE: Stage = "Paddle forward"
+# Paddle 反向阶段覆盖梯度计算与梯度收集。
+PADDLE_BACKWARD_STAGE: Stage = "Paddle backward"
+# 前向同步单独标记 CUDA 异步错误的落点。
+PADDLE_FORWARD_SYNC_STAGE: Stage = "Paddle forward sync"
+# 反向同步单独标记 CUDA 异步错误的落点。
+PADDLE_BACKWARD_SYNC_STAGE: Stage = "Paddle backward sync"
+# Torch 前向阶段与 Paddle 阶段使用同一命名规则。
+TORCH_FORWARD_STAGE: Stage = "Torch forward"
+# Torch 反向阶段与 Paddle 阶段使用同一命名规则。
+TORCH_BACKWARD_STAGE: Stage = "Torch backward"
+# Torch 前向同步保持框架信息，避免只显示 sync。
+TORCH_FORWARD_SYNC_STAGE: Stage = "Torch forward sync"
+# Torch 反向同步保持框架信息，避免只显示 sync。
+TORCH_BACKWARD_SYNC_STAGE: Stage = "Torch backward sync"
+# 前向比较错误属于比较阶段，不归入任一执行框架。
+COMPARE_FORWARD_STAGE: Stage = "Compare forward"
+# 反向比较错误属于比较阶段，不归入任一执行框架。
+COMPARE_BACKWARD_STAGE: Stage = "Compare backward"
+# 资源预检查失败发生在算子执行之前。
+MEMORY_PREFLIGHT_STAGE: Stage = "Memory preflight"
+
 LogType = Literal[
     "checkpoint",
     "pass",

--- a/tester/reporting/log_worker.py
+++ b/tester/reporting/log_worker.py
@@ -327,6 +327,10 @@ def write_case_end(status, api_config_str, *, duration_ms=None):
     if duration_ms is not None:
         fields.append(f"{duration_ms} ms")
     print(" | ".join(fields) + "\n", flush=True)
+    if _redirected_fds is not None:
+        # completed_offset 只有在 CASE_END 已落盘后才可交给主进程。
+        os.fsync(_redirected_fds[0])
+    runtime.sync_process_files()
     completed_offset = get_worker_log_offset()
     _clear_case_result_state(api_config_str)
     return completed_offset
@@ -350,6 +354,7 @@ def append_case_end_to_worker_log(pid, status, api_config_str):
         log_file.parent.mkdir(parents=True, exist_ok=True)
         with log_file.open("ab") as f:
             f.write(f"\n{end_line}\n\n".encode())
+            runtime.sync_file(f)
             return f.tell()
     except Exception as err:
         print(f"Error writing case end to worker log {pid}: {err}", flush=True)

--- a/tester/reporting/log_worker.py
+++ b/tester/reporting/log_worker.py
@@ -19,6 +19,7 @@ from .log_schema import (
     LOG_PREFIXES,
     TERMINAL_LOG_TYPES,
     LogType,
+    Stage,
 )
 
 _process_terminal_configs = {}
@@ -127,25 +128,25 @@ def format_case_result(
     log_type: LogType,
     line,
     *,
-    phase=None,
+    stage: Stage | None = None,
     message=None,
     error=None,
     tensor_position=None,
 ):
     """Format one case-level result line for terminal output."""
     head = f"[{log_type}]"
-    if phase:
-        head += f" {phase}"
+    if stage:
+        head += f" {stage}"
     fields = []
     if tensor_position:
         fields.append(f"tensor {tensor_position}")
     if message:
         fields.append(str(message))
-    if not phase and not tensor_position and message:
+    if not stage and not tensor_position and message:
         first_line = f"{head} {message} | {line}"
     else:
         prefix = " | ".join([head, *fields])
-        first_line = f"{prefix} | {line}" if phase or fields else f"{prefix} {line}"
+        first_line = f"{prefix} | {line}" if stage or fields else f"{prefix} {line}"
     if error is None:
         return first_line
     return f"{first_line}\n{error}"
@@ -155,7 +156,7 @@ def emit_case_result(
     log_type: LogType,
     line,
     *,
-    phase=None,
+    stage: Stage | None = None,
     message=None,
     error=None,
     tensor_position=None,
@@ -168,7 +169,7 @@ def emit_case_result(
         format_case_result(
             log_type,
             line,
-            phase=phase,
+            stage=stage,
             message=message,
             error=error,
             tensor_position=tensor_position,

--- a/tester/runtime/gpu_memory_preflight.py
+++ b/tester/runtime/gpu_memory_preflight.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
+from ..input_generation.backend import DIRECT_DTYPE_NUMEL_THRESHOLD
 from ..input_generation.input_copy_policy import requires_inplace_input_copy
 from ..input_generation.materialization import (
     build_materialization_plan,
@@ -138,7 +139,13 @@ def _input_generation_peak(configs):
             source_bytes = numel * 8
             temporary_peak = max(source_bytes + generated_bytes, 2 * generated_bytes)
         else:
-            source_bytes = numel * 4
+            # 大 float16 已由 native backend 直接生成，预检不能继续计入完整 float32 源。
+            source_bytes = (
+                logical_bytes
+                if name == "float16" and numel >= DIRECT_DTYPE_NUMEL_THRESHOLD
+                else numel * 4
+            )
+            # bfloat16 当前仍使用 float32 storage，不能套用 float16 的估算。
             temporary_peak = max(
                 2 * source_bytes,
                 source_bytes + generated_bytes,

--- a/tester/torch_gpu_performance.py
+++ b/tester/torch_gpu_performance.py
@@ -45,7 +45,7 @@ class APITestTorchGPUPerformance(APITestBase):
                 self.report_case_result("config_input", "generate_input_values failed")
                 return
         except Exception as err:
-            log_type, fatal = self.report_runtime_error(err, "config_input", "input")
+            log_type, fatal = self.report_runtime_error(err, "config_input", self.STAGE_INPUT)
             if fatal:
                 raise
             return
@@ -58,7 +58,9 @@ class APITestTorchGPUPerformance(APITestBase):
             device = torch.device("cuda:0")
             torch.set_default_device(device)
             if not self.build_torch_input():
-                self.report_case_result("torch_error", "build_torch_input failed")
+                self.report_case_result(
+                    "torch_error", "build_torch_input failed", stage=self.STAGE_INPUT
+                )
                 return
 
             bound_arguments = bind_paddle_arguments(
@@ -122,7 +124,7 @@ class APITestTorchGPUPerformance(APITestBase):
                 "\tTorch\t",
                 combined,
             )
-            _, fatal = self.report_runtime_error(err, "torch_error", "forward")
+            _, fatal = self.report_runtime_error(err, "torch_error", self.STAGE_TORCH_FORWARD)
             if fatal:
                 raise err
             return
@@ -177,7 +179,7 @@ class APITestTorchGPUPerformance(APITestBase):
                 "\tTorch\t",
                 combined,
             )
-            _, fatal = self.report_runtime_error(err, "torch_error", "backward")
+            _, fatal = self.report_runtime_error(err, "torch_error", self.STAGE_TORCH_BACKWARD)
             if fatal:
                 raise err
             return


### PR DESCRIPTION
## 背景

本 PR 将 `dev` 合入 `upstream/main` 以来的测试基建修改统一提交，覆盖后台任务互斥、测试阶段错误分类、CASE 日志持久化恢复和 `take_along_axis` 输入生成。原实现按脚本名生成 PID 文件，多个入口可能同时操作同一输出目录；CASE 日志在进程中断或重试时可能留下未闭合记录；错误日志中的阶段信息也不统一，影响定位和复测分类。

## 问题定位

- PID 文件按脚本名区分，无法阻止不同脚本同时写入同一输出目录，停止和自然退出清理之间也存在竞态
- `take_along_axis` 的函数入口参数名为 `arr`，Tensor method 绑定后接收者参数为 `x`，旧规则直接读取 `arr.shape` 会触发 `NoneType` 异常
- worker 日志使用文件尾部作为聚合依据时，主进程或 worker 中断可能把未闭合 CASE 发布到 `log_inorder.log`
- 结果日志阶段名称由调用方自由拼接，输入、Paddle、Torch、同步和比较阶段的错误分类不一致

## 实现方案

后台任务以实际 `output.log_dir` 作为任务身份，使用同目录 PID 文件和 flock 锁串行化启动、停止、状态查询和 PID 清理。CASE 日志继续使用每 worker 一个临时文件和增量 offset；完整 `CASE_END` 后执行 `fsync`，聚合通过 `.log_inorder.build` 和 `.inorder_state.json` 保存安全 offset，使用发布临时文件原子替换最终日志。只有最终派生输出发布成功后才清理 source，主进程重启时可丢弃未闭合尾部并恢复完整 CASE。

测试阶段统一使用 `Stage` 类型和预定义阶段常量，保留错误类型与执行阶段的独立性。输入规则通过 `arr`/`x` 回退兼容函数和 Tensor method 两种绑定形式。

## 主要变更

### 1. 输出目录级任务互斥

`run.py`、`run-example.sh` 和 `test_pipeline/V4/*.sh` 统一使用 `output.log_dir/.paddleapitest.pid` 及对应锁文件，增加进程组停止等待、旧 PID 保护和自然退出清理保护。CLI 文档与 run 配置 schema 同步移除脚本自定义 `pid_file`。

### 2. CASE 日志持久化与恢复

`tester/reporting/log_aggregation.py` 增加安全 build、source offset、`fsync` 和原子发布流程，支持首次 baseline、主进程中断恢复、worker crash synthetic end 和 cleanup 重试幂等。`tester/reporting/log_runtime.py`、`log_worker.py` 负责结果分片和 CASE_END 的落盘。

### 3. 统一错误阶段和结果日志

`tester/reporting/log_schema.py` 定义输入、Paddle、Torch、同步、比较和内存预检查阶段；accuracy、paddle-only、稳定性和性能 tester 使用统一阶段名称，删除旧的 Paddle error dismiss 兼容路径，并扩展结果日志结构化字段。

### 4. 输入生成规则修复

`tester/input_generation/generation_rules.py` 兼容 `paddle.take_along_axis` 和 `paddle.Tensor.take_along_axis` 的参数绑定差异。

## 改动文件

| 类别 | 文件 | 功能说明 |
| --- | --- | --- |
| 任务控制 | `run.py`, `run-example.sh`, `test_pipeline/V4/*.sh` | 输出目录级锁、PID 生命周期和后台任务管理 |
| 配置文档 | `docs/CLI_REFERENCE.md`, `test_pipeline/run_config.schema.json`, `test_pipeline/run_config.yaml` | CLI 和运行配置约束同步 |
| 日志恢复 | `tester/reporting/log_aggregation.py`, `tester/reporting/log_runtime.py`, `tester/reporting/log_worker.py` | CASE source、offset、fsync、原子发布和恢复 |
| 日志结构 | `tester/reporting/log_schema.py`, `tester/reporting/log_comparison.py` | 统一阶段类型和结构化错误输出 |
| 测试执行 | `tester/base.py`, `tester/accuracy.py`, `tester/accuracy_stable.py`, `tester/paddle_only.py`, `tester/paddle_cinn_vs_dygraph.py`, `tester/paddle_device_vs_cpu.py`, `tester/paddle_device_vs_gpu.py`, `tester/paddle_gpu_performance.py`, `tester/paddle_torch_gpu_performance.py`, `tester/torch_gpu_performance.py` | 统一阶段传递和错误分类 |
| 输入生成 | `tester/input_generation/generation_rules.py` | 修复 method 参数绑定兼容 |
