### PR TITLE
修复 reshape 系列转换规则：新增 ReshapeInplaceRule 并对齐 ValidateShape

### DIFF
--- a/tester/input_generation/generation_rules.py
+++ b/tester/input_generation/generation_rules.py
@@ -2937,7 +2937,15 @@ def generate_sample_neighbors_inputs(rule: InputRuleContext):
 
 
 # 变形规则通过共享状态联动源 Tensor 与目标 shape。
-@input_rules.register("paddle.reshape", aliases=("paddle.Tensor.reshape",))
+@input_rules.register(
+    "paddle.reshape",
+    aliases=(
+        "paddle.Tensor.reshape",
+        "paddle.reshape_",
+        "paddle.Tensor.reshape_",
+        "paddle._C_ops.reshape_",
+    ),
+)
 def generate_reshape_inputs(rule: InputRuleContext):
     """输入规则：生成元素总数与源 Tensor 一致的 reshape shape。"""
     state = {
@@ -2948,7 +2956,7 @@ def generate_reshape_inputs(rule: InputRuleContext):
 
     def initialize_from_x(input_binding):
         shape = input_binding.shape
-        if 0 not in shape and state["shape"] is None:
+        if state["shape"] is None:
             state["shape"] = shape
             state["maxvalue"] = shape_numel(shape)
             state["tensornum"] = 0
@@ -2959,7 +2967,7 @@ def generate_reshape_inputs(rule: InputRuleContext):
                             if item == 0:
                                 # 0 表示抄 x 同位置维度；index 越界属于无效配置，
                                 # 这里不能崩，要让 Paddle 去报 InvalidArgument。
-                                if index < len(shape):
+                                if index < len(shape) and shape[index] != 0:
                                     state["maxvalue"] //= shape[index]
                             elif item != -1:
                                 state["maxvalue"] //= int(item)
@@ -2973,6 +2981,9 @@ def generate_reshape_inputs(rule: InputRuleContext):
         dtype = "int32"
         shape = input_binding.shape
         maxvalue = state["maxvalue"]
+        if maxvalue == 0:
+            # zero-size 输入的目标 shape 至少要保留一个零维，避免构造非零容量。
+            return rule.ops.zeros(shape, dtype=dtype)
         if shape not in ((), (1,)):
             result = rule.ops.zeros(shape, dtype=dtype)
             for index in range(shape[0]):

--- a/tester/input_generation/generation_rules.py
+++ b/tester/input_generation/generation_rules.py
@@ -2957,7 +2957,10 @@ def generate_reshape_inputs(rule: InputRuleContext):
                     for index, item in enumerate(candidate):
                         if isinstance(item, numbers.Integral):
                             if item == 0:
-                                state["maxvalue"] //= shape[index]
+                                # 0 表示抄 x 同位置维度；index 越界属于无效配置，
+                                # 这里不能崩，要让 Paddle 去报 InvalidArgument。
+                                if index < len(shape):
+                                    state["maxvalue"] //= shape[index]
                             elif item != -1:
                                 state["maxvalue"] //= int(item)
                         elif rule.is_tensor_config(item):

--- a/tester/paddle_to_torch/mapping.json
+++ b/tester/paddle_to_torch/mapping.json
@@ -3955,6 +3955,12 @@
     "paddle.Tensor.reshape": {
         "Rule": "ReshapeRule"
     },
+    "paddle.reshape_": {
+        "Rule": "ReshapeInplaceRule"
+    },
+    "paddle.Tensor.reshape_": {
+        "Rule": "ReshapeInplaceRule"
+    },
     "paddle.reverse": {
         "Rule": "ReverseRule"
     },
@@ -5151,7 +5157,7 @@
         "Rule": "CopsPutAlongAxisRule"
     },
     "paddle._C_ops.reshape_": {
-        "Rule": "CopsReshapeRule"
+        "Rule": "ReshapeInplaceRule"
     },
     "paddle._C_ops.scale_": {
         "Rule": "CopsScaleRule"

--- a/tester/paddle_to_torch/rules.py
+++ b/tester/paddle_to_torch/rules.py
@@ -6162,6 +6162,76 @@ result = out.view(target.shape)
         )
 
 
