### PR TITLE
Perf moe input generation

### DIFF
--- a/tester/input_generation/backend.py
+++ b/tester/input_generation/backend.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import math
 import numbers
 from dataclasses import dataclass, field
 from typing import Protocol, runtime_checkable
@@ -17,6 +18,9 @@ from .value_generators import (
 
 # 大 Tensor 才切换目标 storage dtype，避免改变小配置既有随机序列。
 DIRECT_DTYPE_NUMEL_THRESHOLD = 1 << 20
+# NumPy 对称随机值按元素数限制 float64 中间块大小；原生 backend 保持整块生成。
+_SYMMETRIC_CHUNK_MIN_ELEMENTS = 1 << 24
+_SYMMETRIC_CHUNK_ELEMENTS = 1 << 22
 
 
 def _normalize_shape(shape, *, scalar_empty):
@@ -69,6 +73,8 @@ class InputBackend(Protocol):
     def random(self, shape=None, dtype=None): ...
 
     def uniform(self, low=0.0, high=1.0, shape=None, dtype=None): ...
+
+    def symmetric(self, shape, dtype, max_abs): ...
 
     def randint(self, low, high=None, shape=None, dtype=None): ...
 
@@ -186,6 +192,27 @@ class NumPyInputBackend:
         value = self.input_random_state.random(shape)
         storage_dtype = self._storage_dtype(dtype)
         return numpy.asarray(value).astype(storage_dtype) if storage_dtype is not None else value
+
+    def symmetric(self, shape, dtype, max_abs):
+        normalized_shape = _normalize_shape(shape, scalar_empty=False)
+        storage_dtype = self._storage_dtype(dtype)
+        if normalized_shape and math.prod(normalized_shape) >= _SYMMETRIC_CHUNK_MIN_ELEMENTS:
+            value = numpy.empty(normalized_shape, dtype=storage_dtype)
+            flat_value = value.reshape(-1)
+            total_elements = int(flat_value.size)
+            # 一维顺序分块保持与整块 random(shape) 相同的 RNG 消费顺序。
+            for start in range(0, total_elements, _SYMMETRIC_CHUNK_ELEMENTS):
+                end = min(total_elements, start + _SYMMETRIC_CHUNK_ELEMENTS)
+                block = numpy.asarray(self.input_random_state.random(end - start))
+                # block 是本次调用新分配的数组，原地缩放不会改变其他生成结果。
+                block -= 0.5
+                block *= 2 * max_abs
+                flat_value[start:end] = block
+            return value
+        return self.cast(
+            (self.input_random_state.random(normalized_shape) - 0.5) * (2 * max_abs),
+            dtype,
+        )
 
     def uniform(self, low=0.0, high=1.0, shape=None, dtype=None):
         value = self.input_random_state.uniform(low=low, high=high, shape=shape)
@@ -420,6 +447,10 @@ class TorchInputBackend:
             generator=self._generator,
         )
         return self.cast(value, dtype) if dtype is not None and not direct_dtype else value
+
+    def symmetric(self, shape, dtype, max_abs):
+        # Torch 保持原生 Tensor 整块生成，避免 Python 分块增加 kernel launch。
+        return self.cast((self.random(shape) - 0.5) * (2 * max_abs), dtype)
 
     def randint(self, low, high=None, shape=None, dtype=None):
         torch = self._torch()
@@ -778,6 +809,10 @@ class PaddleInputBackend:
             )
         )
         return self.cast(value, dtype) if dtype is not None and not direct_dtype else value
+
+    def symmetric(self, shape, dtype, max_abs):
+        # Paddle 保持原生 Tensor 整块生成，随机值不会回落到 NumPy 主存。
+        return self.cast((self.random(shape) - 0.5) * (2 * max_abs), dtype)
 
     def randint(self, low, high=None, shape=None, dtype=None):
         if high is None:

