### PR TITLE
1-D index下的paddle.gather映射由narrow+squeeze+stack改成torch.index_select

### DIFF
--- a/tester/paddle_to_torch/rules.py
+++ b/tester/paddle_to_torch/rules.py
@@ -3453,14 +3453,8 @@ elif index.dim() > 1:
             index = index.unsqueeze(0)
     result = torch.gather(x, axis, index)
 else:
-    ans = []
-    for i in index:
-        temp = torch.narrow(x, axis, i.reshape([]), 1)
-        ans.append(torch.squeeze(temp, axis))
-    if len(ans) == 0:
-        result = torch.zeros([x.shape[0],0])
-    else:
-        result = torch.stack(ans,axis)
+    # 1-D index：生成器保证 index 非负且在界内，故 index_select 与 paddle.gather 语义一致
+    result = torch.index_select(x, axis, index)
 """
         return self.build_result(
             paddle_api,


### PR DESCRIPTION
paddle.gather 的 1-D index（非标量、非空）对应的torch API由逐元素narrow/squeeze/stack 循环改为 torch.index_select，语义等价

torch=2.12.1+cu130 cuda=13.0
| shape+index+axis+n_idx | fwd | bwd |
|---|---|---|
| shape=(1, 3, 512, 64) idx=[0, 0, 0] axis=1 n_idx=3 | OK | MISMATCH max_diff=4.76837e-07 n_diff=10460 |
| shape=(1, 3, 512, 64) idx=[0, 0] axis=1 n_idx=2 | OK | OK |
| shape=(1, 3, 512, 64) idx=[0] axis=1 n_idx=1 | OK | OK |

当index中同一位置重复出现3times+时，受torch.stack（逆向遍历index）和torch.index_select（正向遍历index）反向中遍历顺序不同的影响，浮点数不满足结合律而导致结果之间有误差，其余时候逐元素相等，因此可以替换