### PR TITLE
开启 FLAGS_cudnn_deterministic 时同步启用 Torch 确定算法

### DIFF
--- a/test_pipeline/generic_configs/run_accuracy_compatible.yaml
+++ b/test_pipeline/generic_configs/run_accuracy_compatible.yaml
@@ -8,6 +8,7 @@ runner:
   foreground: true
 env:
   FLAGS_use_accuracy_compatible_kernel: "1"
+  FLAGS_cudnn_deterministic: "1"
 input:
   api_config_file: "${APITEST_MODEL}/accuracy_compatible/accuracy_compatible.txt"
 output:

--- a/tester/paddle_to_torch/rules.py
+++ b/tester/paddle_to_torch/rules.py
@@ -346,6 +346,11 @@ class BaseRule(ABC):
             paddle_api,
             Code(
                 preprocess=[
+                    # Keep Torch deterministic algorithms in lockstep with Paddle.
+                    "import paddle",
+                    "if paddle.get_flags('FLAGS_cudnn_deterministic')"
+                    "['FLAGS_cudnn_deterministic']:",
+                    "    torch.use_deterministic_algorithms(True)",
                     *self._build_default_code(),
                     *code_lines(preprocess),
                     *self._build_argument_map_code(ensure_args=generate_standard_call),


### PR DESCRIPTION
## 背景

`accuracy_compatible` 流水线需要在 Paddle 开启 `FLAGS_cudnn_deterministic` 时，与 Torch 对照侧同步走确定算法。原先 YAML 只打开了 `FLAGS_use_accuracy_compatible_kernel`，Torch 对照仍使用默认非确定实现，`index_select` 等存在重复 index 的反向 scatter-add 在 atol/rtol=0 下无法对齐。

## 修改内容

- `test_pipeline/generic_configs/run_accuracy_compatible.yaml`：增加 `FLAGS_cudnn_deterministic: "1"`。
- `tester/paddle_to_torch/rules.py`：`BaseRule.build_result()` 的 preprocess 在该 flag 为真时调用 `torch.use_deterministic_algorithms(True)`。flag 关闭时不改变 Torch 行为。

## 验证

- `python -m py_compile tester/paddle_to_torch/rules.py`
- `ruff check tester/paddle_to_torch/rules.py` 与 `ruff format --check tester/paddle_to_torch/rules.py`
- `python tools/check_comment_ratio.py`（staged diff 评论比例 20%）
- `git diff --check`
- 在本分支用同一组 4 条 `paddle.index_select`、`atol=0`、`rtol=0`、`FLAGS_use_accuracy_compatible_kernel=1` 实测：
  - 开启 `FLAGS_cudnn_deterministic=1`：4/4 pass
  - 关闭该 flag：4/4 `paddle_accuracy`（反向约 35% 元素差 1 ulp）

未执行：仓库 `pre-commit run --files ...` 因首次拉取 hook 环境超时未跑完；等价的 yaml 解析、ruff、py_compile、comment-ratio 检查已通过。