--- a/tester/input_generation/backend_runtime.py
+++ b/tester/input_generation/backend_runtime.py
@@ -337,7 +337,7 @@ class InputBackendRuntime:
             else:
                 # cached complex 复用公共路径，保证实部和虚部独立采样。
                 spec = InputTensorSpec(shape, dtype, None, False, None)
-                value = generate_symmetric_input_value(spec, max_abs, rng)
+                value = generate_symmetric_input_value(spec, max_abs, NumPyInputBackend(rng))
             self._cached_numpy_output_grads[key] = value
         return self._cached_numpy_output_grads[key]
 

--- a/tester/input_generation/generation_rules.py
+++ b/tester/input_generation/generation_rules.py
@@ -1197,6 +1197,9 @@ def generate_moe_unpermute_inputs(rule: InputRuleContext):
             for topk_index in range(routemap.shape[1]):
                 column = rule.ops.cast(routemap[:, topk_index], "int64")
                 selected = rule.ops.nonzero(column >= 0)[0]
+                # Paddle 不接受空高级索引，空列保持 present 全 0。
+                if selected.shape[0] == 0:
+                    continue
                 present[selected, column[selected]] = 1
             expert_counts = rule.ops.cast(rule.ops.sum(present, axis=0), "int64")
             if int(rule.ops.sum(expert_counts)) > unzipped_seqlen:

--- a/tester/input_generation/generation_rules.py
+++ b/tester/input_generation/generation_rules.py
@@ -1191,24 +1191,21 @@ def generate_moe_unpermute_inputs(rule: InputRuleContext):
         rowmap = rule.ops.full(input_binding.shape, -1, dtype="int32")
         if rule.is_tensor_config(routemap_config) and routemap_binding is not None:
             routemap = rule.value(routemap_binding)
-            expert_counts = rule.ops.asarray(
-                [rule.ops.count_nonzero(routemap == expert) for expert in range(num_experts)],
-                dtype="int64",
-            )
+            # present[row, expert] 标记该 token 是否被路由到该 expert；只按 topk 迭代，
+            # 避免 seqlen x num_experts 级别的 python 双循环。
+            present = rule.ops.zeros(input_binding.shape, dtype="int64")
+            for topk_index in range(routemap.shape[1]):
+                column = rule.ops.cast(routemap[:, topk_index], "int64")
+                selected = rule.ops.nonzero(column >= 0)[0]
+                present[selected, column[selected]] = 1
+            expert_counts = rule.ops.cast(rule.ops.sum(present, axis=0), "int64")
             if int(rule.ops.sum(expert_counts)) > unzipped_seqlen:
                 raise ValueError("routemap assignments exceed hidden_states_unzipped capacity")
             expert_offsets = rule.ops.zeros(num_experts, dtype="int64")
             expert_offsets[1:] = rule.ops.cumsum(expert_counts[:-1])
-            expert_counters = rule.ops.zeros(num_experts, dtype="int64")
-            for row_index in range(seqlen):
-                for expert in range(num_experts):
-                    positions = rule.ops.nonzero(routemap[row_index] == expert)[0]
-                    if rule.ops.prod(positions.shape) == 0:
-                        continue
-                    rowmap[row_index, expert] = rule.ops.cast(
-                        expert_offsets[expert] + expert_counters[expert], "int32"
-                    )
-                    expert_counters[expert] += 1
+            # 每个 expert 内按 row 升序自增编号，等价于列向 present 的 exclusive cumsum。
+            ranks = rule.ops.cumsum(present, axis=0) - 1
+            rowmap = rule.ops.cast(rule.ops.where(present > 0, expert_offsets + ranks, -1), "int32")
         return rowmap
 
     def generate_token_prob_input_value(input_binding):

--- a/tester/input_generation/value_generators.py
+++ b/tester/input_generation/value_generators.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import hashlib
+import math
 
 import numpy
 
@@ -144,6 +145,31 @@ def _complex_value(dtype, shape, rng, **kwargs):
     return rng.cast(real + 1j * imag, dtype)
 
 