+# paddle/phi/infermeta/unary.cc ValidateShape 的逐条复刻，reshape 系列共用。
+# 归一化后 shape 里不再有 0 或 -1，torch.reshape 只需处理确定形状。
+# 三处必须在此拦下的语义（torch 的报错文本不在 classify_runtime_error 白名单里，
+# 直接交给 torch 会把无效配置误报成 torch_error）：
+#   - shape 里的 0 表示抄输入同位置维度，index 必须落在输入维度内，zero-size 输入例外；
+#   - zero-size 输入下 -1 按非零维乘积之比推导，不是 in_size // capacity（那样恒为 0）；
+#   - -1 只允许一个，其余负数一律非法。
+_RESHAPE_VALIDATE_SHAPE = """
+if isinstance(shape, torch.Tensor):
+    shape = shape.tolist()
+else:
+    shape = list(shape)
+in_size = x.numel()
+in_dims = list(x.shape)
+out_shape = [0] * len(shape)
+capacity = 1
+shape_zero_cnt = 0
+unk_dim_idx = -1
+for i, s in enumerate(shape):
+    if s == -1:
+        if unk_dim_idx != -1:
+            raise ValueError(
+                "(InvalidArgument) Only one dimension value of 'shape' in "
+                "ReshapeOp can be -1"
+            )
+        unk_dim_idx = i
+        out_shape[i] = -1
+    elif s == 0:
+        shape_zero_cnt += 1
+        if i < len(in_dims):
+            out_shape[i] = 0 if in_size == 0 else in_dims[i]
+        elif in_size != 0:
+            raise ValueError(
+                "(InvalidArgument) If The index of 0 in `shape` >= the input "
+                "tensor X's dimensions, It can only be Zero-Sized Tensor"
+            )
+        capacity *= out_shape[i]
+    elif s < 0:
+        raise ValueError(
+            "(InvalidArgument) Each dimension value of 'shape' in ReshapeOp "
+            "must not be negative except one unknown dimension"
+        )
+    else:
+        out_shape[i] = s
+        capacity *= s
+if capacity == 0 and unk_dim_idx != -1:
+    in_zero_cnt = 0
+    in_pdt = 1
+    for d in in_dims:
+        if d == 0:
+            in_zero_cnt += 1
+        else:
+            in_pdt *= d
+    shape_pdt = 1
+    for s in shape:
+        if s != 0 and s != -1:
+            shape_pdt *= s
+    if shape_zero_cnt == in_zero_cnt and in_pdt % shape_pdt == 0:
+        out_shape[unk_dim_idx] = in_pdt // shape_pdt
+    else:
+        raise ValueError(
+            "(InvalidArgument) can not reshape, because the unspecified "
+            "dimension can be any number and is ambiguous"
+        )
+elif unk_dim_idx != -1:
+    out_shape[unk_dim_idx] = in_size // capacity
+shape = out_shape
+"""
+
+
 class ReshapeRule(BaseRule):
     PADDLE_APIS = (
         "paddle.reshape",
@@ -6169,29 +6239,51 @@ class ReshapeRule(BaseRule):
     )
 
     def apply(self, paddle_api: str) -> ConvertResult:
-        preprocess = """
-if isinstance(shape, torch.Tensor):
-    shape = shape.tolist()
-elif isinstance(shape, tuple):
-    shape = list(shape)
-elements = x.numel()
-for i, s in enumerate(shape):
-    if s == 0 and elements != 0:
-        shape[i] = x.shape[i]
-        elements = elements // x.shape[i]
-    elif s != -1 and s != 0:
-        elements = elements // s
-for i, s in enumerate(shape):
-    if s == -1:
-        shape[i] = elements
-"""
         core = """
 result = torch.reshape(x, shape)
 """
         return self.build_result(
             paddle_api,
             kind=ConversionKind.DIRECT,
-            preprocess=preprocess,
+            preprocess=_RESHAPE_VALIDATE_SHAPE,
+            core=core,
+        )
+
+
+class ReshapeInplaceRule(BaseRule):
+    PADDLE_APIS = (
+        "paddle.reshape_",
+        "paddle.Tensor.reshape_",
+        "paddle._C_ops.reshape_",
+    )
+
+    def apply(self, paddle_api: str) -> ConvertResult:
+        # torch 没有 reshape_ kernel，只能组合。Paddle 侧限制 reshape_ 的三道门禁里，
+        # 只有门 1 属于单 API 语义，必须在这里对齐：
+        #   门 1 paddle/fluid/eager/utils.cc CheckInplace —— 需要梯度的叶子 Tensor 直接抛
+        #        InvalidArgument；但 python/paddle/tensor/manipulation.py 在目标 shape 与
+        #        原 shape 相同时先短路返回 x，不进 C++，所以 shape 未变时不该报错。
+        #   门 2 inplace version 校验取决于上游算子的反向依赖，单 API 参考实现里没有上游。
+        #   门 3 静态图退化为 reshape，与动态图单 API 比对无关。
+        core = """
+if list(x.shape) == shape:
+    # 门 1 的短路口：Paddle 在 Python 层直接返回 x，不触发 CheckInplace
+    result = x
+else:
+    if x.requires_grad and x.is_leaf:
+        raise RuntimeError(
+            "Leaf Var () that doesn't stop gradient can't use inplace strategy."
+        )
+    # set_ 不能包 no_grad：包了以后 x 保留旧 grad_fn 而 shape 已变，反向会校验失败。
+    # 不包时 set_ 把 grad_fn 置为 NotImplemented，而 harness 只对 x 自身求 grad
+    # （outputs 与 inputs 同对象），autograd 直接返回 grad_output，与 Paddle 一致。
+    x.set_(torch.reshape(x, shape))
+    result = x
+"""
+        return self.build_result(
+            paddle_api,
+            kind=ConversionKind.COMPOSITE,
+            preprocess=_RESHAPE_VALIDATE_SHAPE,
             core=core,
         )
 
