### PR TITLE
修复 Tensor.min/max 转换：用 amin/amax 对齐 Paddle 约简语义

### DIFF
--- a/tester/paddle_to_torch/mapping.json
+++ b/tester/paddle_to_torch/mapping.json
@@ -2200,7 +2200,11 @@
     },
     "paddle.Tensor.max": {
         "Rule": "ReduceRule",
-        "torch_api": "torch.Tensor.max",
+        "torch_api": "torch.amax",
+        "set_defaults": {
+            "axis": "None",
+            "keepdim": "False"
+        },
         "paddle_torch_args_map": {
             "axis": "dim",
             "keepdim": "keepdim"
@@ -2251,7 +2255,12 @@
         }
     },
     "paddle.Tensor.min": {
-        "torch_api": "torch.Tensor.min",
+        "Rule": "ReduceRule",
+        "torch_api": "torch.amin",
+        "set_defaults": {
+            "axis": "None",
+            "keepdim": "False"
+        },
         "paddle_torch_args_map": {
             "axis": "dim",
             "keepdim": "keepdim"

--- a/tester/paddle_to_torch/rules.py
+++ b/tester/paddle_to_torch/rules.py
@@ -6421,6 +6421,7 @@ class ReduceRule(BaseRule):
         "paddle.mean",
         "paddle.Tensor.mean",
         "paddle.min",
+        "paddle.Tensor.min",
         "paddle.prod",
         "paddle.sum",
     )
@@ -6494,15 +6495,18 @@ if isinstance(axis, tuple) and not keepdim:
         elif paddle_api == "paddle.sum":
             core = "result = torch.sum(x, dim=axis, keepdim=keepdim, dtype=dtype)"
             post = ""
-        elif paddle_api == "paddle.Tensor.max":
-            core = """
+        elif paddle_api in {"paddle.Tensor.max", "paddle.Tensor.min"}:
+            core = f"""
+# torch.max/min(dim=) return (values, indices); paddle only returns values.
 if axis is None:
-    result = torch.max(x)
+    result = {self.torch_api}(x)
 else:
-    _max_result = torch.max(x, dim=axis, keepdim=keepdim)
-    result = _max_result.values
+    result = {self.torch_api}(x, dim=axis, keepdim=keepdim)
 """
-            post = ""
+            post = """
+if axis is None and keepdim:
+    result = result.view([1] * x.dim())
+"""
         else:
             core = f"result = {self.torch_api}(x, dim=axis, keepdim=keepdim)"
             post = ""


### PR DESCRIPTION
## 背景

`paddle.Tensor.max` / `paddle.Tensor.min` 在指定 `axis` 时只返回极值 Tensor。原先对照映射到 `torch.Tensor.max` / `torch.Tensor.min`，Torch 在 `dim=` 路径会返回 `(values, indices)`，对照拿到的不是 Paddle 的约简结果。`paddle.Tensor.min` 也未走 `ReduceRule`，`axis=None` 且 `keepdim=True` 时全局约简的形状也对不齐。

## 修改内容

- `tester/paddle_to_torch/mapping.json`
  - `paddle.Tensor.max` 改为 `torch.amax`，补 `axis`/`keepdim` 默认值；
  - `paddle.Tensor.min` 改为 `ReduceRule` + `torch.amin`，同样补默认值。
- `tester/paddle_to_torch/rules.py`
  - `ReduceRule.PADDLE_APIS` 增加 `paddle.Tensor.min`；
  - `Tensor.max` / `Tensor.min` 共用 `amin`/`amax` 路径，避免 `min/max(dim=)` 返回 namedtuple；
  - `axis is None and keepdim` 时把标量 reshape 成 `[1] * x.dim()`，与 Paddle 一致。

## 验证

- `python -m py_compile tester/paddle_to_torch/rules.py`
- `python -c 'import json; json.load(open("tester/paddle_to_torch/mapping.json"))'`
- `ruff check tester/paddle_to_torch/rules.py` 与 `ruff format --check tester/paddle_to_torch/rules.py`
- `python tools/check_comment_ratio.py`（staged 评论比例 20%）
- `git diff --cached --check`

未执行：仓库 `pre-commit run --files ...`（hook 环境拉取不稳定）；未跑 `engineV4.py` 端到端 accuracy。