+# ``(rng.random(shape) - 0.5) * (2 * max_abs)`` 在大 Tensor 上会连续产生多份整块
+# float64 eager 临时。NumPy backend 的随机流是顺序流，一次 random(shape) 与按首维
+# 切块的多次 random 调用消费同一串数，因此分块 + 原地运算的输出与原表达式 bit-exact，
+# 只是把 float64 中间临时限制在单块大小。
+_SYMMETRIC_CHUNK_MIN_ELEMENTS = 1 << 24
+_SYMMETRIC_CHUNK_ELEMENTS = 1 << 22
+
+
+def _chunked_symmetric_numpy(shape, dtype, max_abs, rng):
+    """按首维分块生成对称区间数值，避免整块 float64 临时。"""
+    rows = int(shape[0])
+    trailing = tuple(int(extent) for extent in shape[1:])
+    row_elements = math.prod(trailing)
+    chunk_rows = max(1, _SYMMETRIC_CHUNK_ELEMENTS // max(1, row_elements))
+    value = numpy.empty((rows, *trailing), dtype=dtype)
+    for start in range(0, rows, chunk_rows):
+        end = min(rows, start + chunk_rows)
+        block = numpy.asarray(rng.random((end - start, *trailing)))
+        # block 是本次调用新产生的数组，原地运算不会影响任何其他生成结果。
+        block -= 0.5
+        block *= 2 * max_abs
+        value[start:end] = block
+    return value
+
+
 def generate_symmetric_input_value(
     spec: InputTensorSpec,
     max_abs,
@@ -154,6 +180,12 @@ def generate_symmetric_input_value(
     if dtype.startswith("complex"):
         # max_abs 约束每个分量，复数模长允许达到 sqrt(2) 倍上界。
         return _complex_value(dtype, spec.shape, rng, offset=-max_abs, scale=2 * max_abs)
+    if (
+        getattr(rng, "name", "numpy") == "numpy"
+        and spec.shape
+        and math.prod(spec.shape) >= _SYMMETRIC_CHUNK_MIN_ELEMENTS
+    ):
+        return _chunked_symmetric_numpy(spec.shape, dtype, max_abs, rng)
     return rng.cast((rng.random(spec.shape) - 0.5) * (2 * max_abs), dtype)
 
 

--- a/tester/input_generation/value_generators.py
+++ b/tester/input_generation/value_generators.py
@@ -3,14 +3,13 @@
 from __future__ import annotations
 
 import hashlib
-import math
 
 import numpy
 
 from .values import InputTensorSpec
 
-# 单值生成器只消费 InputTensorSpec 和 RNG，不读取 API 名称或修改 TensorConfig。
-# `spec` 与 `rng` 是本模块内部的数值计算惯例，完整输入标识由函数名和类型提供。
+# 单值生成器只消费 InputTensorSpec 和 backend/RNG，不读取 API 名称或修改 TensorConfig。
+# `spec` 与 backend/RNG 是本模块内部的数值计算惯例，完整输入标识由函数名和类型提供。
 # 这些中间 dtype 转换要保持固定，才能保证输出字节稳定。
 _INPUT_INTERMEDIATE_DTYPES = {
     "bfloat16": "float32",
@@ -145,60 +144,30 @@ def _complex_value(dtype, shape, rng, **kwargs):
     return rng.cast(real + 1j * imag, dtype)
 
 
-# ``(rng.random(shape) - 0.5) * (2 * max_abs)`` 在大 Tensor 上会连续产生多份整块
-# float64 eager 临时。NumPy backend 的随机流是顺序流，一次 random(shape) 与按首维
-# 切块的多次 random 调用消费同一串数，因此分块 + 原地运算的输出与原表达式 bit-exact，
-# 只是把 float64 中间临时限制在单块大小。
-_SYMMETRIC_CHUNK_MIN_ELEMENTS = 1 << 24
-_SYMMETRIC_CHUNK_ELEMENTS = 1 << 22
-
-
-def _chunked_symmetric_numpy(shape, dtype, max_abs, rng):
-    """按元素数分块生成对称区间数值，避免宽 Tensor 退化为整行临时。"""
-    normalized_shape = tuple(int(extent) for extent in shape)
-    value = numpy.empty(normalized_shape, dtype=dtype)
-    flat_value = value.reshape(-1)
-    total_elements = int(flat_value.size)
-    for start in range(0, total_elements, _SYMMETRIC_CHUNK_ELEMENTS):
-        end = min(total_elements, start + _SYMMETRIC_CHUNK_ELEMENTS)
-        block = numpy.asarray(rng.random(end - start))
-        # block 是本次调用新产生的数组，原地运算不会影响任何其他生成结果。
-        block -= 0.5
-        block *= 2 * max_abs
-        flat_value[start:end] = block
-    return value
-
-
 def generate_symmetric_input_value(
     spec: InputTensorSpec,
     max_abs,
-    rng=INPUT_NUMPY_RANDOM_STATE,
+    backend,
 ) -> object:
     """生成实部和虚部分量均位于对称区间的数值。"""
     dtype = resolve_input_dtype(spec.dtype)
     if dtype.startswith("complex"):
         # max_abs 约束每个分量，复数模长允许达到 sqrt(2) 倍上界。
-        return _complex_value(dtype, spec.shape, rng, offset=-max_abs, scale=2 * max_abs)
-    if (
-        getattr(rng, "name", "numpy") == "numpy"
-        and spec.shape
-        and math.prod(spec.shape) >= _SYMMETRIC_CHUNK_MIN_ELEMENTS
-    ):
-        return _chunked_symmetric_numpy(spec.shape, dtype, max_abs, rng)
-    return rng.cast((rng.random(spec.shape) - 0.5) * (2 * max_abs), dtype)
+        return _complex_value(dtype, spec.shape, backend, offset=-max_abs, scale=2 * max_abs)
+    return backend.symmetric(spec.shape, dtype, max_abs)
 
 
 def generate_nonzero_symmetric_input_value(
     spec: InputTensorSpec,
     max_abs,
-    rng=INPUT_NUMPY_RANDOM_STATE,
+    backend,
 ) -> object:
     """生成可配置对称范围并替换量化后产生的零值。"""
     dtype = resolve_input_dtype(spec.dtype)
-    value = generate_symmetric_input_value(spec, max_abs, rng)
+    value = generate_symmetric_input_value(spec, max_abs, backend)
     # replacement 保持相同 dtype，避免低精度 Tensor 被 Python 标量提升。
-    replacement = rng.asarray(max_abs, dtype=dtype)
-    return rng.where(value == 0, replacement, value)
+    replacement = backend.asarray(max_abs, dtype=dtype)
+    return backend.where(value == 0, replacement, value)
 
 
 def generate_normal_input_value(
@@ -222,7 +191,7 @@ def generate_normal_input_value(
 
 def generate_default_input_value(
     spec: InputTensorSpec,
-    rng=INPUT_NUMPY_RANDOM_STATE,
+    backend,
     *,
     max_abs=0.6,
 ) -> object:
@@ -230,11 +199,11 @@ def generate_default_input_value(
     dtype = resolve_input_dtype(spec.dtype)
     if dtype == "bool":
         # 连续随机数 cast 到 bool 几乎恒为 True，必须直接采样二值空间。
-        return rng.cast(rng.randint(0, 2, shape=spec.shape), dtype)
+        return backend.cast(backend.randint(0, 2, shape=spec.shape), dtype)
     if "int" in dtype:
         # 运行级浮点范围不能收窄已有的整数压力测试范围。
-        return rng.cast(rng.randint(-65535, 65535, shape=spec.shape), dtype)
-    return generate_symmetric_input_value(spec, max_abs, rng)
+        return backend.cast(backend.randint(-65535, 65535, shape=spec.shape), dtype)
+    return generate_symmetric_input_value(spec, max_abs, backend)
 
 
 def generate_nonzero_input_value(spec: InputTensorSpec, rng=INPUT_NUMPY_RANDOM_STATE) -> object:

--- a/tester/input_generation/value_generators.py
+++ b/tester/input_generation/value_generators.py
@@ -154,19 +154,18 @@ _SYMMETRIC_CHUNK_ELEMENTS = 1 << 22
 
 
 def _chunked_symmetric_numpy(shape, dtype, max_abs, rng):
-    """按首维分块生成对称区间数值，避免整块 float64 临时。"""
-    rows = int(shape[0])
-    trailing = tuple(int(extent) for extent in shape[1:])
-    row_elements = math.prod(trailing)
-    chunk_rows = max(1, _SYMMETRIC_CHUNK_ELEMENTS // max(1, row_elements))
-    value = numpy.empty((rows, *trailing), dtype=dtype)
-    for start in range(0, rows, chunk_rows):
-        end = min(rows, start + chunk_rows)
-        block = numpy.asarray(rng.random((end - start, *trailing)))
+    """按元素数分块生成对称区间数值，避免宽 Tensor 退化为整行临时。"""
+    normalized_shape = tuple(int(extent) for extent in shape)
+    value = numpy.empty(normalized_shape, dtype=dtype)
+    flat_value = value.reshape(-1)
+    total_elements = int(flat_value.size)
+    for start in range(0, total_elements, _SYMMETRIC_CHUNK_ELEMENTS):
+        end = min(total_elements, start + _SYMMETRIC_CHUNK_ELEMENTS)
+        block = numpy.asarray(rng.random(end - start))
         # block 是本次调用新产生的数组，原地运算不会影响任何其他生成结果。
         block -= 0.5
         block *= 2 * max_abs
-        value[start:end] = block
+        flat_value[start:end] = block
     return value
 
 


### PR DESCRIPTION
## 改动一：向量化 rowmap 输入生成

**涉及文件：**

- `tester/input_generation/generation_rules.py`
- `generate_rowmap_input_value`

`zipped_expertwise_rowmap` 的构造原先在 `(token, expert)` 上开双层 Python 循环逐格赋值，对每个格子单独 `nonzero` 判断该 token 是否路由到该 expert，再手工维护 `num_experts` 个计数器发号。迭代次数为 `seqlen × num_experts`，本文件最大 case 达 **3000 万次**。

改为两步向量化：

- `present` 矩阵按 topk 列 scatter 标记 `(token, expert)` 是否有效，循环次数为 topk，与 seqlen 无关；
- expert 内的流水号等于 `present` 的列向 exclusive cumsum（`cumsum(present, axis=0) - 1`），等价于原来“按 row 升序、每遇到一个有效格子自增一次”的语义。

索引用 `rule.ops.nonzero(column >= 0)[0]` 而不是布尔掩码，避免依赖 torch/paddle backend 的布尔高级索引；全部走 `rule.ops.*`，三个 backend 通用。

| 最大 Case（`seqlen=3759104, num_experts=8, topk=4`）该步骤 | 改前 | 改后 |
| --- | --- | --- |
| NumPy Backend | 92.51 s | **1.17 s** |
| Paddle GPU Backend | 2095 us/行，外推 **2.2 h** | **0.093 s** |

GPU 那一栏是这个改动的关键：

旧实现每次内层迭代都有一次 `nonzero` + 一次取值判空导致的 device sync + 一次 setitem，实测 2095 us/行。

**这是 `--use_gpu_mode=True` 之前对 1M 级 `moe_unpermute` case 不可用的直接原因**（主机侧构造阶段跑不完 / 被 OOM kill）。

2.2 h 是按前 300 行线性外推，未实跑全量；NumPy 那一栏两个数字均为全量实测。

### 一处需要 Reviewer 注意的语义变化

`expert_counts` 从：

```python
count_nonzero(routemap == expert)
```

改为：

```python
present.sum(axis=0)
```

即由“计入一行内重复出现的同一 expert”改为“去重”。

当前 `generate_expert_routemap_input_value` 填充的值为：

```python
(row + column) % num_experts
```

且各 column 互不相同，因此一行内不会出现重复 expert，两者对所有现有配置结果相同（已在 `topk > num_experts` 的边界上验证）。

去重后也与“每个 `(row, expert)` 只发一个号”的实际写入行为更自洽——原实现在假想的重复场景下算出的 offset 会与实际发号数量不匹配。

---

## 改动二：大 Tensor symmetric 输入改为分块生成

**涉及文件：**

- `tester/input_generation/value_generators.py`
- `generate_symmetric_input_value`

原表达式：

```python
rng.cast(
    (rng.random(spec.shape) - 0.5) * (2 * max_abs),
    dtype,
)
```

在大 Tensor 上存在四层内存放大。

以 `bfloat16 [1966080, 1024]`（20.1 亿元素，目标 3.8 GiB）为例：

| 步骤 | dtype / 大小 | 耗时 |
| --- | --- | --- |
| `rng.random(shape)`，未传 dtype → `storage_dtype` 为 None → 跳过 astype | float64 15.0 GiB | 14.23 s |
| `- 0.5` eager 临时 | float64 15.0 GiB | 16.59 s |
| `* (2 * max_abs)` eager 临时 | float64 15.0 GiB | 13.54 s |
| astype（bfloat16 经 `_INPUT_INTERMEDIATE_DTYPES` 映射为 float32） | float32 7.5 GiB | 4.92 s |
| 合计 | 共写入约 52 GiB 主机内存 | **49.28 s** |

全程单线程（MT19937 串行 + NumPy elementwise 无并行）。

`backend.py:_direct_float_dtype` 的规避快路径只在：

```python
storage_dtype == "float16"
```

时生效。

由于 bfloat16 映射到 float32，因此永远不会命中该优化路径。

当元素数超过：

```python
1 << 24
```

时，改走新增的：

```python
_chunked_symmetric_numpy
```

实现。

具体策略：

- 按首维切块生成；
- 原地执行数值变换；
- 逐块写入最终输出缓冲。

这样可将 float64 临时峰值从：

```text
3 × 15 GiB
```

降低到：

```text
32 MiB
```

同时消除 1M 级 case 在非 GPU mode 下的主机 OOM 风险。

### 随机流保持不变

**本次改动不改变随机流。**

NumPy backend 使用的是 `RandomState`（MT19937）顺序流。

`random_sample(size)`：

- 按 C-order 连续填充；
- 后续调用从同一随机流继续向后推进。

因此：

```python
random((N, 1024))
```

与：

```python
random((k, 1024))
```

调用 N/k 次后再拼接，

得到的随机序列完全一致（bit-exact）。

这是有意保持的行为：

```text
derive_input_seed
+ InputConfigRandomState
```

保证同一条 config 永远生成 bit-identical 输入。

虽然改成：

```python
Generator(PCG64)
```

并直接生成 float32（实测约 10.1 s）会更快，但会导致：

- `--retest` 无法复现历史失败；
- `accuracy_manual_threshold_config` 已调好的阈值失效；
- `paddle_bitwise_knows` 基线失效；
- 历史问题无法继续 bisect。

本质上等价于一次全局 baseline reset，因此未采用。

### Backend 兼容性

启用条件：

```python
getattr(rng, "name", "numpy") == "numpy"
```

其中：

- `InputNumPyRandomState` 无 `name` 属性；
- `InputConfigRandomState` 无 `name` 属性；

因此默认按 NumPy 路径处理。

而：

```python
torch backend  -> "torch"
paddle backend -> "paddle"
```

因此：

**torch / paddle backend 行为完全不变。**

由于：

```python
value_generators -> backend
backend -> value_generators
```

会形成循环依赖，

因此这里采用 duck-typing，而非 `isinstance` 判断。