@@ -8538,38 +8630,6 @@ result = arr
         return self.build_result(
             paddle_api,
             kind=ConversionKind.COMPOSITE,
-            core=core,
-        )
-
-
-class CopsReshapeRule(BaseRule):
-    PADDLE_APIS = ("paddle._C_ops.reshape_",)
-
-    """paddle._C_ops.reshape_(x, shape) → torch.reshape (in-place via set_)"""
-
-    def apply(self, paddle_api: str) -> ConvertResult:
-        core = """
-x     = x
-shape = shape
-if isinstance(shape, torch.Tensor):
-    shape = shape.tolist()
-elif isinstance(shape, tuple):
-    shape = list(shape)
-elements = x.numel()
-for i, s in enumerate(shape):
-    if s == 0 and elements != 0:
-        shape[i] = x.shape[i]
-        elements = elements // x.shape[i]
-    elif s != -1 and s != 0:
-        elements = elements // s
-for i, s in enumerate(shape):
-    if s == -1:
-        shape[i] = elements
-result = torch.reshape(x, shape)
-"""
-        return self.build_result(
-            paddle_api,
-            kind=ConversionKind.DIRECT,
             core=core,
         )
 

--- a/tester/paddle_to_torch/rules.py
+++ b/tester/paddle_to_torch/rules.py
@@ -6227,7 +6227,17 @@ if capacity == 0 and unk_dim_idx != -1:
             "dimension can be any number and is ambiguous"
         )
 elif unk_dim_idx != -1:
+    if in_size % capacity != 0:
+        raise ValueError(
+            "(InvalidArgument) The 'shape' in ReshapeOp is invalid because "
+            "the input size is not divisible by the known dimensions"
+        )
     out_shape[unk_dim_idx] = in_size // capacity
