### PR TITLE
修复 put_along_axis 空 index 转换

### DIFF
--- a/tester/paddle_to_torch/rules.py
+++ b/tester/paddle_to_torch/rules.py
@@ -5783,7 +5783,9 @@ def infer_broadcast_shape(input, index, dim):
             return None
     return broadcast_shape
 
-if broadcast == True:
+if broadcast == True and 0 not in tuple(index.shape):
+    # paddle 在 `0 in indices.shape` 时直接返回 arr 的副本：不广播、不校验 values。
+    # 空 index 无法 expand 到 broadcast_shape，这里必须同样短路。
     broadcast_shape = infer_broadcast_shape(input, indices, axis)
     if broadcast_shape:
         index = torch.broadcast_to(index, broadcast_shape)
@@ -8522,17 +8524,24 @@ def _infer_broadcast_shape(inp, idx, dim):
 index = indices
 src   = values
 dim   = axis
-if broadcast:
-    bshape = _infer_broadcast_shape(arr, indices, axis)
-    if bshape:
-        index = torch.broadcast_to(index, bshape)
-        src   = torch.broadcast_to(src, bshape)
-index = index.to(dtype=torch.int64)
-with torch.no_grad():
-    if reduce == "assign":
-        arr.scatter_(dim, index, src)
-    else:
-        arr.scatter_reduce_(dim, index, src, reduce, include_self=include_self)
+# paddle 在 `0 in indices.shape` 时直接原样返回 arr：不广播、不校验 values。
+# torch 侧必须同样短路，否则空 index 无法 expand 到 broadcast_shape
+# （例如 arr=[8192,32] / index=[0,10] 会报 "expanded size (8192) must match
+# the existing size (0)"），而原生 torch.scatter_ 在此本就是 no-op。
+if 0 in tuple(index.shape):
+    pass
+else:
+    if broadcast:
+        bshape = _infer_broadcast_shape(arr, indices, axis)
+        if bshape:
+            index = torch.broadcast_to(index, bshape)
+            src   = torch.broadcast_to(src, bshape)
+    index = index.to(dtype=torch.int64)
+    with torch.no_grad():
+        if reduce == "assign":
+            arr.scatter_(dim, index, src)
+        else:
+            arr.scatter_reduce_(dim, index, src, reduce, include_self=include_self)
 result = arr
 """
         return self.build_result(


### PR DESCRIPTION
## 背景

`put_along_axis` 在 `indices.shape` 包含零维度时，Paddle 会直接返回输入结果，不执行索引广播，也不会校验 `values`。

原有 Torch 转换逻辑仍会先执行 `torch.broadcast_to`。当索引为空且形状无法扩展时，例如：

- `arr = [8192, 32]`
- `indices = [0, 10]`

会触发广播错误，导致本应通过的测试用例失败。

## 修改内容

- 修复 `paddle.put_along_axis` 和 `paddle.Tensor.put_along_axis` 的空索引处理。
- 当索引包含零维度时，跳过广播预处理，直接返回输入副本。
- 修复 `paddle._C_ops.put_along_axis_` 和 `paddle.Tensor.put_along_axis_` 的空索引处理。
- 原地版本在空索引时跳过广播以及 `scatter_` / `scatter_reduce_`，保持 Paddle 的 no-op 语义。
- 修改范围仅限 `tester/paddle_to_torch/rules.py` 中的 4 个 `put_along_axis` API 入口。
- 非空索引场景保持原有转换逻辑不变。

## 影响范围

本次修改仅针对 **空索引（`indices.shape` 包含零维度）** 的场景：

- 空索引：跳过 Torch 侧的广播预处理，保持 Paddle 原有 no-op 语义。
- 非空索引：保持原有 `put_along_axis` 转换逻辑不变。

因此修改范围较小，不影响正常的非空索引场景。