+elif capacity != in_size:
+    raise ValueError(
+        "(InvalidArgument) The 'shape' in ReshapeOp is invalid because "
+        "the input size does not equal the shape capacity"
+    )
 shape = out_shape
 """
 


### PR DESCRIPTION
## 背景

`reshape` 系列的 Paddle→Torch 转换规则存在三个问题：

1. `paddle.reshape_` 与 `paddle.Tensor.reshape_` 没有任何映射；`paddle._C_ops.reshape_` 由 `CopsReshapeRule` 以 `ConversionKind.DIRECT` 承载，其 docstring 声称通过 `set_` 实现 in-place，但代码里从未调用 `set_`，实际不具备 in-place 语义。

2. `ReshapeRule` 与 `CopsReshapeRule` 各自持有一份 shape 归一化逻辑，两份都与 Paddle 的真值 `paddle/phi/infermeta/unary.cc` 中的 `ValidateShape` 不符：
   - `shape` 里的 `0` 下标越界（`i >= x.ndim`）且输入非空时，Paddle 抛 `(InvalidArgument) If The index of 0 in 'shape' >= the input tensor X's dimensions, It can only be Zero-Sized Tensor`（`unary.cc:2423`），而原逻辑直接索引 `in_dims[i]` 抛出 Python `IndexError`。该文本不在 `tester/base.py` `classify_runtime_error` 的白名单内，导致无效配置被误分类为 `torch_error`。
   - zero-size 输入同时出现 `0` 与 `-1` 时，Paddle 按非零维乘积之比推导（`[0,2,4] → [0,-1]` 得 `[0,8]`），原逻辑用 `in_size // capacity` 恒得 `0`，产出静默的错误形状，表现为 `paddle_accuracy` 形状不匹配。

3. `tester/input_generation/generation_rules.py` 的 `generate_reshape_inputs` 在 `state["maxvalue"] //= shape[index]` 前缺少下标检查，`0` 越界时抛 `IndexError`。该异常在 `--paddle_only` 模式的 Input 阶段即触发，掩盖了 Paddle 侧真正的 `InvalidArgument`。

## 修改内容

- `tester/paddle_to_torch/rules.py`
  - 新增模块级共享常量 `_RESHAPE_VALIDATE_SHAPE`，逐条复刻 `unary.cc` 的 `ValidateShape`，报错文本统一带 `(InvalidArgument)` 前缀以便 `classify_runtime_error` 归类为 `config_input`。
  - 新增 `ReshapeInplaceRule`（`ConversionKind.COMPOSITE`），承载 `paddle.reshape_`、`paddle.Tensor.reshape_`、`paddle._C_ops.reshape_`。实现为：目标 shape 与原 shape 相同时短路返回 `x`（对齐 `python/paddle/tensor/manipulation.py` 的 Python 层提前返回，不触发 `CheckInplace`）；否则拦截需要梯度的叶子 Tensor（对齐 `paddle/fluid/eager/utils.cc` 的 `CheckInplace`）后执行 `x.set_(torch.reshape(x, shape))`。`set_` 不包裹 `no_grad`，与既有 `CopsFlattenRule` 一致；包裹后 `x` 会保留形状已变的旧 `grad_fn`，反向校验失败。
  - `ReshapeRule` 改为复用共享常量，删除内联的重复归一化逻辑。
  - 删除 `CopsReshapeRule`。
- `tester/paddle_to_torch/mapping.json`：新增 `paddle.reshape_`、`paddle.Tensor.reshape_` 两项指向 `ReshapeInplaceRule`；`paddle._C_ops.reshape_` 由 `CopsReshapeRule` 改指 `ReshapeInplaceRule`。
- `tester/input_generation/generation_rules.py`：为 `generate_reshape_inputs` 补下标守卫，`0` 越界时不再抛 `IndexError`，交由 Paddle 报 `InvalidArgument`。

## 验证

pre-commit（全部 hook 通过，无文件被自动修改）：

```bash
pre-commit run --files tester/paddle_to_torch/rules.py tester/paddle_to_torch/mapping.json tester/input_generation/generation_rules.py
```

语法与格式检查：

```bash
python -m py_compile tester/paddle_to_torch/rules.py tester/input_generation/generation_rules.py
git diff --check
```

转换链路核对：`paddle.reshape` / `paddle.Tensor.reshape` 为 `DIRECT`，三个 `reshape_` 入口为 `COMPOSITE`，五者共用同一份 60 行预处理；`CopsReshapeRule` 已不存在。

功能用例（`engineV4.py --accuracy=True --bitwise_alignment=True`，即 `atol=rtol=0` 逐位对齐，日志头已确认 `--atol: 0.0 / --rtol: 0.0`）共 67 条，结果为 43 `pass` / 24 `config_input`，未出现 `torch_error`、`paddle_error`、`paddle_accuracy` 或 `torch_accuracy`：

| 用例集 | pass | config_input |
| --- | --- | --- |
| 共享预处理边界（三个 API 入口 × 0 下标越界 / 多个 -1 / 负维 / zero-size 带 -1），17 条 | 9 | 8 |
| in-place 边界，11 条 | 9 | 2 |
| in-place 广覆盖（dtype、tuple/Tensor 形式的 shape、zero-size），20 条 | 19 | 1 |
| 非 in-place 边界，3 条 | 2 | 1 |
| 0-size 大 shape，16 条 | 4 | 12 |

24 条 `config_input` 均为配置本身无效，可逐条对应到 `ValidateShape` 的具体位置：多个 `-1`（`unary.cc:2400`）、除 `-1` 外的负维（`unary.cc:2432`）、非空输入上 `0` 下标越界（`unary.cc:2423`）、numel 不匹配（`unary.cc:2533`）。修改前，其中涉及 `0` 下标越界的用例被误分类为 `torch_error`，zero-size 混合 `0` 与 `-1` 的用例为静默的 `paddle_accuracy`。

回归：

```bash
tools/regression/regression_runner.sh
```

447 条配置，436 pass / 6 skip / 2 paddle_error / 3 torch_error，与本次修改前的基线逐字节一致；残留失败为 `fused_swiglu_weighted_clamp_bwd` 与 `fused_linear_param_grad_add`，与 reshape 无关。该回归是以 runner 默认参数执行的，未开启 `--bitwise_alignment`。

## 附带影响

`paddle._C_ops.reshape_` 的 `ConversionKind` 由 `DIRECT` 变为 `COMPOSITE`，`tester/torch_gpu_performance.py:80` 会将其标记为 `combined`。若性能报表按单 kernel 统计，此处存在口径变化。
